### PR TITLE
removing overeager external report update inheritance

### DIFF
--- a/src/ReportForm/index.js
+++ b/src/ReportForm/index.js
@@ -82,19 +82,6 @@ const ReportForm = (props) => {
     return report.priority;
   }, [eventTypes, report]);
 
-  useEffect(() => {
-    updateStateReport({
-      ...report,
-      ...originalReport,
-      event_details: {
-        ...report.event_details,
-        ...originalReport.event_details,
-      },
-    });
-    updateFilesToUpload([]);
-    updateNotesToAdd([]);
-  }, [originalReport]); // eslint-disable-line
-
   const handleSaveError = useCallback((e) => {
     setSavingState(false);
     setSaveErrorState(e);


### PR DESCRIPTION
https://vulcan.atlassian.net/browse/DAS-6528

The report form component's effect hook which consumes and applies external data changes (aka changes to that report occurring from outside the form) is overly eager, causing false positive overrides to local changes. This removes that hook.