### PR TITLE
[DAS-5448] undoing Suspense+lazy client code loading for immediate white screen fix

### DIFF
--- a/src/EulaProtectedRoute/index.js
+++ b/src/EulaProtectedRoute/index.js
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, memo, useEffect, useState } from 'react';
+import React, { Fragment, memo, useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { Redirect, withRouter } from 'react-router-dom';
 
@@ -6,9 +6,11 @@ import { REACT_APP_ROUTE_PREFIX } from '../constants';
 import { fetchCurrentUser } from '../ducks/user';
 import { fetchSystemStatus } from '../ducks/system-status';
 
-import LoadingOverlay from '../EarthRangerIconLoadingOverlay';
+/* ADD BACK AFTER LAZY LOADING MISSING CHUNK ERROR IS RESOLVED */
+// import LoadingOverlay from '../EarthRangerIconLoadingOverlay';
+// const PrivateRoute = lazy(() => import('../PrivateRoute'));
 
-const PrivateRoute = lazy(() => import('../PrivateRoute'));
+import PrivateRoute from '../PrivateRoute';
 
 const EulaProtectedRoute = (props) => {
   const { dispatch:_dispatch, fetchCurrentUser, fetchSystemStatus, user, eulaEnabled, ...rest } = props;
@@ -34,13 +36,13 @@ const EulaProtectedRoute = (props) => {
     }
   }, [user, eulaEnabled]);
 
-  return <Suspense fallback={<LoadingOverlay message='Loading...' />}>
+  return <Fragment>
     {!eulaAccepted && <Redirect to={{
       pathname: `${REACT_APP_ROUTE_PREFIX}eula`,
       search: this.props.location.search,
     }} />}
     {eulaAccepted === 'unknown' ? null : <PrivateRoute {...rest} />}
-  </Suspense>;
+  </Fragment>;
 };
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import ReactGA from 'react-ga';
 import { Provider } from 'react-redux';
@@ -27,14 +27,15 @@ import './index.scss';
 import withTracker from './WithTracker';
 
 import DetectOffline from './DetectOffline';
-import LoadingOverlay from './EarthRangerIconLoadingOverlay';
 import RequestConfigManager from './RequestConfigManager';
 
-const App = lazy(() => import('./App'));
-const Login = lazy(() => import('./Login'));
-const EulaPage = lazy(() => import('./views/EULA'));
-const PrivateRoute = lazy(() => import('./PrivateRoute'));
-const EulaProtectedRoute = lazy(() => import('./EulaProtectedRoute'));
+/* LAZY LOAD THESE WITH React.Suspense and React.lazy once the server is config'd to keep old deployment chunks */
+// import LoadingOverlay from './EarthRangerIconLoadingOverlay';
+import App from './App';
+import Login from './Login';
+import EulaPage from './views/EULA';
+import PrivateRoute from './PrivateRoute';
+import EulaProtectedRoute from './EulaProtectedRoute';
 
 // registering icons from fontawesome as needed
 library.add(faPlus, faTimes, faArrowUp, faArrowDown);
@@ -51,37 +52,35 @@ ReactDOM.render(
   <Provider store={store}>
     <PersistGate loading={null} persistor={persistor} >
       <BrowserRouter>
-        <Suspense fallback={<LoadingOverlay message='Loading...' />}>
-          <Switch>
-            <EulaProtectedRoute exact path={REACT_APP_ROUTE_PREFIX} component={withTracker(App)} />
-            <Route path={`${REACT_APP_ROUTE_PREFIX}login`} component={withTracker(Login)} />
-            <PrivateRoute exact path={`${REACT_APP_ROUTE_PREFIX}eula`} component={withTracker(EulaPage)} />
-            <Route component={(props) => {
-              const externalRedirectRef = useRef(null);
+        <Switch>
+          <EulaProtectedRoute exact path={REACT_APP_ROUTE_PREFIX} component={withTracker(App)} />
+          <Route path={`${REACT_APP_ROUTE_PREFIX}login`} component={withTracker(Login)} />
+          <PrivateRoute exact path={`${REACT_APP_ROUTE_PREFIX}eula`} component={withTracker(EulaPage)} />
+          <Route component={(props) => {
+            const externalRedirectRef = useRef(null);
 
-              useEffect(() => {
-                !!externalRedirectRef.current && externalRedirectRef.current.click();
-              });
+            useEffect(() => {
+              !!externalRedirectRef.current && externalRedirectRef.current.click();
+            });
 
-              const GoToHomepage = () => <Redirect
-                to={REACT_APP_ROUTE_PREFIX}
-              />;
+            const GoToHomepage = () => <Redirect
+              to={REACT_APP_ROUTE_PREFIX}
+            />;
 
-              if (process.env.NODE_ENV !== 'production') {
-                return <GoToHomepage />;
-              } 
+            if (process.env.NODE_ENV !== 'production') {
+              return <GoToHomepage />;
+            } 
 
-              const localMatch = EXTERNAL_SAME_DOMAIN_ROUTES.find(item => item === props.location.pathname);
-              if (!localMatch) {
-                return <GoToHomepage />;
-              }
+            const localMatch = EXTERNAL_SAME_DOMAIN_ROUTES.find(item => item === props.location.pathname);
+            if (!localMatch) {
+              return <GoToHomepage />;
+            }
 
 
-              return <a href={localMatch} style={{opacity: 0}} target='_self' ref={externalRedirectRef}>{localMatch}</a>;
-            }} />
+            return <a href={localMatch} style={{opacity: 0}} target='_self' ref={externalRedirectRef}>{localMatch}</a>;
+          }} />
 
-          </Switch>
-        </Suspense>
+        </Switch>
         <RequestConfigManager />
       </BrowserRouter>
       <ToastContainer />


### PR DESCRIPTION
**Root cause analysis** The client has been using lazy loading as a tool for code splitting; any component imported via `React.lazy` is only loaded when needed, meaning the initial code bundle needed to bootstrap the application is smaller, loads faster, etc, and those lazy-loaded components are downloaded as separate file chunks.

The chunks of code generated by this code splitting have file names which are unique to each deployment (all client resources have unique-per-deployment names).  If a new deployment goes out, but an end user's initial page is served from cache (via browser cache, service worker, etc), it means the client is running old code, which will ask for now-non-existent-on-the-server chunks when attempting to lazy load a component. This results in 400/bad request errors from the server, and a white screen of death from the browser.

As a stopgap fix, this PR removes lazy loading as a means of code splitting. @chrisjvulcan will look into keeping deployment artifacts around on the server so that, in the near future, we can add lazy loading back in for its end user benefits without accidentally knocking things over.