### PR TITLE
intercept compass control events

### DIFF
--- a/src/Map/Map.scss
+++ b/src/Map/Map.scss
@@ -59,8 +59,3 @@
     display: none !important;
   }
 }
-
-.compass-wrapper {
-  background: transparent;
-  border: 0
-} 

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -441,7 +441,7 @@ class Map extends Component {
               {subjectHeatmapAvailable && <SubjectHeatmapLegend onClose={this.onSubjectHeatmapClose} />}
               {subjectTracksVisible && <TrackLegend onClose={this.onTrackLegendClose} />}
               {showReportHeatmap && <ReportsHeatmapLegend onClose={this.onCloseReportHeatmap} />}
-              <button className={'compass-wrapper'} onClick={this.onRotationControlClick}><RotationControl style={{position: 'relative', top: 'auto', width: '1.75rem', margin: '0.5rem'}} /></button>
+              <span className={'compass-wrapper'} onClick={this.onRotationControlClick}><RotationControl style={{position: 'relative', top: 'auto', width: '1.75rem', margin: '0.5rem'}} /></span>
             </div>
 
             {subjectHeatmapAvailable && <SubjectHeatLayer />}


### PR DESCRIPTION
In mapboxgl, it is possible to modify both pitch (ie tilt) and bearing via holding the control key down with mouse movements in x and y directions. In a recent triage, it was decided that we should reset both the bearing and pitch with the current compass control.

To do so, the existing control is wrapped in a button, which intercepts the onClick event, and forwards it to a function that resets both pitch and bearing

https://vulcan.atlassian.net/browse/DAS-5208