### PR TITLE
Override popover defaults for date and filter dialogs

### DIFF
--- a/src/EventFilter/index.js
+++ b/src/EventFilter/index.js
@@ -239,7 +239,7 @@ const EventFilter = (props) => {
     <Popover.Title>
       <div className={styles.popoverTitle}>
         <ClockIcon />Report Date Range
-        <Button type="button" variant='primary' size='sm'
+        <Button type="button" variant='light' size='sm'
           onClick={clearDateRange} disabled={!dateRangeModified}>Reset</Button>
       </div>
     </Popover.Title>
@@ -252,7 +252,7 @@ const EventFilter = (props) => {
     <Popover.Title>
       <div className={styles.popoverTitle}>
         Report Filters
-        <Button type="button" variant='primary' size='sm'
+        <Button type="button" variant='light' size='sm'
           onClick={resetPopoverFilters} disabled={!filterModified}>Reset all</Button>
       </div>
     </Popover.Title>

--- a/src/EventFilter/styles.module.scss
+++ b/src/EventFilter/styles.module.scss
@@ -54,7 +54,9 @@
     border-bottom-color: $popover-header-color;
   }
   [class*=popover-header] {
-    @include popoverTitle;
+    background: $highlight-color;
+    color: white;
+    padding: 1.0rem;
     &::before {
       display: none;
     }
@@ -155,9 +157,10 @@ div.filterPopover {
 
 .popoverTitle {
   --dimensions: 1.5rem;
+  background: $highlight-color;
   svg {
     height: var(--dimensions);
-    margin-right: 0.5rem;
+    margin-right: 1.0rem;
     width: var(--dimensions);
     * {
       stroke: white;


### PR DESCRIPTION
This PR styles the sidebar dialogs so that the headers of the popover are similiar in appearance. Note: The sidebar dialogs are wider than the timeslider pickers, and share styling. 

![Screen Shot 2020-04-24 at 10 25 59 AM](https://user-images.githubusercontent.com/34458934/80240025-12246900-8616-11ea-90dc-1063af9c6c21.png)
![Screen Shot 2020-04-24 at 10 25 40 AM](https://user-images.githubusercontent.com/34458934/80240029-13559600-8616-11ea-9779-e146a4436cab.png)
