### PR TITLE
Short term fix, set homeMap zoom level on map load

### DIFF
--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -355,9 +355,10 @@ class Map extends Component {
   }
 
   setMap(map) {
+    map.setZoom(this.props.homeMap.zoom);
     window.map = map;
     this.props.onMapLoad(map);
-    this.onMapMoveEnd();
+    this.onMapMoveEnd(); 
   }
 
   onSubjectHeatmapClose() {


### PR DESCRIPTION
This fix resets the zoom level on the current homeMap each time there is a setMap call. To verify, select a map from the nav bar, increase/decrease zoom, and then do a page reload. There will be a slight jumping effect, as the map loads at its default zoom level (~11) and then is moved to the zoom level set for that map. We'll need to determine if this is an effective fix for the time being.