### PR TITLE
self-managed interval-based state updates within patrol cards

### DIFF
--- a/src/PatrolList/index.js
+++ b/src/PatrolList/index.js
@@ -13,7 +13,7 @@ import styles from './styles.module.scss';
 import PatrolCard from '../PatrolCard';
 
 const PatrolListItem = forwardRef((props, ref) => { /* eslint-disable-line react/display-name */
-  const { map, patrol, updatePatrol, ...rest } = props;
+  const { map, onStateUpdateFromCard, patrol, updatePatrol, ...rest } = props;
 
   const onTitleClick = useCallback(() => {
     openModalForPatrol(patrol, map);
@@ -31,6 +31,7 @@ const PatrolListItem = forwardRef((props, ref) => { /* eslint-disable-line react
       ref={ref}
       onTitleClick={onTitleClick}
       onPatrolChange={onPatrolChange}
+      onSelfManagedStateChange={onStateUpdateFromCard}
       patrol={patrol}
       map={map}
       {...rest} />
@@ -44,6 +45,10 @@ const PatrolList = (props) => {
   // const scrollRef = useRef(null);
 
   const [listItems, setListItems] = useState(patrols);
+
+  const onStateUpdateFromCard = useCallback(() => {
+    setListItems(sortPatrolCards(patrols));
+  }, [patrols]);
 
   useEffect(() => {
     setListItems(sortPatrolCards(patrols));
@@ -60,6 +65,7 @@ const PatrolList = (props) => {
       {listItems.map((item, index) =>
         <ConnectedListItem
           patrol={item}
+          onStateUpdateFromCard={onStateUpdateFromCard}
           map={map}
           key={item.id}/>
       )}


### PR DESCRIPTION
**RCA** - Certain aspects of patrol state were only calculated when their data structure received an update -- meaning temporal-based state changes flew under the radar. 

This adds interval polling to the individual cards, triggers state+render updates when necessary, and provides a callback for enacting side effects in the parent <PatrolList> (namely, to re-sort based on internal state changes). 


🤠  yeehaw 🤠  