### PR TITLE
Displaying 'invalid credentials' error messaging on the login page

### DIFF
--- a/src/Login/index.js
+++ b/src/Login/index.js
@@ -54,14 +54,12 @@ class LoginPage extends Component {
         });
       })
       .catch((error) => {
-        let errorObject = JSON.parse(JSON.stringify(error));
+        let errorObject = error.toJSON();
         this.props.clearAuth();
 
         const errorMessage = errorObject
-          && errorObject.response
-          && errorObject.response.data 
-          && ((errorObject.response.status >= 400 && errorObject.response.status <= 499) || errorObject.response.data.error) === 'invalid_grant' 
-          ? 'Invalid credentials given. Please try again.' 
+          && errorObject.message
+          && errorObject.message.includes('400') ? 'Invalid credentials given. Please try again.' 
           : 'An error has occured. Please try again.';
 
         !this.isCancelled && this.setState({

--- a/src/RequestConfigManager/index.js
+++ b/src/RequestConfigManager/index.js
@@ -62,9 +62,9 @@ const RequestConfigManager = (props) => {
             pathname: `${REACT_APP_ROUTE_PREFIX}login`,
             search: location.search,
           });
-          return Promise.reject(error);
         });
       }
+      return Promise.reject(error);
     }];
 
     if (onAuthFailure.current) {


### PR DESCRIPTION
Root cause analysis:

1. We had an error interceptor configured within axios which was only returning a rejected promise for 401s, meaning we accidentally swallowed all other errors. This made other network errors handled via "happy path" handlers for request promises.
2. The means of reading the status code within the error response was outdated as per an older version of axios.