### PR TITLE
reducing date comparison granularity …

### DIFF
--- a/src/DateTimePickerPopover/index.js
+++ b/src/DateTimePickerPopover/index.js
@@ -2,13 +2,14 @@ import React, { forwardRef, memo, useCallback, useEffect, useRef, useState, useM
 import format from 'date-fns/format';
 import debounce from 'lodash/debounce';
 import InputMask from 'react-input-mask';
-import setSeconds from 'date-fns/set_seconds';
 import Popover from 'react-bootstrap/Popover';
 import Overlay from 'react-bootstrap/Overlay';
+import setSeconds from 'date-fns/set_seconds';
+
 import DateTimePicker from '../DateTimePicker';
 import { ReactComponent as ClearIcon } from '../common/images/icons/close-icon.svg';
 
-import { dateIsValid } from '../utils/datetime';
+import { dateIsValid, timeValuesAreEqualToTheMinute } from '../utils/datetime';
 import { DATEPICKER_DEFAULT_CONFIG } from '../constants';
 import styles from './styles.module.scss';
 
@@ -90,11 +91,9 @@ const DateTimePickerPopover = (props, ref) => {
 
   useEffect(() => {
     if (value && dateIsValid(value)) {
-      const potentialVal = setSeconds(new Date(value), 0);
-
-      if (potentialVal.getTime() !== new Date(inputValue).getTime()) {
+      if (!timeValuesAreEqualToTheMinute(value, inputValue)) {
         setInputValue(
-          format(potentialVal, DATEPICKER_DEFAULT_CONFIG.format) 
+          format(value, DATEPICKER_DEFAULT_CONFIG.format) 
         );
       }
     } else {
@@ -106,7 +105,7 @@ const DateTimePickerPopover = (props, ref) => {
 
   useEffect(() => {
     const handleChange = (newDate) => {
-      if (new Date(newDate).getTime() !== new Date(value).getTime()) {
+      if (!timeValuesAreEqualToTheMinute(newDate, value)) {
         !!onChange && onChange(newDate);
       }
     };

--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -5,6 +5,8 @@ import subWeeks from 'date-fns/sub_weeks';
 import subDays from 'date-fns/sub_days';
 import startOfDay from 'date-fns/start_of_day';
 import format from 'date-fns/format';
+import setSeconds from 'date-fns/set_seconds';
+import setMilliseconds from 'date-fns/set_milliseconds';
 
 export const DEFAULT_FRIENDLY_DATE_FORMAT = 'Mo MMM YYYY';
 
@@ -48,3 +50,13 @@ export const generateMonthsAgoDate = (monthsAgo = 1) => new Date(
 export const formatEventSymbolDate = (dateString) => format(new Date(dateString), EVENT_SYMBOL_DATE_FORMAT);
 
 export const generateCurrentTimeZoneTitle = () => `Date displayed in the ${window.Intl.DateTimeFormat().resolvedOptions().timeZone} time zone`;
+
+export const timeValuesAreEqualToTheMinute = (val1, val2) => {
+  const flattenDate = date => setSeconds(
+    setMilliseconds(
+      new Date(date),
+      0),
+    0);
+  
+  return flattenDate(val1).getTime() === flattenDate(val2).getTime();
+};


### PR DESCRIPTION
so seconds/milliseconds aren't shaved off reports of an automatic provenance, such as an analyzer.  This is the sneaky root cause of [DAS-5616](https://vulcan.atlassian.net/browse/DAS-5616).