### PR TITLE
normalizing event filter requests a bit with the idea of an empty arr…

### DIFF
--- a/src/DataExportMenu/index.js
+++ b/src/DataExportMenu/index.js
@@ -31,7 +31,7 @@ const DataExportMenu = (props) => {
         title: 'Field Reports',
         content: DataExportModal,
         url: 'activity/events/export',
-        paramString: calcEventFilterForRequest({ exclude_contained: false }),
+        paramString: calcEventFilterForRequest(),
       },
       ...(exportKmlEnabled? [{
         title: 'Master KML',

--- a/src/ReportTypeMultiSelect/index.js
+++ b/src/ReportTypeMultiSelect/index.js
@@ -33,6 +33,8 @@ const filterEventTypes = (eventTypes, filterText) =>
 const ReportTypeMultiSelect = (props) => {
   const { eventTypes, onCategoryToggle, selectedReportTypeIDs, onTypeToggle, onFilteredItemsSelect } = props;
 
+  const noEventTypeSetInFilter = !selectedReportTypeIDs.length;
+
   const [filterText, setFilterText] = useState('');
   const onFilterChange = ({ target: { value } }) => setFilterText(value);
   const onFilterClear = () => setFilterText('');
@@ -42,6 +44,8 @@ const ReportTypeMultiSelect = (props) => {
   const itemsGroupedByCategory = mapReportTypesToCategories(filteredEventTypes);
 
   const categoryFullyChecked = (category) => {
+    if (noEventTypeSetInFilter) return true;
+
     const categoryTypeIDs = category.types.map(t => t.id);
     return intersection(categoryTypeIDs, selectedReportTypeIDs).length === categoryTypeIDs.length;
   };
@@ -55,7 +59,7 @@ const ReportTypeMultiSelect = (props) => {
     onFilteredItemsSelect(filteredEventTypes);
   };
 
-  const reportTypeChecked = (type) => selectedReportTypeIDs.includes(type.id);
+  const reportTypeChecked = (type) => noEventTypeSetInFilter ? true : selectedReportTypeIDs.includes(type.id);
 
   const ListItem = (props) => { // eslint-disable-line react/display-name
     const { display, types } = props;

--- a/src/SideBar/index.js
+++ b/src/SideBar/index.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import Tabs from 'react-bootstrap/Tabs';
 import Tab from 'react-bootstrap/Tab';
 import Button from 'react-bootstrap/Button';
+import isEqual from 'react-fast-compare';
 
 import { BREAKPOINTS } from '../constants';
 import { useMatchMedia } from '../hooks';
@@ -13,6 +14,7 @@ import { getFeedEvents } from '../selectors';
 import { ReactComponent as ChevronIcon } from '../common/images/icons/chevron.svg';
 
 import { fetchEventFeed, fetchNextEventFeedPage } from '../ducks/events';
+import { INITIAL_FILTER_STATE } from '../ducks/event-filter';
 import { setReportHeatmapVisibility } from '../ducks/map-ui';
 import SubjectGroupList from '../SubjectGroupList';
 import FeatureLayerList from '../FeatureLayerList';
@@ -65,9 +67,14 @@ const SideBar = (props) => {
     trackEvent('Drawer', `Click '${tabTitles[eventKey]}' tab`);
   };
 
+  const optionalFeedProps = {};
+  if (isEqual(eventFilter, INITIAL_FILTER_STATE)) {
+    optionalFeedProps.exclude_contained = true;
+  }
+
   const loadFeedEvents = () => {
     setEventLoadState(true);
-    fetchEventFeed({}, calcEventFilterForRequest())
+    fetchEventFeed({}, calcEventFilterForRequest(optionalFeedProps))
       .then(() => setEventLoadState(false));
   };
 

--- a/src/ducks/event-filter.js
+++ b/src/ducks/event-filter.js
@@ -1,9 +1,8 @@
+import isEqual from 'react-fast-compare';
 import { generateMonthsAgoDate } from '../utils/datetime';
 
 // ACTIONS
 const UPDATE_EVENT_FILTER = 'UPDATE_EVENT_FILTER';
-
-const RESET_EVENT_FILTER = 'RESET_EVENT_FILTER';
 
 // ACTION CREATORS
 export const updateEventFilter = update => (dispatch) => {
@@ -13,26 +12,8 @@ export const updateEventFilter = update => (dispatch) => {
   });
 };
 
-export const resetEventFilter = () => (dispatch, getState) => {
-  const eventTypeIDs = getState().data.eventTypes.map(type => type.id);
-
-  const freshFilter = {
-    ...INITIAL_FILTER_STATE,
-    filter: {
-      ...INITIAL_FILTER_STATE.filter,
-      event_type: eventTypeIDs,
-    },
-  };
-
-  dispatch({
-    type: RESET_EVENT_FILTER,
-    payload: freshFilter,
-  });
-};
-
 // REDUCER
 export const INITIAL_FILTER_STATE = {
-  exclude_contained: true,
   include_notes: true,
   include_related_events: true,
   state: ['active', 'new'],
@@ -61,9 +42,6 @@ export default (state = INITIAL_FILTER_STATE, action) => {
         ...payload.filter,
       }
     };
-  }
-  case (RESET_EVENT_FILTER): {
-    return { ...payload };
   }
   default: {
     return state;

--- a/src/ducks/event-types.js
+++ b/src/ducks/event-types.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
 import { API_URL } from '../constants';
-import { updateEventFilter } from './event-filter';
 
 export const EVENT_TYPE_API_URL = `${API_URL}activity/events/eventtypes`;
 
@@ -15,12 +14,6 @@ export const fetchEventTypes = () => dispatch => axios.get(EVENT_TYPE_API_URL)
   });
 
 const fetchEventTypesSuccess = response => dispatch => {
-  dispatch(updateEventFilter({
-    filter:
-    {
-      event_type: response.data.data.map(({ id }) => id)
-    }
-  }));
   dispatch({
     type: FETCH_EVENT_TYPES_SUCCESS,
     payload: response.data.data,

--- a/src/ducks/events.js
+++ b/src/ducks/events.js
@@ -270,7 +270,7 @@ const cancelableMapEventsFetch = () => {
     if (!map && !lastKnownBbox) return Promise.reject();
     
     const bbox = map ? getBboxParamsFromMap(map) : lastKnownBbox;
-    const eventFilterParamString = calcEventFilterForRequest({ bbox, exclude_contained: false, page_size: 25 });
+    const eventFilterParamString = calcEventFilterForRequest({ bbox, page_size: 25 });
     
     dispatch({
       type: FETCH_MAP_EVENTS_START,

--- a/src/ducks/map-layer-filter.js
+++ b/src/ducks/map-layer-filter.js
@@ -12,14 +12,6 @@ export const updateMapLayerFilter = (update) => (dispatch) => {
   });
 };
 
-export const resetEventFilter = () => (dispatch) => {
-  const freshFilter = INITIAL_FILTER_STATE;
-  dispatch({
-    type: RESET_MAP_LAYER_FILTER,
-    payload: freshFilter,
-  });
-};
-
 // REDUCER
 export const INITIAL_FILTER_STATE = {
   filter: {


### PR DESCRIPTION
…ay being an empty value for various filter params. applying the exclude_contained filter prop in a manner consistent with the old web app. cleaning up old, unused filter state code.

This fixes issues with both DAS-4906 and DAS-4845