### PR TITLE
Revert "End patrols that come before the current time"

### DIFF
--- a/src/PatrolModal/index.js
+++ b/src/PatrolModal/index.js
@@ -234,11 +234,9 @@ const PatrolModal = (props) => {
     const [segment] = statePatrol.patrol_segments;
 
     const update = new Date(value).toISOString();
-    const doneState = isPast(update) ? {state: 'done'} : {};
 
     setStatePatrol({
       ...statePatrol,
-      ...doneState,
       patrol_segments: [
         {
           ...segment,


### PR DESCRIPTION
Reverts PADAS/das-web-react#378

Sorry @JayLVulcan I just realized this PR is only a one-way mechanism, and could lead to falsely closed patrols.  It needs to also calculate active states. Imagine I set and save an end time in the past, then set and save an end time in the future. This would mark the patrol as "done" with the first operation, and not override that "done" value back to an "open" status with the second operation. 