### PR TITLE
Mark state done/open based on end times of patrol

### DIFF
--- a/src/PatrolModal/index.js
+++ b/src/PatrolModal/index.js
@@ -19,13 +19,13 @@ import { subjectIsARadio, radioHasRecentActivity } from '../utils/subjects';
 import { generateSaveActionsForReportLikeObject, executeSaveActions } from '../utils/save';
 
 import { actualEndTimeForPatrol, actualStartTimeForPatrol, calcPatrolCardState, displayTitleForPatrol, displayStartTimeForPatrol, displayEndTimeForPatrol, displayDurationForPatrol, 
-  isSegmentActive, displayPatrolSegmentId, getReportsForPatrol, isSegmentEndScheduled, patrolTimeRangeIsValid, patrolCanBeMarkedDone,
+  isSegmentActive, displayPatrolSegmentId, getReportsForPatrol, isSegmentEndScheduled, patrolTimeRangeIsValid, patrolShouldBeMarkedDone, patrolShouldBeMarkedOpen,
   iconTypeForPatrol, extractAttachmentUpdates } from '../utils/patrols';
 
 import { trackEvent } from '../utils/analytics';
 
 
-import { PATROL_CARD_STATES, REPORT_PRIORITIES, PERMISSION_KEYS, PERMISSIONS } from '../constants';
+import { PATROL_CARD_STATES, REPORT_PRIORITIES, PERMISSION_KEYS, PERMISSIONS, PATROL_API_STATES } from '../constants';
 
 import EditableItem from '../EditableItem';
 import DasIcon from '../DasIcon';
@@ -460,11 +460,12 @@ const PatrolModal = (props) => {
     setSaveState(true);
     trackEvent('Patrol Modal', `Click "save" button for ${!!statePatrol.id ? 'existing' : 'new'} patrol`);
 
-    let toSubmit = statePatrol;
+    let toSubmit = {...statePatrol};
 
-    const shouldMarkClose = patrolCanBeMarkedDone(statePatrol);
-    if(shouldMarkClose) {
-      toSubmit.state='done';
+    if(patrolShouldBeMarkedDone(statePatrol)){
+      toSubmit.state=PATROL_API_STATES.DONE;
+    } else if (patrolShouldBeMarkedOpen(statePatrol)) {
+      toSubmit.state=PATROL_API_STATES.OPEN;
     }
 
     const LOCATION_PROPS =  ['start_location', 'end_location'];

--- a/src/utils/patrols.js
+++ b/src/utils/patrols.js
@@ -3,7 +3,7 @@ import addMinutes from 'date-fns/add_minutes';
 import isToday from 'date-fns/is_today';
 import isThisYear from 'date-fns/is_this_year';
 import format from 'date-fns/format';
-import { PATROL_CARD_STATES, PERMISSION_KEYS, PERMISSIONS } from '../constants';
+import { PATROL_CARD_STATES, PERMISSION_KEYS, PERMISSIONS, PATROL_API_STATES } from '../constants';
 import { SHORT_TIME_FORMAT, normalizeDate } from '../utils/datetime';
 import merge from 'lodash/merge';
 import concat from 'lodash/concat';
@@ -644,9 +644,19 @@ export const patrolTimeRangeIsValid = (patrol) => {
   
 };
 
-export const patrolCanBeMarkedDone = (patrol) => {
-  const isOpen = (patrol.state === 'open');
-  const endTime = displayEndTimeForPatrol(patrol);
+
+
+export const patrolShouldBeMarkedOpen = (patrol) => {
+  const isDone = (patrol.state === PATROL_API_STATES.DONE);
+  const endTime = actualEndTimeForPatrol(patrol);
+  const now = new Date();
+
+  return isDone && endTime && (now.getTime() < endTime.getTime());
+};
+
+export const patrolShouldBeMarkedDone = (patrol) => {
+  const isOpen = (patrol.state === PATROL_API_STATES.OPEN);
+  const endTime = actualEndTimeForPatrol(patrol);
   const now = new Date();
 
   return isOpen && endTime && (now.getTime() > endTime.getTime());


### PR DESCRIPTION
To address the issue of someone marking something 'Done', but then going back into the UI and changing the dates again before saving, we determine at the point of saving if the patrol state is currently open, and if the end date is in the past. If so, we mark the patrol as done. Likewise, as my dear partner in crime pointed out, we need to consider when to open state if we move something into the future.