### PR TITLE
Use state and end date to determine if done or open

### DIFF
--- a/src/PatrolModal/index.js
+++ b/src/PatrolModal/index.js
@@ -19,7 +19,7 @@ import { subjectIsARadio, radioHasRecentActivity } from '../utils/subjects';
 import { generateSaveActionsForReportLikeObject, executeSaveActions } from '../utils/save';
 
 import { actualEndTimeForPatrol, actualStartTimeForPatrol, calcPatrolCardState, displayTitleForPatrol, displayStartTimeForPatrol, displayEndTimeForPatrol, displayDurationForPatrol, 
-  isSegmentActive, displayPatrolSegmentId, getReportsForPatrol, isSegmentEndScheduled, patrolTimeRangeIsValid, 
+  isSegmentActive, displayPatrolSegmentId, getReportsForPatrol, isSegmentEndScheduled, patrolTimeRangeIsValid, patrolCanBeMarkedDone,
   iconTypeForPatrol, extractAttachmentUpdates } from '../utils/patrols';
 
 import { trackEvent } from '../utils/analytics';
@@ -234,11 +234,10 @@ const PatrolModal = (props) => {
     const [segment] = statePatrol.patrol_segments;
 
     const update = new Date(value).toISOString();
-    const doneState = isPast(update) ? {state: 'done'} : {};
+
 
     setStatePatrol({
       ...statePatrol,
-      ...doneState,
       patrol_segments: [
         {
           ...segment,
@@ -457,6 +456,13 @@ const PatrolModal = (props) => {
     if (!patrolTimeRangeIsValid(statePatrol)) {
       addModal({content: TimeRangeAlert});
       return;
+    }
+
+    if(patrolCanBeMarkedDone(statePatrol)) {
+      const doneState = {state: 'done'};
+      setStatePatrol({
+        ...statePatrol,
+        ...doneState});
     }
 
     setSaveState(true);

--- a/src/utils/patrols.js
+++ b/src/utils/patrols.js
@@ -644,6 +644,15 @@ export const patrolTimeRangeIsValid = (patrol) => {
   
 };
 
+export const patrolCanBeMarkedDone = (patrol) => {
+  const isOpen = (patrol.state === 'open');
+  const endTime = displayEndTimeForPatrol(patrol);
+  const now = new Date();
+
+  return isOpen && endTime && now.getTime() > endTime.getTime();
+
+};
+
 export const getBoundsForPatrol = ((patrolData) => {
   const { leader, trackData, patrol } = patrolData;
   


### PR DESCRIPTION
To address the issue of someone marking something 'Done', but then going back into the UI and changing the dates again before saving, we determine at the point of saving if the patrol state is currently open, and if the end date is in the past. If so, we mark the patrol as done. Likewise, as my dear partner in crime pointed out, we need to consider when to open state if we move something into the future.