### PR TITLE
das-3739 - removed anchor option from mapboxgl popup

### DIFF
--- a/src/SubjectPopup/index.js
+++ b/src/SubjectPopup/index.js
@@ -28,7 +28,7 @@ const SubjectPopup = (props) => {
   }, [data]);
 
   return (
-    <Popup anchor='bottom' offset={[0, -16]} coordinates={geometry.coordinates} id={`subject-popup-${properties.id}`} {...rest}>
+    <Popup offset={[0, -16]} coordinates={geometry.coordinates} id={`subject-popup-${properties.id}`} {...rest}>
       <h4>{properties.name}</h4>
       {coordProps.time && <DateTime date={coordProps.time} />}
       {<GpsFormatToggle lng={geometry.coordinates[0]} lat={geometry.coordinates[1]} />}


### PR DESCRIPTION
Removed the anchor property from the SubjectPopup. Per the docs from mapbox:

`If unset the anchor will be dynamically set to ensure the popup falls within the map container with a preference for 'bottom' .` https://docs.mapbox.com/mapbox-gl-js/api/#popup

Expected behavior:
- Move a subject marker near the map border
- Click on the subject marker
- Popup should render the entire popup balloon within the map, ie there should be no clipping of the dialog.

![Screen Shot 2020-04-08 at 4 10 32 PM](https://user-images.githubusercontent.com/34458934/78841923-8246b400-79b3-11ea-9cbb-d7beb840cb24.png)

