### PR TITLE
un-plumbing bad memoization, code cleanup

### DIFF
--- a/src/SubjectGroupList/SubjectListItem.js
+++ b/src/SubjectGroupList/SubjectListItem.js
@@ -1,15 +1,14 @@
 import React, { memo } from 'react';
 import SubjectControls from '../SubjectControls';
-import isEqual from 'react-fast-compare';
 
 import listStyles from '../SideBar/styles.module.scss';
 
-const SubjectListItem = memo((props) => { // eslint-disable-line react/display-name
+const SubjectListItem = (props) => { // eslint-disable-line react/display-name
   const { map, ...rest } = props;
   return <div>
     <span className={listStyles.itemTitle}>{props.name}</span>
     <SubjectControls className={listStyles.controls} map={map} showTitles={false} subject={rest} />
   </div>;
-}, (prevProps, currentProps) => isEqual(prevProps, currentProps));
+};
 
-export default SubjectListItem;
+export default memo(SubjectListItem);

--- a/src/SubjectGroupList/index.js
+++ b/src/SubjectGroupList/index.js
@@ -2,8 +2,6 @@ import React, { memo, useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import isEqual from 'react-fast-compare';
-
 import { hideSubjects, showSubjects } from '../ducks/map-ui';
 import { getUniqueSubjectGroupSubjects, filterSubjects } from '../utils/subjects';
 import { trackEvent } from '../utils/analytics';
@@ -89,11 +87,8 @@ const SubjectGroupList = (props) => {
 
 const mapStateToProps = ({ data: { subjectGroups, mapLayerFilter }, view: { hiddenSubjectIDs } }) =>
   ({ subjectGroups, mapLayerFilter, hiddenSubjectIDs });
-export default connect(mapStateToProps, { hideSubjects, showSubjects })(memo(SubjectGroupList, (prev, current) =>
-  isEqual(prev.mapLayerFilter, current.mapLayerFilter)
-   && isEqual(prev.subjectGroups.length, current.subjectGroups.length)
-   && isEqual(prev.hiddenSubjectIDs, current.hiddenSubjectIDs)
-));
+
+export default connect(mapStateToProps, { hideSubjects, showSubjects })(memo(SubjectGroupList));
 
 SubjectGroupList.defaultProps = {
   map: {},

--- a/src/SubjectsLayer/index.js
+++ b/src/SubjectsLayer/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Source } from 'react-mapbox-gl';
 import { featureCollection } from '@turf/helpers';
 
-import { calcUrlForImage, calcImgIdFromUrlForMapImages } from '../utils/img';
+import { calcImgIdFromUrlForMapImages } from '../utils/img';
 
 import { addFeatureCollectionImagesToMap } from '../utils/map';
 

--- a/src/utils/subjects.js
+++ b/src/utils/subjects.js
@@ -92,7 +92,7 @@ export const updateSubjectsInSubjectGroupsFromSocketStatusUpdate = (subjectGroup
           if (!cachedSubjectUpdate) {
             cachedSubjectUpdate = updateSubjectLastPositionFromSocketStatusUpdate(s, update);
           }
-          return cachedSubjectUpdate;
+          return { ...cachedSubjectUpdate };
         }
         return s;
       }),


### PR DESCRIPTION
Removing some old/naive memoization logic that was preventing subject position updates from flowing through to the `<SubjectGroupList>`, even though it was updated in state. And a bit of code cleaup along the way.