### PR TITLE
realtime socket bugfixes

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -130,7 +130,7 @@ aside {
 
 .floating-report-filter {
   @include fade-in;
-  border-radius: 0.25rem;
+  border-radius: 0.666rem;
   position: absolute;
   z-index: 7;
   background: rgba(255, 255, 255, 0.85);

--- a/src/EventFilter/styles.module.scss
+++ b/src/EventFilter/styles.module.scss
@@ -5,7 +5,7 @@
 
 .form {
   align-items: center;
-  border-bottom: 1px solid $gray-border;
+  border-bottom: 1px solid $light-gray-border;
   flex-wrap: wrap;
   display: flex;
   justify-content: flex-end;

--- a/src/socket/config.js
+++ b/src/socket/config.js
@@ -4,7 +4,6 @@ import { SOCKET_UPDATE_EVENT, SOCKET_NEW_EVENT, fetchMapEvents } from '../ducks/
 
 const SOCKET_DISPATCHES = {
   resp_authorization: [/* 'SOCKET_AUTH_RESPONSE' ,*/ SOCKET_HEALTHY_STATUS],
-  connect: [/* 'SOCKET_CONNECT' ,*/ SOCKET_HEALTHY_STATUS],
   connect_error: [/* 'SOCKET_CONNECT_ERROR' ,*/ SOCKET_UNHEALTHY_STATUS],
   disconnect: [/* 'SOCKET_DISCONNECT' ,*/ SOCKET_UNHEALTHY_STATUS],
   error: [/* 'SOCKET_ERROR' ,*/ SOCKET_UNHEALTHY_STATUS],

--- a/src/socket/index.js
+++ b/src/socket/index.js
@@ -20,7 +20,7 @@ const stateManagedSocketEventHandler = (socket, type, callback) => {
   return socket.on(type, (payload) => {
     const { mid } = payload;
     if (!validateSocketIncrement(type, mid)) {
-      resetSocket(socket);
+      resetSocketStateTracking(socket);
     } else {
       updateSocketStateTrackerForEventType({ type, mid });
     }
@@ -46,7 +46,7 @@ export const pingSocket = (socket) => {
       socket.emit('echo', { data: 'ping' });
     } else {
       window.clearInterval(interval);
-      resetSocket(socket);
+      resetSocketStateTracking(socket);
     }
   }, 30000);
   return interval;
@@ -60,11 +60,11 @@ const bindSocketEvents = (socket, store) => {
   });
   socket.on('disconnect', (msg) => {
     console.log('realtime: disconnected', msg);
-    resetSocket(socket);
+    resetSocketStateTracking(socket);
   });
   socket.on('connect_error', () => {
     console.log('realtime: connection error');
-    resetSocket(socket);
+    resetSocketStateTracking(socket);
   });
   socket.on('resp_authorization', ({ status }) => {
     if (status.code === 401) {
@@ -81,10 +81,8 @@ const bindSocketEvents = (socket, store) => {
   });
 };
 
-const resetSocket = (socket) => {
-  unbindSocketEvents(socket);
+const resetSocketStateTracking = (socket) => {
   store.dispatch(resetSocketActivityState());
-  bindSocketEvents(socket, store);
   SOCKET_RECOVERY_DISPATCHES.forEach(actionCreator => store.dispatch(actionCreator()));
   return socket;
 };

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -31,9 +31,6 @@ export const recursivePaginatedQuery = async (initialQuery, cancelToken = null, 
   initialQuery
     .then((response) => {
       if (response) {
-
-        console.log('initialQuery canceled', initialQuery.__CANCEL__, response.__CANCEL__);
-
         const { data: { data: res } } = response;
         const { results, next } = res;
         
@@ -50,5 +47,5 @@ export const recursivePaginatedQuery = async (initialQuery, cancelToken = null, 
       }
     })
     .catch((e) => {
-      console.log('recursive query failure', e);
+      console.warn('recursive query failure', e);
     });

--- a/src/withSocketConnection/index.js
+++ b/src/withSocketConnection/index.js
@@ -7,6 +7,7 @@ const withSocketConnection = (Component) => (props) => { // eslint-disable-line 
     socket.current = createSocket();
     return () => {
       unbindSocketEvents(socket.current);
+      socket.current.disconnect();
     };
   }, []);
 


### PR DESCRIPTION
Some legacy socket-sustaining logic had been brought over from the Angular app, which ended up being not only redundant but harmful to the health of our realtime connections. 

This PR removes that code (which was unbinding and rebinding all events when a socket errors or reconnects).

 We now also manually disconnect the socket on Map component unmount to help clean up connections for client and server. Various style tweaks as per UI feedback as well.