### PR TITLE
Add metric for clicked track points

### DIFF
--- a/src/TracksLayer/index.js
+++ b/src/TracksLayer/index.js
@@ -8,6 +8,7 @@ import { trimmedVisibleTrackData } from '../selectors/tracks';
 import Arrow from '../common/images/icons/track-arrow.svg';
 
 import TrackLayer from './track';
+import { trackEvent } from '../utils/analytics';
 
 const ARROW_IMG_ID = 'track_arrow';
 
@@ -19,6 +20,7 @@ const TracksLayer = (props) => {
 
   const onTimepointClick = useCallback((e) => {
     const layer = getPointLayer(e, map);
+    trackEvent('Map Layers', 'Clicked Track Timepoint');
     onPointClick(layer);
   }, [map, onPointClick]);
 


### PR DESCRIPTION
This PR adds a GA event for when track timepoints are clicked, and emits a GA event,  with a category type of 'Map Layers', and an action type of 'Clicked Track Timepoint' 

Expected behavior of this PR:
- using the GA debugger for chrome, enable it for the site you are testing
- in the map, select a subject that has tracks associated with it (a yellow line with blue chevrons will appear)
- in the now displayed track, click on one of the track timepoints, which appear as blue chevrons within the track
- verify in the GA debugger, you see an event with the types described above