### PR TITLE
Prevent feature list items from collapsing

### DIFF
--- a/src/FeatureLayerList/FeatureTypeListItem.js
+++ b/src/FeatureLayerList/FeatureTypeListItem.js
@@ -2,7 +2,6 @@ import React, { memo, useState } from 'react';
 // import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Collapsible from 'react-collapsible';
-import uniq from 'lodash/uniq';
 
 import { hideFeatures, showFeatures } from '../ducks/map-ui';
 import { trackEvent } from '../utils/analytics';
@@ -22,7 +21,9 @@ const FeatureTypeListItem = (props) => {
   const { name, features, hiddenFeatureIDs, hideFeatures, showFeatures, map,
     featureFilterEnabled } = props;
 
-  const [openFeatureTypes, setOpenFeatureTypes] = useState([]);
+  const [openFeatureType, setOpenFeatureType] = useState('');
+
+  console.log('feature type', name, 'openFeatureType', openFeatureType);
 
   if (featureFilterEnabled && !features.length) return null;
 
@@ -39,18 +40,16 @@ const FeatureTypeListItem = (props) => {
     }
   };
 
-  const collapsibleShouldBeOpen = (featureFilterEnabled && !!features.length) || openFeatureTypes.includes(name);
+  const collapsibleShouldBeOpen = (featureFilterEnabled && !!features.length) || openFeatureType === name;
 
   const onFeatureTypeOpen = () => {
-    console.log('adding ', name);
-    const featureTypes = uniq([...openFeatureTypes, name]);
-    setOpenFeatureTypes(featureTypes);
+    console.log('setOpenFeatureType', name);
+    setOpenFeatureType(name);
   };
 
   const onFeatureTypeClose = () => {
-    console.log('removing ', name);
-    const featureTypes = openFeatureTypes.filter((f) => f !== name);
-    setOpenFeatureTypes(featureTypes);
+    console.log('setOpenFeatureType', '');
+    setOpenFeatureType('');
   };
 
   const itemProps = { map };


### PR DESCRIPTION
This fix adds the following:
 - a property that persists in state the name of the currently opened feature type.
 - modify the collapsibleShouldBeOpen function to return a true value if it is the currently open feature list

Note: My sense is there should be a lighter weight way, just didn't find a good way to achieve it.