### PR TITLE
Das 5056 show eula link

### DIFF
--- a/src/Login/index.js
+++ b/src/Login/index.js
@@ -95,8 +95,7 @@ class LoginPage extends Component {
         </Alert>}
       </Form>
       {this.props.eulaEnabled === true &&
-        <p className={styles.eulalink}>Please <a href={eula_url} target='_blank' rel='noopener noreferrer'>click here and
-            read our EULA</a> before using EarthRanger
+        <p className={styles.eulalink}><a href={eula_url} target='_blank' rel='noopener noreferrer'>EarthRanger EULA</a>
         </p>}
     </div>;
   }

--- a/src/Login/styles.module.scss
+++ b/src/Login/styles.module.scss
@@ -1,3 +1,5 @@
+@import '../common/styles/vars/colors';
+
 .container {
   align-items: center;
   display: flex;
@@ -23,7 +25,14 @@
 }
 
 .eulalink {
-  padding-top: 5rem;
+  padding-top: 3rem;
+  font-size: 85%;
+  a {
+    color: $light-font-color;
+    &:hover {
+      color: $primary-font-color;
+    }
+  }
 }
 
 .error {


### PR DESCRIPTION
Added eula awareness to login component.
Initially, this was done via a wrapper component, what is referred to in React as a higher order component, which was shared between the login and eula components. However, in testing, it became obvious that there were edge cases where that was not a good choice. This PR just connects the login component to redux to request and recieve eula info (to retrieve a eula link) and status info (to determine if the link to the eula should be shown).

Expected behavior:
- When the server config property 'EULA_ENABLED' is set to True, a link to the current eula is displayed in the react login page. When the propert is set to False, no link should be displayed