### PR TITLE
Make sure the body can be scrolled in iPhoneSE/6/7/8

### DIFF
--- a/src/BetaWelcomeModal/index.js
+++ b/src/BetaWelcomeModal/index.js
@@ -31,7 +31,7 @@ const BetaWelcomeModal = (props) => {
       <Title>EarthRanger Beta Preview</Title>
     </Header>
     <Form onSubmit={onClose}>
-      <Body>
+      <Body style={{maxHeight: '60vh', overflowY: 'scroll'}}>
         <p>You have early access to the upcoming version of EarthRanger!</p>
         <p>Here&apos;s what we ask:</p>
         <ul className={styles.list}>


### PR DESCRIPTION
Constrain the body of the welcome dialog to be no more that 60% of the screen, and make sure the body is set to overflow.

Note - there were a couple of paths for this one, but this one seems to be the least intrusive (you can set the behavior of all Modals, by tweaking the global overlay style, but this one seemed to be the most effective for single instances, as styling Modal.Dialog and Content to be 100vh did not give the effect desired.