### PR TITLE
@page media size property for appropriate print options.

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -496,7 +496,8 @@ div.mapboxgl-popup-tip {
 
 @media print {
   @page {
-    size: landscape;
+    margin: 0.5cm;
+    size: auto;
   }
   .primary-nav .rightMenus > div {
     &:first-child, &:last-child {


### PR DESCRIPTION
Well, what do you know. Having an `@page` style declaration can apparently remove system-level print dialog options if you're not careful. 🤷‍♂️