### PR TITLE
Add short format date to event symbol titles

### DIFF
--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -1,10 +1,11 @@
 
 import { distanceInWords } from 'date-fns';
 
-import { subMonths, subWeeks, subDays, startOfDay } from 'date-fns';
+import { subMonths, subWeeks, subDays, startOfDay, format } from 'date-fns';
 
 export const DEFAULT_FRIENDLY_DATE_FORMAT = 'Mo MMM YYYY';
 
+export const EVENT_SYMBOL_DATE_FORMAT = 'DD MMM YY';
 
 export const dateIsValid = date => date instanceof Date && !isNaN(date.valueOf());
 
@@ -13,7 +14,7 @@ export const calcFriendlyDurationString = (from, until) => {
 
   if (!until) return `${distanceInWords(startOfDay(from), new Date())} ago until now`;
 
-  if (!from) return `1 month ago until ${distanceInWords(startOfDay(until), new Date())} ago`
+  if (!from) return `1 month ago until ${distanceInWords(startOfDay(until), new Date())} ago`;
 
   return `${distanceInWords(startOfDay(from), new Date())} ago until ${distanceInWords(startOfDay(until), new Date())} ago`;
 };
@@ -38,3 +39,5 @@ export const generateMonthsAgoDate = (monthsAgo = 1) => new Date(
     subMonths(new Date(), monthsAgo)
   )
 );
+
+export const formatEventSymbolDate = (dateString) => format(new Date(dateString), EVENT_SYMBOL_DATE_FORMAT);

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -6,6 +6,7 @@ import { feature, featureCollection, polygon } from '@turf/helpers';
 import { LngLatBounds } from 'mapbox-gl';
 import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
 import { MAP_ICON_SIZE/* , MAX_ZOOM */ } from '../constants';
+import { formatEventSymbolDate } from '../utils/datetime';
 import { fileNameFromPath } from './string';
 import { imgElFromSrc } from './img';
 
@@ -77,9 +78,12 @@ export const filterInactiveRadiosFromCollection = (subjects) => {
   return emptyFeatureCollection;
 };
 
-const addTitleToGeoJson = (geojson, title) => (geojson.properties.display_title = title) && geojson;
+const addTitleWithDateToGeoJson = (geojson, title) => { 
+  const displayTitle = geojson.properties.datetime ? title + '\n' + formatEventSymbolDate(geojson.properties.datetime) : title;
+  return (geojson.properties.display_title = displayTitle) && geojson;
+};
 
-const setUpEventGeoJson = events => addIdToCollectionItemsGeoJsonByKey(events, 'geojson').map(event => copyResourcePropertiesToGeoJsonByKey(event, 'geojson')).map(({ geojson, title, event_type }) => addTitleToGeoJson(addIconToGeoJson(geojson), title || event_type));
+const setUpEventGeoJson = events => addIdToCollectionItemsGeoJsonByKey(events, 'geojson').map(event => copyResourcePropertiesToGeoJsonByKey(event, 'geojson')).map(({ geojson, title, event_type }) => addTitleWithDateToGeoJson(addIconToGeoJson(geojson), title || event_type));
 const setUpSubjectGeoJson = subjects => addIdToCollectionItemsGeoJsonByKey(subjects, 'last_position').map(subject => copyResourcePropertiesToGeoJsonByKey(subject, 'last_position')).map(({ last_position: geojson }) => addIconToGeoJson(geojson));
 const featureCollectionFromGeoJson = geojson_collection => featureCollection(geojson_collection.map(({ geometry, properties }) => feature(geometry, properties)));
 


### PR DESCRIPTION
Modify the event title to include a short formatted date. After looking at the mapbox docs, there did not seem to be a format that would wrap labels as you would in other rendering toolkits, so the fix is pretty low rent - we append a newline character to the label and a short formatted date.

For simplicity, I concatenated using '+' - I'm used to using array formatting (it was interesting to see that Python and Javascript share a common idiom), but in googling it seems that there is not much performance gain in array concatention in modern browsers. 