### PR TITLE
smarter start time/location inheritance and updates for creating a new patrol

### DIFF
--- a/src/DateTimePickerPopover/index.js
+++ b/src/DateTimePickerPopover/index.js
@@ -20,7 +20,7 @@ const DEFAULT_PLACEMENT = 'bottom';
 const BLANK_VALUE = '____-__-__ __:__';
 
 const DateTimePickerPopover = (props, ref) => {
-  const { className = '', popperConfig = {}, inputClassName = '', placeholder = '', onPopoverToggle, minDate, maxDate, onChange, required, value, placement, showClockIcon = false } = props;
+  const { className = '', popperConfig = {}, inputClassName = '', placeholder = '', onPopoverToggle, onPopoverClosed, onPopoverOpened, minDate, maxDate, onChange, required, value, placement, showClockIcon = false } = props;
   const popoverStateIsControlled = props.hasOwnProperty('popoverOpen');
 
   const [popoverOpen, setPopoverState] = useState(popoverStateIsControlled ? props.popoverOpen : false);
@@ -73,15 +73,16 @@ const DateTimePickerPopover = (props, ref) => {
     } else {
       popoverStateIsControlled ? onPopoverToggle(false) : setPopoverState(false);
     }
+    onPopoverClosed && onPopoverClosed();
     props.onHide && props.onHide();
-  }, [props, popoverStateIsControlled, onPopoverToggle]);
+  }, [onPopoverClosed, props, popoverStateIsControlled, onPopoverToggle]);
 
   const handleKeyDown = useCallback((event) => {
     const { key } = event;
     const closingKeys = ['Escape', 'Enter'];
 
     if (key === 'Enter') {
-      props.onEnter && props.onEnter();
+      props.onEnterKeyPress && props.onEnterKeyPress();
     }
 
     if (closingKeys.includes(key) && popoverOpen) {
@@ -173,7 +174,7 @@ const DateTimePickerPopover = (props, ref) => {
     {showClockIcon && <ClockIcon className={styles.clockIcon} />}
     <InputMask type='text' value={inputValue} mask="9999-99-99 99:99" placeholder={placeholder || BLANK_VALUE} onClick={onInputClick} onChange={onInputChange} onBlur={onInputBlur} ref={buttonRef} className={`${styles.input} ${!isValid ? styles.invalid : ''} ${inputClassName}`} />
     {canShowClearButton && <ClearIcon onClick={onClickClearIcon} className={styles.clearIcon} />}
-    <Overlay popperConfig={popperConfig} show={popoverOpen} placement={placement || DEFAULT_PLACEMENT} {...optionalProps} rootClose onHide={hidePopover} target={buttonRef.current} container={containerRef.current}>
+    <Overlay popperConfig={popperConfig} show={popoverOpen} placement={placement || DEFAULT_PLACEMENT} {...optionalProps} rootClose onHide={hidePopover} onEnter={onPopoverOpened} target={buttonRef.current} container={containerRef.current}>
       <DateTimePopover {...props}  />
     </Overlay>
   </div>;

--- a/src/PatrolModal/DateInput.js
+++ b/src/PatrolModal/DateInput.js
@@ -11,11 +11,12 @@ import { DATEPICKER_DEFAULT_CONFIG } from '../constants';
 import styles from './styles.module.scss';
 
 const PatrolDateInput = (props) => {
-  const { autoCheckLabel = 'Automatic', onAutoCheckToggle, calcSubmitButtonTitle, children,
+  const { autoCheckLabel = 'Automatic', defaultValue, onAutoCheckToggle, calcSubmitButtonTitle, children,
     isAuto = false, title, value, onChange, className, ...rest } = props;
 
   const [stateTime, setStateTime] = useState(value);
   const [tempPopoverProps, setTempPopoverProps] = useState({});
+
 
   const onHide = useCallback(() => {
     setStateTime(value);
@@ -71,13 +72,27 @@ const PatrolDateInput = (props) => {
     setStateTime(value);
   }, [value]);
 
+  const onPopoverOpened = useCallback(() => {
+    if (!value && !!defaultValue) {
+      setStateTime(defaultValue);
+    }
+  }, [defaultValue, value]);
+
+  const onPopoverClosed = useCallback(() => {
+    if (!value) {
+      setStateTime(value);
+    }
+  }, [value]);
+
   return <DateTimePickerPopover
     {...DATEPICKER_DEFAULT_CONFIG}
     value={stateTime} 
     className={timeClassName} 
     {...tempPopoverProps} 
     onHide={onHide} 
-    onEnter={commitTimeChange}
+    onEnterKeyPress={commitTimeChange}
+    onPopoverClosed={onPopoverClosed}
+    onPopoverOpened={onPopoverOpened}
     onChange={onTimeChange}
     {...rest}
   >  

--- a/src/PatrolModal/index.js
+++ b/src/PatrolModal/index.js
@@ -285,7 +285,7 @@ const PatrolModal = (props) => {
 
         update.patrol_segments[0].start_location = null;
         update.patrol_segments[0].time_range = {
-          start_time: null,
+          start_time: new Date().toISOString(),
         };
       }
     }
@@ -559,7 +559,7 @@ const PatrolModal = (props) => {
         <div>
           <h6>Start</h6>
           <PatrolDateInput
-            value={displayStartTime} 
+            value={displayStartTime}
             calcSubmitButtonTitle={startTimeCommitButtonTitle}
             onChange={onStartTimeChange}
             maxDate={displayEndTime || null}
@@ -606,6 +606,7 @@ const PatrolModal = (props) => {
           <h6>End</h6>
           <PatrolDateInput
             value={displayEndTime} 
+            defaultValue={new Date()}
             calcSubmitButtonTitle={endTimeCommitButtonTitle}
             onChange={onEndTimeChange}
             maxDate={null}


### PR DESCRIPTION
Start time/start location smart updates for a new patrol based on the following criteria:

If the patrol is new and unsaved, and the newly-selected subject is a recently active radio, and the selected tracked subject has a valid GPS location, then update both the start time and start location to match that selected subject’s most recent location.

If the patrol is new and unsaved, and the newly-selected subject is a null value (aka the subject has been cleared), then clear the start location value and set the start time value to now.

Also contains a bugfix for [DAS-6049](https://vulcan.atlassian.net/browse/DAS-6049)