### PR TITLE
indexing vs numeric values vs object/array enumNames cases

### DIFF
--- a/src/SchemaFields/index.js
+++ b/src/SchemaFields/index.js
@@ -44,8 +44,13 @@ const SelectField = (props) => {
   const getOptionLabel = (option) => {
     const { label, name } = option;
     const value = getOptionValue(option);
-    if (label === value && schema.enumNames && schema.enumNames[value]) {
-      return schema.enumNames[value];
+    if (label === value && schema.enumNames) {
+      if (
+        (Array.isArray(schema.enumNames) && schema.enumNames.includes(value))
+        || (schema.enumNames[value])
+      ) {
+        return value;
+      }
     }
     return (label || name);
   };
@@ -227,10 +232,10 @@ const CustomCheckboxes = (props) => {
         })
         .map((option, index) => {
         
-        const disabledCls =
+          const disabledCls =
           (disabled || readonly) ? 'disabled' : '';
-        const inputId = `${id}_${instanceId}_${index}`;
-        const checkbox =  <span>
+          const inputId = `${id}_${instanceId}_${index}`;
+          const checkbox =  <span>
             <input
               type='checkbox'
               id={inputId}
@@ -246,17 +251,17 @@ const CustomCheckboxes = (props) => {
               }}
             />
             <span>{option.label}</span>
-          </span>
-        return inline ? (
-          <label htmlFor={inputId} key={index} className={`checkbox-inline ${disabledCls}`}>
-            {checkbox}
-          </label>
-        ) : (
-          <div key={index} className={`checkbox ${disabledCls}`}>
-            <label htmlFor={inputId}>{checkbox}</label>
-          </div>
-        );
-      })}
+          </span>;
+          return inline ? (
+            <label htmlFor={inputId} key={index} className={`checkbox-inline ${disabledCls}`}>
+              {checkbox}
+            </label>
+          ) : (
+            <div key={index} className={`checkbox ${disabledCls}`}>
+              <label htmlFor={inputId}>{checkbox}</label>
+            </div>
+          );
+        })}
     </div>
   );
 };


### PR DESCRIPTION
The label generation logic for dropdown selects didn't seem to gel well with enumNames varying between objects and arrays -- combined with a `value` prop that can be numeric and you get weird indexing issues.

**Regular case:**
```
const value = 'hello';
const enumNames = {
  hello: 'My Display Name'
};

const label = enumNames[value]; //becomes 'My Display Name'
```


**Error case:**
```
const value = 1;
const enumNames = [1, 2, 2.4, 4];

const label = enumNames[value]; // becomes '2', because it's at the 1 index of the enumNames array
```

The solution:
A guard clause to check both arrays and objects for enumNames.
