### PR TITLE
clearing token cookie.

### DIFF
--- a/src/ducks/auth.js
+++ b/src/ducks/auth.js
@@ -1,7 +1,7 @@
 import axios, { CancelToken } from 'axios';
 import { REACT_APP_DAS_HOST, REACT_APP_DAS_AUTH_TOKEN_URL } from '../constants';
 import { clearUserProfile } from '../ducks/user';
-import { getAuthTokenFromCookies } from '../utils/auth';
+import { deleteAuthTokenCookie, getAuthTokenFromCookies } from '../utils/auth';
 
 const AUTH_URL = `${REACT_APP_DAS_HOST}${REACT_APP_DAS_AUTH_TOKEN_URL}`;
 
@@ -49,6 +49,7 @@ const postAuthError = error => ({
 });
 
 export const clearAuth = () => dispatch => {
+  deleteAuthTokenCookie();
   dispatch(clearUserProfile());
   dispatch({
     type: CLEAR_AUTH,

--- a/src/ducks/system-status.js
+++ b/src/ducks/system-status.js
@@ -42,7 +42,7 @@ export const fetchSystemStatus = () => {
         service_status: true,
       },
     }).catch(error => {
-      dispatch(fetchSystemStatusError(error))
+      dispatch(fetchSystemStatusError(error));
       throw error;
     });
 
@@ -70,7 +70,7 @@ const setZendeskConfigStatus = (response) => (dispatch) => {
     type: SET_ZENDESK_ENABLED,
     payload: enabled,
   });
-}; 
+};
 
 const setSystemConfig = ({ data: { data } }) => (dispatch) => {
   dispatch({
@@ -171,7 +171,7 @@ const genericStatusReducer = (reducer, onApiResponse = (update, state) => state)
 const INITIAL_NETWORK_STATUS_STATE = genericStatusModel({
   title: 'Network',
   details: window.navigator.onLine ? 'online' : 'offline',
-  status: window.navigator.onLine ? HEALTHY_STATUS: UNHEALTHY_STATUS,
+  status: window.navigator.onLine ? HEALTHY_STATUS : UNHEALTHY_STATUS,
 });
 const networkStatusReducer = function (state = INITIAL_NETWORK_STATUS_STATE, { payload, type }) {
   switch (type) {
@@ -197,7 +197,7 @@ const serverStatusReducer = genericStatusReducer((state = INITIAL_SERVER_STATUS_
   switch (type) {
   case (SERVER_VERSION_CHANGE): {
     const { version } = payload;
-    
+
     setServerVersionAnalyticsDimension(version);
     return {
       ...state,
@@ -252,7 +252,7 @@ const realtimeStatusReducer = genericStatusReducer((state = INITIAL_REALTIME_STA
       timestamp,
     };
   }
-  case(SERVER_STATUS_CHANGE): {
+  case (SERVER_STATUS_CHANGE): {
     if (payload === UNKNOWN_STATUS) {
       return {
         ...state,
@@ -286,7 +286,7 @@ const serviceStatusReducer = genericStatusReducer((state = INITIAL_SERVICES_STAT
     const { services } = payload;
     return createServiceModelsFromApiResponse(services);
   }
-  case(SERVER_STATUS_CHANGE): {
+  case (SERVER_STATUS_CHANGE): {
     if (payload === UNKNOWN_STATUS) {
       return state.map(service => ({ ...service, status: UNKNOWN_STATUS }));
     }
@@ -314,30 +314,32 @@ const INITIAL_SYSTEM_CONFIG_STATE = {
   eventSearchEnabled: false,
   alertsEnabled: false,
   showTrackDays: DEFAULT_SHOW_TRACK_DAYS,
-}
+};
 export const systemConfigReducer = (state = INITIAL_SYSTEM_CONFIG_STATE, { type, payload }) => {
   switch (type) {
-    case (SET_ZENDESK_ENABLED): {
-      return {...state, zendeskEnabled: payload,};
-    }
-    case (SET_DAILY_REPORT_ENABLED): {
-      return {...state, dailyReportEnabled: payload,};
-    }
-    case (SET_EXPORT_KML_ENABLED): {
-      return {...state, exportKmlEnabled: payload,};
-    }
-    case (SET_EVENT_MATRIX_ENABLED): {
-      return {...state, eventMatrixEnabled: payload,};
-    }      
-    case (SET_EVENT_SEARCH_ENABLED): {
-      return {...state, eventSearchEnabled: payload,};
-    }
-    case (SET_ALERTS_ENABLED): {
-      return {...state, alertsEnabled: payload,};
-    }
-    case (SET_SHOW_TRACK_DAYS): {
-      return {...state, showTrackDays: payload,};
-    }
+  case (SET_ZENDESK_ENABLED): {
+    return { ...state, zendeskEnabled: payload, };
   }
-  return state;
+  case (SET_DAILY_REPORT_ENABLED): {
+    return { ...state, dailyReportEnabled: payload, };
+  }
+  case (SET_EXPORT_KML_ENABLED): {
+    return { ...state, exportKmlEnabled: payload, };
+  }
+  case (SET_EVENT_MATRIX_ENABLED): {
+    return { ...state, eventMatrixEnabled: payload, };
+  }
+  case (SET_EVENT_SEARCH_ENABLED): {
+    return { ...state, eventSearchEnabled: payload, };
+  }
+  case (SET_ALERTS_ENABLED): {
+    return { ...state, alertsEnabled: payload, };
+  }
+  case (SET_SHOW_TRACK_DAYS): {
+    return { ...state, showTrackDays: payload, };
+  }
+  default: {
+    return state;
+  }
+  }
 };

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -9,6 +9,10 @@ export const getAuthTokenFromCookies = () => {
   return token ? token.replace('token=', '').replace(';', '') : null;
 };
 
+export const deleteAuthTokenCookie = () => {
+  document.cookie = 'token=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+};
+
 
 const goToLoginPageOnAuthFailure = (error) => {
   if (error && error.response && error.response.data && error.response.data.status && error.response.data.status.code === 401) {


### PR DESCRIPTION
Adding a token cookie for use within the alerts app made our auth token "stickier" than intended. This PR makes sure that logging out actually logs out.