### PR TITLE
report type filter functionality, sans presets

### DIFF
--- a/src/EventFilter/index.js
+++ b/src/EventFilter/index.js
@@ -77,6 +77,10 @@ const EventFilter = (props) => {
     }
   };
 
+  const onFilteredReportsSelect = (types) => {
+    updateEventFilter({ filter: { event_type: types.map(({ id }) => id) } });
+  };
+
 
   const { lower, upper } = date_range;
 
@@ -180,7 +184,7 @@ const EventFilter = (props) => {
         transitionTime={0.1}
         lazyRender={true}
         className={styles.closedFilterDrawer}
-        openedClassName={styles.openedFilterDrawer}
+        openedClassName={`${styles.openedFilterDrawer} ${styles.reportTypeDrawer}`}
         trigger={ReportTypeTrigger}>
         {/* <span className={styles.toggleAllReportTypes}>
           <CheckMark onClick={toggleAllReportTypes} fullyChecked={allReportTypesChecked} partiallyChecked={someReportTypesChecked} />
@@ -188,7 +192,7 @@ const EventFilter = (props) => {
           {someReportTypesChecked && 'Some'}
           {noReportTypesChecked && 'None'}
         </span> */}
-        <ReportTypeMultiSelect selectedReportTypeIDs={currentFilterReportTypes} onCategoryToggle={onReportCategoryToggle} onTypeToggle={onReportTypeToggle} />
+        <ReportTypeMultiSelect selectedReportTypeIDs={currentFilterReportTypes} onCategoryToggle={onReportCategoryToggle} onFilteredItemsSelect={onFilteredReportsSelect} onTypeToggle={onReportTypeToggle} />
       </Collapsible>
     </Popover.Content>
   </Popover>;

--- a/src/EventFilter/styles.module.scss
+++ b/src/EventFilter/styles.module.scss
@@ -220,4 +220,13 @@ div.filterPopover {
     max-height: 24rem;
     overflow-y: auto !important;
   }
+  &.reportTypeDrawer {
+    [class*=Collapsible__contentOuter] {
+      overflow-y: hidden !important;
+      [class*=Collapsible__contentInner] {
+        height: 70vh;
+        max-height: 24rem;
+      }
+    }
+  }
 }

--- a/src/Nav/NavHomeMenu/index.js
+++ b/src/Nav/NavHomeMenu/index.js
@@ -36,9 +36,9 @@ const NavHomeMenu = function NavHomeMenu(props) {
           <Divider />
           <Item className={styles.currentLocationJump} 
             onClick={() => onCurrentLocationClick(userLocation)}>
-            <h5>
+            <h6>
               <GpsLocationIcon /> My Current Location
-            </h5>
+            </h6>
           </Item>
         </Fragment>}
       </Menu>

