### PR TITLE
increasing infinite scroll container padding height to account for sort control vertical offset

### DIFF
--- a/src/EventFeed/styles.module.scss
+++ b/src/EventFeed/styles.module.scss
@@ -13,7 +13,7 @@
 div.scrollContainer {
   height: 100%;
   overflow-y: auto;
-  padding-bottom: 4.5rem;
+  padding-bottom: 7.5rem;
   position: relative;
 }
 


### PR DESCRIPTION
https://allenai.atlassian.net/browse/DAS-7079

The infinite scroll container's bottom padding no longer created the correct amount of offset to allow infinite scrolling, due to the additional vertical space consumed by our new sort control. This PR fixes that by upping the padding.