### PR TITLE
DAS-5547 - proper post-EULA redirection

### DIFF
--- a/src/views/EULA/index.js
+++ b/src/views/EULA/index.js
@@ -74,7 +74,7 @@ const EulaPage = (props) => {
 
   useEffect(() => {
     if (user.accepted_eula) return history.goBack();
-  }, [history, user.accepted_eula]);
+  }, []); /* eslint-disable-line react-hooks/exhaustive-deps */
 
   const onSubmit = useCallback((event, ...rest) => {
     event.preventDefault();


### PR DESCRIPTION
This PR Cleans up overeager effect hook in the EULA view which was firing as soon as the EULA was accepted -- thus redirecting to login