--- a/src/ReportTypeMultiSelect/index.js
+++ b/src/ReportTypeMultiSelect/index.js
@@ -1,18 +1,45 @@
-import React, { memo, Fragment } from 'react';
+import React, { memo, Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
+import Button from 'react-bootstrap/Button';
 import { connect } from 'react-redux';
 import intersection from 'lodash/intersection';
 
 import { mapReportTypesToCategories } from '../utils/event-types';
 import CheckableList from '../CheckableList';
+import SearchBar from '../SearchBar';
 import EventTypeListItem from '../EventTypeListItem';
 
 import styles from './styles.module.scss';
 
-const ReportTypeMultiSelect = memo((props) => {
-  const { eventTypes, onCategoryToggle, selectedReportTypeIDs, onTypeToggle } = props;
+const filterProps = ['display', 'value', 'category.display'];
 
-  const itemsGroupedByCategory = mapReportTypesToCategories(eventTypes);
+const filterEventTypes = (eventTypes, filterText) =>
+  eventTypes.filter(item =>
+    filterProps.some((prop) => {
+      if (prop.includes('.')) {
+        const nestedFilterProp = prop.split('.').reduce((accumulator, prop) => {
+          if (typeof accumulator === 'object') {
+            return accumulator[prop];
+          }
+          return accumulator;
+        }, item);
+        return nestedFilterProp && nestedFilterProp.toString().toLowerCase().includes(filterText.toString().toLowerCase());
+      }
+      return item[prop] && item[prop].toString().toLowerCase().includes(filterText.toString().toLowerCase());
+    })
+  );
+
+
+const ReportTypeMultiSelect = (props) => {
+  const { eventTypes, onCategoryToggle, selectedReportTypeIDs, onTypeToggle, onFilteredItemsSelect } = props;
+
+  const [filterText, setFilterText] = useState('');
+  const onFilterChange = ({ target: { value } }) => setFilterText(value);
+  const onFilterClear = () => setFilterText('');
+
+  const filteredEventTypes = filterText.length ? filterEventTypes(eventTypes, filterText) : eventTypes;
+
+  const itemsGroupedByCategory = mapReportTypesToCategories(filteredEventTypes);
 
   const categoryFullyChecked = (category) => {
     const categoryTypeIDs = category.types.map(t => t.id);
@@ -22,6 +49,10 @@ const ReportTypeMultiSelect = memo((props) => {
   const categoryPartiallyChecked = (category) => {
     const categoryTypeIDs = category.types.map(t => t.id);
     return !categoryFullyChecked(category) && !!intersection(categoryTypeIDs, selectedReportTypeIDs).length;
+  };
+
+  const selectFilteredItems = () => {
+    onFilteredItemsSelect(filteredEventTypes);
   };
 
   const reportTypeChecked = (type) => selectedReportTypeIDs.includes(type.id);
@@ -39,19 +70,33 @@ const ReportTypeMultiSelect = memo((props) => {
     </Fragment>;
   });
 
-  return <CheckableList
-    className={styles.reportTypeList}
-    onCheckClick={onCategoryToggle}
-    items={itemsGroupedByCategory}
-    itemComponent={ListItem}
-    itemFullyChecked={categoryFullyChecked}
-    itemPartiallyChecked={categoryPartiallyChecked}
-  />;
-});
+  return <div className={styles.wrapper}>
+    <div className={styles.searchBar}>
+      <SearchBar className={styles.search} placeholder='Search types' text={filterText}
+        onChange={onFilterChange} onClear={onFilterClear} />
+      {!!filterText.length
+        && <Button onClick={selectFilteredItems} type="button" variant='info' size='sm' disabled={!filteredEventTypes.length}>
+          {filteredEventTypes.length ?
+            `Set to these ${filteredEventTypes.length}`
+            : 'No matches'
+          }
+        </Button>
+      }
+    </div>
+    <CheckableList
+      className={styles.reportTypeList}
+      onCheckClick={onCategoryToggle}
+      items={itemsGroupedByCategory}
+      itemComponent={ListItem}
+      itemFullyChecked={categoryFullyChecked}
+      itemPartiallyChecked={categoryPartiallyChecked}
+    />
+  </div>;
+};
 
 const mapStateToProps = ({ data: { eventTypes } }) => ({ eventTypes });
 
-export default connect(mapStateToProps, null)(ReportTypeMultiSelect);
+export default connect(mapStateToProps, null)(memo(ReportTypeMultiSelect));
 
 
 

--- a/src/ReportTypeMultiSelect/styles.module.scss
+++ b/src/ReportTypeMultiSelect/styles.module.scss
@@ -1,6 +1,29 @@
 @import '../common/styles/vars/colors';
 
+
+.wrapper {
+  height: 100%;
+  overflow: hidden;
+  padding-top: 3rem;
+  position: relative;
+}
+
+.searchBar {
+  align-items: center;
+  background: white;
+  display: flex;
+  justify-content: space-between;
+  left: 0;
+  padding: 0 0.75rem;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
 .reportTypeList {
+  height: 100%;
+  margin: 0;
+  overflow-y: auto;
   > li {
     background: $light-gray-background;
     display: flex;

--- a/src/SearchBar/index.js
+++ b/src/SearchBar/index.js
@@ -1,13 +1,11 @@
 import React, { memo, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 
-import { trackEvent } from '../utils/analytics';
-
 import { ReactComponent as SearchIcon } from '../common/images/icons/search-icon.svg';
 import { ReactComponent as ClearIcon } from '../common/images/icons/close-icon.svg';
 import styles from './styles.module.scss';
 
-const SearchBar = memo((props) => {
+const SearchBar = (props) => {
   const { text, onChange, onClear, placeholder, className, ...rest } = props;
 
   const [isActive, setIsActiveState] = useState(false);
@@ -41,7 +39,7 @@ const SearchBar = memo((props) => {
       <ClearIcon className={styles.clearIcon} />
     </button>    
   </label>;
-});
+};
 
 SearchBar.defaultProps = {
   placeholder: 'Search...',
@@ -56,4 +54,4 @@ SearchBar.propTypes = {
   onClear: PropTypes.func,
 };
 
-export default SearchBar;
+export default memo(SearchBar);


### PR DESCRIPTION
This adds the filter-driven functionality to the report type and category selection filter widget.

However, I did _not_ add the "security only/all but analyzer" presets. This is because report categories are purportedly schema-driven, and while out-of-the-box report categories may come as 'security' and 'analyzer' we can't have any guarantees that is the case. We should revisit the way the presets are created at a later date to ensure they work across all use cases, rather than only tying into a defaults-only implementation.

Otherwise, this story is done.