### PR TITLE
Don't display the save overlay

### DIFF
--- a/src/PatrolModal/TimeRangeAlert.js
+++ b/src/PatrolModal/TimeRangeAlert.js
@@ -9,11 +9,10 @@ const { Header, Title, Body, Footer } = Modal;
 
 const TimeRangeAlert = (props) => {
 
-  const { id, removeModal, onSaveCancelled } = props;
+  const { id, removeModal } = props;
 
   const onClickDone = useCallback(() => {
     removeModal(id);
-    onSaveCancelled();
   }, [id, removeModal]);
 
 

--- a/src/PatrolModal/index.js
+++ b/src/PatrolModal/index.js
@@ -450,9 +450,13 @@ const PatrolModal = (props) => {
     return({...statePatrol, updates: allPatrolUpdateHistory});
   }, [statePatrol, allPatrolUpdateHistory]);
 
-  const onSaveCancelled = useCallback(() => setSaveState(false));
-
   const onSave = useCallback(() => {
+
+    if (!patrolTimeRangeIsValid(statePatrol)) {
+      addModal({content: TimeRangeAlert});
+      return;
+    }
+
     setSaveState(true);
     trackEvent('Patrol Modal', `Click "save" button for ${!!statePatrol.id ? 'existing' : 'new'} patrol`);
 
@@ -465,11 +469,6 @@ const PatrolModal = (props) => {
         toSubmit[prop] = null;
       }
     });
-
-    if (!patrolTimeRangeIsValid(statePatrol)) {
-      addModal({content: TimeRangeAlert, onSaveCancelled: onSaveCancelled});
-      return;
-    }
 
     // just assign added reports to inital segment id for now
     addedReports.forEach(async (report) => {


### PR DESCRIPTION
https://vulcan.atlassian.net/browse/DAS-6300

First, I added a callback to cancel the save overlay, but realized after testing it that that it made more sense just to display the overlay after the time range check, and skip the callback

So this bug comes about when the user has input a end date before a start date. In previous conversations with mec, the thought is it is not reasonable to try to limit date ranges due to user workflow, so during the save operation, we display a dialog that informs the user that the selected date range is incorrect. This validation occurs during the save operation, which initially kicks off the save dialog. This fix short circuits the save dialog, where it is shown after it passes the daterange validation.