### PR TITLE
DAS-6249 - Unpinned Patrol Track Disappearing on Track Point Click

### DIFF
--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -424,7 +424,7 @@ class Map extends Component {
   })
 
   hideUnpinnedTrackLayers(map, event) {
-    const { updatePatrolTrackState, updateTrackState, subjectTrackState: { visible } } = this.props;
+    const { updatePatrolTrackState, updateTrackState, patrolTrackState: { visible:visiblePatrolIds }, subjectTrackState: { visible } } = this.props;
     if (!visible.length) return;
 
     const clickedLayerIDs = map.queryRenderedFeatures(event.point)
@@ -437,7 +437,7 @@ class Map extends Component {
       visible: visible.filter(id => clickedLayerIDs.includes(id)),
     });
     updatePatrolTrackState({
-      visible: visible.filter(id => matchingPatrolIds.includes(id)),
+      visible: visiblePatrolIds.filter(id => matchingPatrolIds.includes(id)),
     });
   }
   onCloseReportHeatmap() {

--- a/src/PatrolCard/Popover.js
+++ b/src/PatrolCard/Popover.js
@@ -99,26 +99,7 @@ const PatrolCardPopover = forwardRef((props, ref) => { /* eslint-disable-line re
 
     onHide();
 
-    const patrolTrackIsPinned = patrolTrackState.pinned.includes(patrol.id);
-    const subjectTrackIsPinned = subjectTrackState.pinned.includes(leader.id);
-    
-    if (patrolTrackIsPinned && subjectTrackIsPinned) return;
-
-    if (!patrolTrackIsPinned) {
-      updatePatrolTrackState({
-        ...patrolTrackState,
-        visible: patrolTrackState.visible.filter(id => id !== patrol.id),
-      });
-    }
-
-    if (!subjectTrackIsPinned) {
-      updateTrackState({
-        ...subjectTrackState,
-        visible: subjectTrackState.visible.filter(id => id !== leader.id),
-      });
-    }
-
-  }, [leader, onHide, patrol.id, patrolTrackState, subjectTrackState, updatePatrolTrackState, updateTrackState]);
+  }, [leader, onHide]);
 
   return <Overlay show={isOpen} target={target.current} placement='auto' flip='true' container={container.current} onEntered={onOverlayOpen} onHide={onOverlayClose} rootClose>
     <Popover {...rest} placement='left' className={styles.popover}> {/* eslint-disable-line react/display-name */}


### PR DESCRIPTION
patrol track state management mismatch fix.
removing redundant track state management from patrol card popover  handler.