### PR TITLE
Feature/das 4180 user feature flag to show hide daily report option

### DIFF
--- a/src/DataExportMenu/index.js
+++ b/src/DataExportMenu/index.js
@@ -13,7 +13,7 @@ const { Toggle, Menu, Item, Header, Divider } = Dropdown;
 const mailTo = (email, subject, message) => window.open(`mailto:${email}?subject=${subject}&body=${message}`, '_self');
 
 const DataExportMenu = (props) => {
-  const { addModal, zendeskEnabled, dailyReportEnabled, exportKmlEnabled, ...rest } = props;
+  const { addModal, systemConfig: {dailyReportEnabled, exportKmlEnabled, zendeskEnabled}, ...rest } = props;
   const [isOpen, setOpenState] = useState(false);
 
   const modals = [
@@ -77,6 +77,6 @@ const DataExportMenu = (props) => {
   </Dropdown>;
 };
 
-const mapStateToProps = ({ view: { zendeskEnabled } }) => ({ zendeskEnabled });
+const mapStateToProps = ({ view: { systemConfig } }) => ({ systemConfig });
 
 export default connect(mapStateToProps, { addModal })(DataExportMenu);

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -158,3 +158,5 @@ export const MAPBOX_STYLE_LAYER_SOURCE_TYPES = ['mapbox_style'];
 export const GOOGLE_LAYER_SOURCE_TYPES = ['google_map'];
 export const TILE_LAYER_SOURCE_TYPES = ['tile_server', 'mapbox_tiles'];
 export const VALID_LAYER_SOURCE_TYPES = [...MAPBOX_STYLE_LAYER_SOURCE_TYPES, /* ...GOOGLE_LAYER_SOURCE_TYPES, */ ...TILE_LAYER_SOURCE_TYPES];
+
+export const DEFAULT_SHOW_TRACK_DAYS = 7;

--- a/src/ducks/system-status.js
+++ b/src/ducks/system-status.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { combineReducers } from 'redux';
 
-import { API_URL, REACT_APP_DAS_HOST, STATUSES } from '../constants';
+import { API_URL, REACT_APP_DAS_HOST, STATUSES, DEFAULT_SHOW_TRACK_DAYS } from '../constants';
 
 const STATUS_API_URL = `${API_URL}status`;
 
@@ -18,8 +18,7 @@ export const SOCKET_UNHEALTHY_STATUS = 'SOCKET_UNHEALTHY_STATUS';
 export const SOCKET_WARNING_STATUS = 'SOCKET_WARNING_STATUS';
 export const SOCKET_SERVICE_STATUS = 'SOCKET_SERVICE_STATUS';
 
-export const SET_ZENDESK_CONFIG = 'SET_ZENDESK_CONFIG';
-
+export const SET_ZENDESK_ENABLED = 'SET_ZENDESK_ENABLED';
 export const SET_DAILY_REPORT_ENABLED = 'SET_DAILY_REPORT_ENABLED';
 export const SET_EXPORT_KML_ENABLED = 'SET_EXPORT_KML_ENABLED';
 export const SET_EVENT_MATRIX_ENABLED = 'SET_EVENT_MATRIX_ENABLED';
@@ -44,13 +43,7 @@ export const fetchSystemStatus = () => {
     }).catch(error => dispatch(fetchSystemStatusError(error)));
 
     dispatch(setZendeskConfigStatus(response));
-    dispatch(setDailyReportEnabled(response));
-    dispatch(setExportKmlEnabled(response));
-    dispatch(setEventMatrixEnabled(response));
-    dispatch(setEventSearchEnabled(response));
-    dispatch(setAlertsEnabled(response));
-    dispatch(setShowTrackDays(response));
-
+    dispatch(setSystemConfig(response));
     dispatch(fetchSystemStatusSuccess(response));
   };
 };
@@ -70,49 +63,46 @@ const setZendeskConfigStatus = (response) => (dispatch) => {
     enabled = false;
   }
   dispatch({
-    type: SET_ZENDESK_CONFIG,
+    type: SET_ZENDESK_ENABLED,
     payload: enabled,
   });
 }; 
