### PR TITLE
Fix leader property

### DIFF
--- a/src/utils/patrols.js
+++ b/src/utils/patrols.js
@@ -488,7 +488,7 @@ export const sortPatrolCards = (patrols) => {
     return 6;
   };
 
-  const patrolDisplayTitleFunc = (patrol) => displayTitleForPatrol(patrol, patrol.leader).toLowerCase();
+  const patrolDisplayTitleFunc = (patrol) => displayTitleForPatrol(patrol, patrol?.patrol_segments[0]?.leader).toLowerCase();
 
   return orderBy(patrols, [sortFunc, patrolDisplayTitleFunc], ['asc', 'asc']);
 };


### PR DESCRIPTION
https://vulcan.atlassian.net/browse/DAS-6276

Fix for alphabetical listing of patrols - we were specifying the wrong property in the sort. We now display alphabetically within a patrol status grouping, with a case insensitive sort