### PR TITLE
fixing parentheses typo which was flunking action type eval

### DIFF
--- a/src/ducks/patrols.js
+++ b/src/ducks/patrols.js
@@ -277,7 +277,9 @@ export const patrolStoreReducer = (state = INITIAL_STORE_STATE, { type, payload 
   }
 
 
-  if (type === (UPDATE_PATROL_SUCCESS || UPDATE_PATROL_REALTIME || CREATE_PATROL_REALTIME)) {
+  if (type === UPDATE_PATROL_SUCCESS 
+    || type === UPDATE_PATROL_REALTIME
+    || type ===CREATE_PATROL_REALTIME) {
     return {
       ...state,
       [payload.id]: {


### PR DESCRIPTION
Scooped this up during sprint planning because I noticed a typo making this not work. 