+
+const setSystemConfig = ({ data: { data } }) => (dispatch) => {
+  dispatch({
+    type: SET_DAILY_REPORT_ENABLED,
+    payload: data.daily_report_enabled,
+  });
+  dispatch({
+    type: SET_EXPORT_KML_ENABLED,
+    payload: data.export_kml_enabled,
+  });
+  dispatch({
+    type: SET_EVENT_MATRIX_ENABLED,
+    payload: data.event_matrix_enabled,
+  });
+  dispatch({
+    type: SET_EVENT_SEARCH_ENABLED,
+    payload: data.event_search_enabled,
+  });
+  dispatch({
+    type: SET_ALERTS_ENABLED,
+    payload: data.alerts_enabled,
+  });
+  dispatch({
+    type: SET_SHOW_TRACK_DAYS,
+    payload: data.show_track_days,
+  });
+};
 
 const fetchSystemStatusSuccess = ({ data: { data } }) => ({
   type: FETCH_SYSTEM_STATUS_SUCCESS,
   payload: data,
 });
 
-const fetchSystemStatusError = error => ({
+const fetchSystemStatusError = (error) => ({
   type: FETCH_SYSTEM_STATUS_ERROR,
   payload: error,
-});
-
-const setDailyReportEnabled = ({ data: { data } }) => ({
-    type: SET_DAILY_REPORT_ENABLED,
-    payload: data.daily_report_enabled,
-});
-
-const setExportKmlEnabled = ({ data: { data } }) => ({
-  type: SET_EXPORT_KML_ENABLED,
-  payload: data.export_kml_enabled,
-});
-
-const setEventMatrixEnabled = ({ data: { data } }) => ({
-  type: SET_EVENT_MATRIX_ENABLED,
-  payload: data.event_matrix_enabled,
-});
-
-const setEventSearchEnabled = ({ data: { data } }) => ({
-  type: SET_EVENT_SEARCH_ENABLED,
-  payload: data.event_search_enabled,
-});
-
-const setAlertsEnabled = ({ data: { data } }) => ({
-  type: SET_ALERTS_ENABLED,
-  payload: data.alerts_enabled,
-});
-
-const setShowTrackDays = ({ data: { data } }) => ({
-  type: SET_SHOW_TRACK_DAYS,
-  payload: data.show_track_days,
 });
 
 // utility functions
@@ -309,49 +299,38 @@ export default combineReducers({
   services: serviceStatusReducer,
 });
 
-const INITIAL_ZENDESK_STATE = { enabled: false };
-export const zendeskReducer = (state = INITIAL_ZENDESK_STATE, action) => {
-  const { type, payload } = action;
-  if (type === SET_ZENDESK_CONFIG) {
-    return {
-      enabled: payload,
-    };
+const INITIAL_SYSTEM_CONFIG_STATE = {
+  zendeskEnabled: false,
+  dailyReportEnabled: false,
+  exportKmlEnabled: false,
+  eventMatrixEnabled: false,
+  eventSearchEnabled: false,
+  alertsEnabled: false,
+  showTrackDays: DEFAULT_SHOW_TRACK_DAYS,
+}
+export const systemConfigReducer = (state = INITIAL_SYSTEM_CONFIG_STATE, { type, payload }) => {
+  switch (type) {
+    case (SET_ZENDESK_ENABLED): {
+      return {...state, zendeskEnabled: payload,};
+    }
+    case (SET_DAILY_REPORT_ENABLED): {
+      return {...state, dailyReportEnabled: payload,};
+    }
+    case (SET_EXPORT_KML_ENABLED): {
+      return {...state, exportKmlEnabled: payload,};
+    }
+    case (SET_EVENT_MATRIX_ENABLED): {
+      return {...state, eventMatrixEnabled: payload,};
+    }      
+    case (SET_EVENT_SEARCH_ENABLED): {
+      return {...state, eventSearchEnabled: payload,};
+    }
+    case (SET_ALERTS_ENABLED): {
+      return {...state, alertsEnabled: payload,};
+    }
+    case (SET_SHOW_TRACK_DAYS): {
+      return {...state, showTrackDays: payload,};
+    }
   }
-  return state;
-};
-
-export const dailyReportEnabledReducer = (state = false, action) => {
-  const { type, payload } = action;
-  if (type === SET_DAILY_REPORT_ENABLED) return payload;
-  return state;
-};
-
-export const exportKmlEnabledReducer = (state = false, action) => {
-  const { type, payload } = action;
-  if (type === SET_EXPORT_KML_ENABLED) return payload;
-  return state;
-};
-
-export const eventMatrixEnabledReducer = (state = false, action) => {
-  const { type, payload } = action;
-  if (type === SET_EVENT_MATRIX_ENABLED) return payload;
-  return state;
-};
-
-export const eventSearchEnabledReducer = (state = false, action) => {
-  const { type, payload } = action;
-  if (type === SET_EVENT_SEARCH_ENABLED) return payload;
-  return state;
-};
-
-export const alertsEnabledReducer = (state = false, action) => {
-  const { type, payload } = action;
-  if (type === SET_ALERTS_ENABLED) return payload;
-  return state;
-};
-
-export const showTrackDaysReducer = (state = false, action) => {
-  const { type, payload } = action;
-  if (type === SET_SHOW_TRACK_DAYS) return payload;
   return state;
 };

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -7,9 +7,7 @@ import eventTypesReducer from '../ducks/event-types';
 import mapsReducer, { homeMapReducer } from '../ducks/maps';
 import tracksReducer from '../ducks/tracks';
 import mapSubjectReducer, { subjectGroupsReducer } from '../ducks/subjects';
-import systemStatusReducer, { zendeskReducer, dailyReportEnabledReducer, 
-  exportKmlEnabledReducer, eventMatrixEnabledReducer, eventSearchEnabledReducer, 
-  alertsEnabledReducer, showTrackDaysReducer} from '../ducks/system-status';
+import systemStatusReducer, { systemConfigReducer } from '../ducks/system-status';
 import { heatmapStyleConfigReducer, hiddenSubjectIDsReducer, displayMapNamesReducer,
   hiddenFeatureIDsReducer, heatmapSubjectIDsReducer, subjectTrackReducer, mapLockStateReducer,
   pickingLocationOnMapReducer, displayUserLocationReducer, displayTrackTimepointsReducer } from '../ducks/map-ui';
@@ -44,7 +42,6 @@ const heatmapConfigPersistanceConfig = {
   key: 'heatmapConfig',
   storage,
 };
-
 
 const userProfilePersistanceConfig = {
   key: 'userProfile',
@@ -91,13 +88,7 @@ const rootReducer = combineReducers({
     popup: popupReducer,
     userPreferences: persistReducer(userPrefPersistanceConfig, userPreferencesReducer),
     userLocation: userLocationReducer,
-    zendeskEnabled: zendeskReducer,
-    dailyReportEnabled: dailyReportEnabledReducer,
-    exportKmlEnabled: exportKmlEnabledReducer,
-    eventMatrixEnabled: eventMatrixEnabledReducer,
-    eventSearchEnabled: eventSearchEnabledReducer,
-    alertsEnabled: alertsEnabledReducer,
-    showTrackDays: showTrackDaysReducer,
+    systemConfig: systemConfigReducer,
   }),
 });
 


### PR DESCRIPTION
Implemented systemConfigReducer:
- systemConfigReducer is the reducer for the system configuration fields from the API status call. The story calls for implementing the dailyReportEnabled flag, and I implemented the other flags while I was at it.
- Refactored zendeskReducer into systemConfigReducer to put all system config fields into one reducer.
- Made use of dailyReportEnabled and exportKmlEnabled flags in DataExportMenu\index.js to determine if the respective export menu items should be displayed.