### PR TITLE
removing state filtering on 'add to incident' modal feed query

### DIFF
--- a/src/ReportForm/AddToIncidentModal.js
+++ b/src/ReportForm/AddToIncidentModal.js
@@ -31,7 +31,7 @@ const AddToIncidentModal = (props) => {
   };
 
   const fetchFeed = async () => {
-    await fetchIncidentFeed({}, 'is_collection=true&state=active&state=new');
+    await fetchIncidentFeed({}, 'is_collection=true');
     setLoadedState(true);
   };
 


### PR DESCRIPTION
It's a mythical one-liner.