### PR TITLE
gentle, controlled nudge of bootstrap version for better key event pr…

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mb-isochrone": "^0.1.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
-    "react-bootstrap": "1.0.0-beta.16",
+    "react-bootstrap": "1.0.0",
     "react-collapsible": "^2.6.2",
     "react-css-loaders": "^0.0.5",
     "react-datetime-picker": "^3.0.2",

--- a/src/AddReport/index.js
+++ b/src/AddReport/index.js
@@ -33,30 +33,28 @@ const AddReport = (props) => {
     trackEvent('Feed', 'Click \'Add Report\' button');
   }, [clickSideEffect, popoverOpen]);
 
+  const handleKeyDown = useCallback((event) => {
+    const { key } = event;
+    if (key === 'Escape' && popoverOpen) {
+      event.preventDefault();
+      event.stopPropagation();
+      setPopoverState(false);
+    }
+  }, [popoverOpen]);
+
   useEffect(() => {
     const handleOutsideClick = (e) => {
       if (containerRef.current && !containerRef.current.contains(e.target)) {
         setPopoverState(false);
       }
     };
-    const handleKeyDown = (event) => {
-      const { key } = event;
-      if (key === 'Escape') {
-        event.preventDefault();
-        event.stopPropagation();
-        setPopoverState(false);
-      }
-    };
     if (popoverOpen) {
       document.addEventListener('mousedown', handleOutsideClick);
-      document.addEventListener('keydown', handleKeyDown);
     } else {
       document.removeEventListener('mousedown', handleOutsideClick);
-      document.removeEventListener('keydown', handleKeyDown);
     }
     return () => {
       document.removeEventListener('mousedown', handleOutsideClick);
-      document.removeEventListener('keydown', handleKeyDown);
     };
   }, [popoverOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -121,7 +119,7 @@ const AddReport = (props) => {
   </Popover>
   );
 
-  return <div ref={containerRef}>
+  return <div ref={containerRef} tabIndex={0} onKeyDown={handleKeyDown}>
     <button title={title} className={styles.addReport} ref={targetRef}
       type='button' onClick={onButtonClick}>
       {showIcon && <AddButtonIcon />}

--- a/src/AddReport/styles.module.scss
+++ b/src/AddReport/styles.module.scss
@@ -9,8 +9,10 @@
   display: flex;
   flex-flow: column;
   font-size: 0.8rem;
+  height: 100%;
   justify-content: center;
   position: relative;
+  width: 100%;
   @media (min-width: $md-layout-width-min) {
     font-size: 1rem;
   }

--- a/src/App.scss
+++ b/src/App.scss
@@ -304,7 +304,7 @@ aside {
   [class*=addReportContainer] {
     .bs-popover-left {
       margin-left: -0.5rem;
-      margin-top: 2.5rem;
+      margin-top: -1.25rem;
     }
   }
 


### PR DESCRIPTION
…opagation within modals/popovers etc. style tweaks to support slight layout changes from newer bootstrap wrapper version.

This resolves our regression with the escape key handler for popovers within the report form modal, and also doesn't lock the app on "add report" click as does 1.0.1. Everybody wins.