### PR TITLE
Route to external endpoints

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,6 @@ ReactDOM.render(
       <BrowserRouter>
         <Suspense fallback={<LoadingOverlay message='Loading...' />}>
           <Switch>
-            <Route path='/cancel-admin-eula' component={() => { window.location.href='/admin/login/'; }}/>
             <Route path={`${REACT_APP_ROUTE_PREFIX}${REACT_APP_ROUTE_PREFIX === '/' ? 'login' : '/login'}`} component={withTracker(Login)} />
             <PrivateRoute exact path={`${REACT_APP_ROUTE_PREFIX}${REACT_APP_ROUTE_PREFIX === '/' ? 'eula' : '/eula'}`} component={withTracker(EulaPage)} />
             <EulaProtectedRoute exact path={REACT_APP_ROUTE_PREFIX} component={withTracker(App)} />

--- a/src/views/EULA/index.js
+++ b/src/views/EULA/index.js
@@ -32,8 +32,8 @@ const EulaPage = (props) => {
     document.cookie.split(' ').find(item => item.startsWith('routeAfterEulaAccepted='))
       .replace('routeAfterEulaAccepted=', '').replace('"', '').replace(';', '').replace('/"', '/') : null;
 
-  const loginUrl = REACT_APP_ROUTE_PREFIX === '/' ? 'login' : '/login';
-  const cancelUrl = /admin/.test(rerouteCookieValue) ? '/cancel-admin-eula' : REACT_APP_ROUTE_PREFIX.concat(loginUrl);
+  // inspect the redirect cookie set and see if it is an admin endpoint
+  const adminReferrer = /admin/.test(rerouteCookieValue);
 
   const generateTempAuthHeaderIfNecessary = useCallback(() => {
     return temporaryAccessToken ? {
@@ -61,10 +61,14 @@ const EulaPage = (props) => {
   }, [rerouteCookieValue, submitted]);
 
   useEffect(() => {
+    if (canceled && adminReferrer && rerouteCookieValue) {
+      window.location = rerouteCookieValue.concat('logout/');
+    }
+  }, [adminReferrer, canceled, rerouteCookieValue]);
+
+  useEffect(() => {
     if (user.accepted_eula) return history.goBack();
   }, []);
-
-
 
   const onSubmit = useCallback((event, ...rest) => {
     event.preventDefault();
@@ -122,7 +126,7 @@ const EulaPage = (props) => {
       </Form>
     </Dialog>;
     {submitted && !rerouteCookieValue && <Redirect to={rerouteOnSuccess} />}
-    {canceled && <Redirect to={cancelUrl} />}
+    {canceled && !adminReferrer && <Redirect to={`${REACT_APP_ROUTE_PREFIX}${REACT_APP_ROUTE_PREFIX === '/' ? 'login' : '/login'}`} />}
   </div>;
 };
 


### PR DESCRIPTION
This commit is done to address  https://vulcan.atlassian.net/browse/DAS-4978

Our react app users react-router-dom, which is not designed to route to external endpoints. In our app, we offer users the ability to cancel out of accepting the EULA. To accomodate cancellations from our /admin referrer, a Route is constructed with a component that calls window.locaction.href, to allow the routing mechanism to  connect to the /admin/login/ endpoint