### PR TITLE
using only actual start/end figures for display duration

### DIFF
--- a/src/utils/patrols.js
+++ b/src/utils/patrols.js
@@ -68,6 +68,7 @@ export const generatePseudoReportCategoryForPatrolTypes = (patrolTypes) => {
   };
 };
 
+
 export const createNewPatrolForPatrolType = ({ value: patrol_type, icon_id, default_priority: priority = 0 }, data) => {
   const location = data && data.location;
   const reportedById = data && data.reportedById;
@@ -149,6 +150,17 @@ export const displayStartTimeForPatrol = (patrol) => {
     : null;
 };
 
+const actualStartTimeForPatrol = (patrol) => {
+  if (!patrol.patrol_segments.length) return null;
+  const [firstLeg] = patrol.patrol_segments;
+
+  const { time_range: { start_time } } = firstLeg;
+
+  return start_time
+    ? new Date(start_time)
+    : null;
+};
+
 export const getReportsForPatrol = (patrol) => {
   if (!patrol.patrol_segments.length) return null;
   // this is only grabbibng the first segment for now
@@ -164,6 +176,19 @@ export const displayEndTimeForPatrol = (patrol) => {
   const { scheduled_end, time_range: { end_time } } = firstLeg;
 
   const value = end_time || scheduled_end;
+
+  return value
+    ? new Date(value)
+    : null;
+};
+
+const actualEndTimeForPatrol = (patrol) => {
+  if (!patrol.patrol_segments.length) return null;
+  const [firstLeg] = patrol.patrol_segments;
+
+  const { time_range: { end_time } } = firstLeg;
+
+  const value = end_time;
 
   return value
     ? new Date(value)
@@ -242,8 +267,8 @@ export const displayDurationForPatrol = (patrol) => {
   const now = new Date();
   const nowTime = now.getTime();
 
-  const displayStartTime = displayStartTimeForPatrol(patrol);
-  const displayEndTime = displayEndTimeForPatrol(patrol);
+  const displayStartTime = actualStartTimeForPatrol(patrol);
+  const displayEndTime = actualEndTimeForPatrol(patrol);
 
   const hasStarted = !!displayStartTime
     && (displayStartTime.getTime() < nowTime);

--- a/src/utils/subjects.js
+++ b/src/utils/subjects.js
@@ -8,7 +8,7 @@ import { getActivePatrolsForLeaderId } from './patrols';
 const STATIONARY_RADIO_SUBTYPES = ['stationary-radio'];
 const MOBILE_RADIO_SUBTYPES = ['ranger'];
 const RADIO_SUBTYPES = [...STATIONARY_RADIO_SUBTYPES, ...MOBILE_RADIO_SUBTYPES];
-const RECENT_RADIO_DECAY_THRESHOLD = (30 * 60); // 30 minutes
+export const RECENT_RADIO_DECAY_THRESHOLD = (30 * 60); // 30 minutes
 
 export const subjectIsARadio = subject => RADIO_SUBTYPES.includes(subject.subject_subtype);
 export const subjectIsAFixedPositionRadio = subject => STATIONARY_RADIO_SUBTYPES.includes(subject.subject_subtype);
@@ -35,14 +35,16 @@ const calcElapsedTimeSinceSubjectRadioActivity = (subject) => {
   return -1;
 };
 
+export const radioHasRecentActivity = (radio) => {
+  const elapsedSeconds = calcElapsedTimeSinceSubjectRadioActivity(radio);
+
+  return (elapsedSeconds >= 0) && (elapsedSeconds < RECENT_RADIO_DECAY_THRESHOLD);
+};
+
 export const calcRecentRadiosFromSubjects = (...subjects) => {
   const recentRadios = subjects
     .filter(subjectIsARadio)
-    .filter((subject) => {
-      const elapsedSeconds = calcElapsedTimeSinceSubjectRadioActivity(subject);
-
-      return (elapsedSeconds >= 0) && (elapsedSeconds < RECENT_RADIO_DECAY_THRESHOLD);
-    })
+    .filter(radioHasRecentActivity)
     .sort((a, b) => calcElapsedTimeSinceSubjectRadioActivity(a) - calcElapsedTimeSinceSubjectRadioActivity(b));
 
   return recentRadios;


### PR DESCRIPTION
>The code for calculating a patrol's display duration was erroneously including scheduled times – so if a patrol was scheduled to end, but had not been ended, the duration length would still be measured with the scheduled end time as a parameter. This leads to confusing states, in which a patrol that ran several days ago and is overdue to end had a display duration of "one hour" while having actually been active for a number of days.

https://vulcan.atlassian.net/browse/DAS-6224