### PR TITLE
Apply tile layers below polygons

### DIFF
--- a/src/BaseLayerRenderer/TileLayerRenderer.js
+++ b/src/BaseLayerRenderer/TileLayerRenderer.js
@@ -3,7 +3,7 @@ import { Layer, Source } from 'react-mapbox-gl';
 
 import { TILE_LAYER_SOURCE_TYPES, LAYER_IDS } from '../constants';
 
-const { SUBJECT_SYMBOLS } = LAYER_IDS;
+const { FEATURE_FILLS } = LAYER_IDS;
 
 const RASTER_SOURCE_OPTIONS = {
   'type': 'raster',
@@ -30,7 +30,7 @@ const TileLayerRenderer = (props) => {
       const layout = {
         'visibility': layer.id === currentBaseLayer.id ? 'visible' : 'none',
       };
-      return <Layer before={SUBJECT_SYMBOLS} id={`tile-layer-${layer.id}`} key={layer.id} layout={layout} sourceId={`layer-source-${layer.id}`} type="raster" />;
+      return <Layer before={FEATURE_FILLS} id={`tile-layer-${layer.id}`} key={layer.id} layout={layout} sourceId={`layer-source-${layer.id}`} type="raster" />;
     });
 
   return <Fragment>


### PR DESCRIPTION
Change to make sure the new layer tiles are layered below the feature fill layer. Verified that feature symbols and lines are still visible after this change