### PR TITLE
change conditional spread operation to be key-agnostic, fixing potent…

### DIFF
--- a/src/socket/index.js
+++ b/src/socket/index.js
@@ -2,6 +2,7 @@ import io from 'socket.io-client';
 import { store } from '../index';
 import { REACT_APP_DAS_HOST } from '../constants';
 import { events, SOCKET_RECOVERY_DISPATCHES } from './config';
+import { SOCKET_HEALTHY_STATUS } from '../ducks/system-status';
 import { newSocketActivity, resetSocketActivityState } from '../ducks/realtime';
 import { clearAuth } from '../ducks/auth';
 
@@ -54,6 +55,7 @@ export const pingSocket = (socket) => {
 const bindSocketEvents = (socket, store) => {
   socket.on('connect', () => {
     console.log('realtime: connected');
+    store.dispatch({ type: SOCKET_HEALTHY_STATUS });
     socket.emit('authorization', { type: 'authorization', id: 1, authorization: `Bearer ${store.getState().data.token.access_token}` });
   });
   socket.on('disconnect', (msg) => {

--- a/src/utils/system-status.js
+++ b/src/utils/system-status.js
@@ -6,11 +6,11 @@ const worstToBest = [UNKNOWN_STATUS, UNHEALTHY_STATUS, WARNING_STATUS, HEALTHY_S
 
 const calcWorstCaseStatus = (systemStatus) => {
   const statusArray = Object.entries(systemStatus)
-    .reduce((accumulator, [key, value]) => {
-    if (key === 'services') return [...accumulator, ...value];
-    return [...accumulator, value];
-  }, [])
-  .map(({ status }) => status);
+    .reduce((accumulator, [_key, value]) => {
+      if (Array.isArray(value)) return [...accumulator, ...value];
+      return [...accumulator, value];
+    }, [])
+    .map(({ status }) => status);
 
   return worstToBest.find(item => statusArray.includes(item));
 };


### PR DESCRIPTION
…ial single-entry service status calculations and enabling other system status values to have multiple entries in the future. displaying a 'healthy' socket status upon successful initial connection.

@JayLVulcan please give the code a good once-over.

@jenaea the changes to `utils/system-status.js` should resolve the occasional "white screen of death" bug we've been seeing at bootstrapping time for the main app (e.g. right after pageload and/or right after logging in)