### PR TITLE
DAS-5586 Change icon placement to be centered on the location, rather than the…

### DIFF
--- a/src/FeatureLayer/index.js
+++ b/src/FeatureLayer/index.js
@@ -68,7 +68,7 @@ const symbolLayout = {
     'marker-icon',
   ],
   'text-size': 0,
-  'icon-anchor': 'bottom',
+  'icon-anchor': 'center',
 };
 
 const symbolPaint = {


### PR DESCRIPTION
This PR changes the symbol style to center icons around the geolocation, rather than aligning the icon bottom to the geolocation.