### PR TITLE
hiding the mic activity section for inactive/non-radio type subjects

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-REACT_APP_DAS_HOST=https://dev.pamdas.org
+REACT_APP_DAS_HOST=https://develop.pamdas.org
 REACT_APP_GA_TRACKING_ID=UA-12413928-16

--- a/src/SubjectPopup/index.js
+++ b/src/SubjectPopup/index.js
@@ -24,7 +24,7 @@ const SubjectPopup = (props) => {
   const [radioWithRecentMicActivity, setIsRadioWithRecentMicActivity] = useState(subjectIsARadioWithRecentVoiceActivity(data));
 
   useEffect(() => {
-    setIsRadioWithRecentMicActivity(data);
+    setIsRadioWithRecentMicActivity(subjectIsARadioWithRecentVoiceActivity(data));
   }, [data]);
 
   return (


### PR DESCRIPTION
Fixes a typo/oversight which caused the 'mic activity' section to be shown for non-radio-type subjects in the subject popover.