### PR TITLE
Added flip property to allow auto positioning to work

### DIFF
--- a/src/EventFilter/index.js
+++ b/src/EventFilter/index.js
@@ -282,13 +282,13 @@ const EventFilter = (props) => {
 
   return <form className={`${styles.form} ${className}`} onSubmit={e => e.preventDefault()}>
     <div className={styles.controls}>
-      <OverlayTrigger shouldUpdatePosition={true} rootClose trigger='click' placement='auto' overlay={FilterPopover}>
+      <OverlayTrigger shouldUpdatePosition={true} rootClose trigger='click' placement='auto' overlay={FilterPopover} flip={true}>
         <span className={`${styles.popoverTrigger} ${filterModified ? styles.modified : ''}`}>
           <FilterIcon className={styles.filterIcon} />
           <span>Filters</span>
         </span>
       </OverlayTrigger>
-      <OverlayTrigger shouldUpdatePosition={true} rootClose trigger='click' placement='auto' overlay={FilterDatePopover}>
+      <OverlayTrigger shouldUpdatePosition={true} rootClose trigger='click' placement='auto' overlay={FilterDatePopover} flip={true}>
         <span className={`${styles.popoverTrigger} ${dateRangeModified ? styles.modified : ''}`}>
           <ClockIcon className={styles.clockIcon} />
           <span>Dates</span>


### PR DESCRIPTION
This change prevents the Filter popup and Date popup from being cutoff, as described in https://vulcan.atlassian.net/browse/DAS-5083


![Screen Shot 2020-04-06 at 11 14 18 AM](https://user-images.githubusercontent.com/34458934/78595030-d1b4a500-7838-11ea-82c2-07fa96c6bf71.png)

This behavior does not seem to exist on all platforms, for example my MacBook Pro does not exhibit this behavior, but with this change to the OverlayTrigger components, it does render correctly on a 2011 Mac that does display this behavior.
