### PR TITLE
Hotfix: Invert the sort order of reports in the patrol modal so that they match incidents

### DIFF
--- a/src/PatrolModal/index.js
+++ b/src/PatrolModal/index.js
@@ -100,7 +100,7 @@ const PatrolModal = (props) => {
     return orderBy(topLevelReports, [
       (item) => {
         return new Date(item.updated_at);
-      }],['desc']);
+      }],['acs']);
   }, [addedReports, patrolReports]);
 
   const allPatrolReportIds = useMemo(() => {


### PR DESCRIPTION
Simple fix to invert the sort order, I misread the AC