### PR TITLE
case insensitive sort of popover list

### DIFF
--- a/src/LayerSelectorPopup/index.js
+++ b/src/LayerSelectorPopup/index.js
@@ -20,10 +20,8 @@ const LayerSelectorPopup = ({ id, data, hidePopup, mapImages }) => {
 
   const layers = useMemo(() => {
     const sortedLayerList = layerList.sort((a, b) => {
-      const first = a.properties.name ? a.properties.name.toLowerCase() : 
-        a.properties.display_title ? a.properties.display_title.toLowerCase() : '';
-      const second = b.properties.name ? b.properties.name.toLowerCase() : 
-        b.properties.display_title ? b.properties.display_title.toLowerCase() : '';
+      const first = (a.properties.display_title || a.properties.name || '').toLowerCase();
+      const second = (b.properties.display_title || b.properties.name || '').toLowerCase();
       return first > second ? 1 : first < second ? -1 : 0;
     });
     if (!filter) return sortedLayerList;


### PR DESCRIPTION
This PR adds a case insensitive sort of the layers just before the popup is shown, to minimize the number of times the sort is calculated. See [this bug for more info](https://vulcan.atlassian.net/secure/RapidBoard.jspa?rapidView=5&projectKey=DAS&modal=detail&selectedIssue=DAS-5618)

Known issues:
- Because it is case insensitive, both upper and lowered cased names are co-mingled in a sort