### PR TITLE
DAS-6714 fixing async feed validation edge case

### DIFF
--- a/src/ducks/events.js
+++ b/src/ducks/events.js
@@ -436,7 +436,12 @@ const namedFeedReducer = (name, reducer = state => state) => globallyResettableR
   if (type === FEED_FETCH_START) {
     return INITIAL_EVENT_FEED_STATE;
   }
-  if (type === FEED_FETCH_SUCCESS) {
+  if (type === FEED_FETCH_SUCCESS
+   && (
+     !payload.results.length
+    || validateReportAgainstCurrentEventFilter(payload.results[0]) /* extra layer of validation for async query race condition edge cases */
+   )
+  ) {
     return {
       ...payload,
       results: payload.results.map(event => event.id),


### PR DESCRIPTION
https://vulcan.atlassian.net/browse/DAS-6714

This PR just adds a guard clause to prevent state transitions if the underlying event filter has changed out of sync with the async data fetching.