### PR TITLE
fixing race condition bug b/w system status and patrol queries

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -106,23 +106,25 @@ const App = (props) => {
       .catch((e) => {
         // 
       });
-    if (evaluateFeatureFlag(FEATURE_FLAGS.PATROL_MANAGEMENT)) {
-      fetchPatrolTypes()
-        .catch((e) => {
-          // 
-        });
-      const currentPatrolQuery = currentPatrolDateQuery();
-      fetchPatrols(currentPatrolQuery)
-      //fetchPatrols()
-        .catch((e) => {
-        //
-        });
-    }
     fetchAnalyzers()
       .catch((e) => {
         // 
       });
     fetchSystemStatus()
+      .then(({ patrol_enabled }) => {
+        if (patrol_enabled) {
+          fetchPatrolTypes()
+            .catch((e) => {
+              // 
+            });
+          const currentPatrolQuery = currentPatrolDateQuery();
+          fetchPatrols(currentPatrolQuery)
+          //fetchPatrols()
+            .catch((e) => {
+              //
+            });
+        }
+      })
       .catch((e) => {
         /* toast('Error fetching system status. Please refresh and try again.', {
           type: toast.TYPE.ERROR,

--- a/src/ducks/system-status.js
+++ b/src/ducks/system-status.js
@@ -45,6 +45,7 @@ export const fetchSystemStatus = () => (dispatch) => axios.get(STATUS_API_URL, {
     dispatch(setZendeskConfigStatus(response));
     dispatch(setSystemConfig(response));
     dispatch(fetchSystemStatusSuccess(response));
+    return response.data.data;
   })
   .catch(error => {
     dispatch(fetchSystemStatusError(error));


### PR DESCRIPTION
**Root Cause Analysis**
The system status API query determines whether or not patrols are enabled for a site, which in turn determines whether or not to fetch patrol data. 

However, in some cases, the system status API query had not yet returned a response by the time the app evaluated if it should fetch patrols. It defaults to `false`, and as such patrol and patrol type data was not being fetched.
