### PR TITLE
[DAS-5335]nulling an empty location value

### DIFF
--- a/src/ReportForm/index.js
+++ b/src/ReportForm/index.js
@@ -104,6 +104,10 @@ const ReportForm = (props) => {
       }
     }
 
+    if (toSubmit.hasOwnProperty('location') && !toSubmit.location) {
+      toSubmit.location = null;
+    }
+
     trackEvent(`${is_collection?'Incident':'Event'} Report`, `Click 'Save' button for ${reportIsNew?'new':'existing'} report`);
 
     const actions = generateSaveActionsForReport(toSubmit, notesToAdd, filesToUpload);


### PR DESCRIPTION
**Root cause** The API does not accept POST/PATCH/PUT requests for reports which include an empty string for the `location` property, but we occasionally attempt to send just that, getting 500 (soon to be 400) errors which influence

This is a guard rail to ensure that no longer happens.