### PR TITLE
das-4192 - no sidebar when user has no permissions

### DIFF
--- a/src/AddReport/index.js
+++ b/src/AddReport/index.js
@@ -92,7 +92,7 @@ const AddReport = (props) => {
     )}
   </ul>;
 
-  const reportTypeItems = hasEventCategories ? eventsByCategory.find(({ value: c }) => c === selectedCategory).types.map(createListItem) : '';
+  const reportTypeItems = hasEventCategories ? eventsByCategory.find(({ value: c }) => c === selectedCategory).types.map(createListItem) : null;
 
   const reportTypeList = <ul className={styles.reportTypeMenu}>
     {reportTypeItems}


### PR DESCRIPTION
This bugfix addresses an issue with the AddReport control, when no event categories are available to be processed. Specifically, this fix guards against two null conditions that assumes valid data.

To verify:
Create a user with no permissions. 
Log into the app
Observe the sidebar on the right side of the screen

Expected:
An empty sidebar, with usable controls

https://vulcan.atlassian.net/browse/DAS-4912