### PR TITLE
[DAS-6571] Google Translate whitescreen fix 

### DIFF
--- a/src/SubjectHeatLayer/index.js
+++ b/src/SubjectHeatLayer/index.js
@@ -17,6 +17,8 @@ const SubjectHeatLayer = ({ trackData }) => {
     setPoints(convertTrackDataToHeatmapPoints(trackData));
   }, [trackData]);
 
+  if (!points.length) return null;
+
   return <HeatLayer points={points} />;
 };
 


### PR DESCRIPTION
This is a seemingly minor/useless change, but it resolves a long-standing issue wherein React and Google Translate don't play nicely with one another. The main clash appears to be when a component is unmounting, and `react-dom` is traversing and removing nodes from the document, it fatally conflicts with the under-the-hood markup manipulations injected by Google Translate when translating a page.  🤷  Yeehaw

Here's the relevant React issue:
https://github.com/facebook/react/issues/11538