### PR TITLE
feed logic changes to ensure reports which have been newly added to an incident are consolidated into those incidents when appropriate.

### DIFF
--- a/src/socket/index.js
+++ b/src/socket/index.js
@@ -53,7 +53,7 @@ export const pingSocket = (socket) => {
 };
 
 const bindSocketEvents = (socket, store) => {
-  let eventsBounds = false;
+  let eventsBound = false;
 
   socket.on('connect', () => {
     console.log('realtime: connected');
@@ -74,7 +74,7 @@ const bindSocketEvents = (socket, store) => {
     }
     pingSocket(socket);
 
-    if (!eventsBounds) {
+    if (!eventsBound) {
       Object.entries(events).forEach(([event_name, actionTypes]) => {
         return stateManagedSocketEventHandler(socket, event_name, (payload) => {
           actionTypes.forEach(type => store.dispatch({ type, payload }));
@@ -82,7 +82,7 @@ const bindSocketEvents = (socket, store) => {
       });
     }
 
-    eventsBounds = true;
+    eventsBound = true;
   });
 };
 


### PR DESCRIPTION
In other words:

1. If the feed is in a 'pristine' (unfiltered) state, `exclude_contained` is true. So if you change a report relationship, we need extra logic to filter those from the feed, as it's more efficient than making another round trip on the network to manually refresh that report's data.

This also fixes a non-functionally-affecting typo in the socket event binding.