### PR TITLE
Verify homeMap property is present when setting zoom

### DIFF
--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -355,7 +355,10 @@ class Map extends Component {
   }
 
   setMap(map) {
-    map.setZoom(this.props.homeMap.zoom);
+    // don't set zoom if not hydrated
+    if (this.props.homeMap && this.props.homeMap.zoom) {
+      map.setZoom(this.props.homeMap.zoom);
+    };   
     window.map = map;
     this.props.onMapLoad(map);
     this.onMapMoveEnd(); 


### PR DESCRIPTION
This fix addresses behavior that was created when resetting zoom, in ticket das-5251. This fix prevents a null value from being set if the redux property homeMap is not yet hydrated during a map re-render