### PR TITLE
cleaner, more demystified track date+length trimming

### DIFF
--- a/src/selectors/tracks.js
+++ b/src/selectors/tracks.js
@@ -40,7 +40,7 @@ const trackTimeEnvelope = createSelector([trackLength, getTimeSliderState, getEv
         trackLengthStartDate = virtualDate ? subDays(virtualDate, trackLength.length) : trackLengthStartDate;
       }
 
-      const startDate = !!(trackLengthStartDate - new Date(lower)) ? trackLengthStartDate : new Date(lower);
+      const startDate = new Date(Math.max(trackLengthStartDate, new Date(lower)));
       return { from: startDate, until: virtualDate };
     }
 


### PR DESCRIPTION
This PR fixes a bug in which tracks beyond the lower boundary of the timeslider were being drawn to the map, rather than filtered out.

One of those rare moments where demystifying and simplifying the code also solves the issue at hand. Yeehaw.