### PR TITLE
[DAS-5334] - better computation of when a report state has changed, for kicking off form saves

### DIFF
--- a/src/ReportForm/StateButton.js
+++ b/src/ReportForm/StateButton.js
@@ -2,12 +2,11 @@ import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import Button from 'react-bootstrap/Button';
 
-const ACTIVE_STATES = ['active', 'new'];
-
+import {reportIsActive } from './';
 
 const StateButton = (props) => {
   const { state, isCollection, onStateToggle, ...rest } = props;
-  const isActive = ACTIVE_STATES.includes(state);
+  const isActive = reportIsActive(state);
 
   const onClick = () => {
     onStateToggle(isActive ? 'resolved' : 'active');

--- a/src/ReportForm/index.js
+++ b/src/ReportForm/index.js
@@ -29,6 +29,10 @@ import ImageModal from '../ImageModal';
 
 import styles from './styles.module.scss';
 
+const ACTIVE_STATES = ['active', 'new'];
+
+export const reportIsActive = (state) => ACTIVE_STATES.includes(state) || !state;
+
 const ReportForm = (props) => {
   const { map, report: originalReport, removeModal, onSaveSuccess, onSaveError, relationshipButtonDisabled,
     schema, uiSchema, addModal, createEvent, addEventToIncident, fetchEvent, setEventState } = props;
@@ -45,6 +49,8 @@ const ReportForm = (props) => {
   const [saving, setSavingState] = useState(false);
 
   const { is_collection } = report;
+
+  const isActive = reportIsActive(report.state);
 
   useEffect(() => {
     updateStateReport({
@@ -121,7 +127,7 @@ const ReportForm = (props) => {
     } else {
       startSave();
     }
-  }, [report.state]); // eslint-disable-line
+  }, [isActive]); // eslint-disable-line
 
   useEffect(() => {
     const onSubmit = () => {


### PR DESCRIPTION
**Bug root cause:** We have an effect hook that, after form initialization, watches for changes to the report's state and kicks off a save accordingly. However, new reports no longer have a `state` property, meaning the first time that report is saved the `state` prop is set by the server, so the updated report in the store would have a `state` change and the form would incorrectly think it's time to close.  This is a recent change (previously we set the `state` prop in a new report on the client, but that was removed as it's not what some end users expected). 

This shores up that behavior to only trigger a save when a _meaningful_ state change happens, lumping a lack of state prop together with our active category of states.