### PR TITLE
End patrols that come before the current time

### DIFF
--- a/src/PatrolModal/index.js
+++ b/src/PatrolModal/index.js
@@ -234,9 +234,11 @@ const PatrolModal = (props) => {
     const [segment] = statePatrol.patrol_segments;
 
     const update = new Date(value).toISOString();
+    const doneState = isPast(update) ? {state: 'done'} : {};
 
     setStatePatrol({
       ...statePatrol,
+      ...doneState,
       patrol_segments: [
         {
           ...segment,


### PR DESCRIPTION
https://vulcan.atlassian.net/browse/DAS-6330

Marks patrols as done if a user selects an end date that is less than the current time. This affects both 'End Patrol' and other dates that were set in the past. We should verify that is desired behavior, I could make a fix similiar to how we set the end labels (within 2 minutes of the date selected)