### PR TITLE
'disabling' choices when disabled in the admin

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-REACT_APP_DAS_HOST=https://dev.pamdas.org
+REACT_APP_DAS_HOST=https://develop.pamdas.org
 REACT_APP_GA_TRACKING_ID=UA-12413928-16

--- a/src/SchemaFields/index.js
+++ b/src/SchemaFields/index.js
@@ -17,7 +17,7 @@ const SelectField = (props) => {
 
   const getOptionLabel = ({ label, name }) => label || name;
   const getOptionValue = (val) => isPlainObject(val) ? val.value : val;
-  const isOptionDisabled = (option) => schema.inactive_table && schema.inactive_table.includes(option.label.toLowerCase());
+  const isOptionDisabled = (option) => schema.inactive_enum && schema.inactive_enum.includes(option.value.toLowerCase());
 
   const selected = enumOptions.find((item) => value ?
     item.value ===

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -175,8 +175,9 @@ export const DEFAULT_SELECT_STYLES = {
     return {
       ...styles,
       backgroundColor: isDisabled ? 'gray' : (isFocused ? '#006cd9' : 'white'),
-      color: isFocused ? 'white' : 'inherit',
+      color: (isFocused || isDisabled) ? 'white' : 'inherit',
       cursor: isDisabled ? 'not-allowed' : 'default',
+      opacity: isDisabled ? 0.5 : 1,
     };
   },
   menu(styles, state) {


### PR DESCRIPTION
This keys off the `inactive_enum` entries for individual schema fields to disable certain selectable options in forms.

![disabled-option-demo](https://user-images.githubusercontent.com/38018017/81093311-c5af1800-8eb6-11ea-939d-0e518d6c11f5.gif)
