### PR TITLE
DAS-7059 Overlapping cluster of reports, clicking on the name of one of the reports opens the disambiguation control

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -135,8 +135,8 @@ export const IF_IS_GENERIC = (ifGeneric, ifNonGeneric) => ['case',
 
 export const SYMBOL_ICON_SIZE_EXPRESSION = [
   'interpolate', ['exponential', 0.5], ['zoom'],
-  0, IF_IS_GENERIC(0.1 / MAP_ICON_SCALE, 0.2 / MAP_ICON_SCALE),
-  14, IF_IS_GENERIC(0.5 / MAP_ICON_SCALE, 1 / MAP_ICON_SCALE),
+  0, IF_IS_GENERIC(0.1/MAP_ICON_SCALE, 0.2/MAP_ICON_SCALE),
+  14, IF_IS_GENERIC(0.5/MAP_ICON_SCALE, 1/MAP_ICON_SCALE),
   // MAX_ZOOM, IF_IS_GENERIC(0.75/MAP_ICON_SCALE, 1.1/MAP_ICON_SCALE),
 ];
 


### PR DESCRIPTION
## Change
Add event symbols to the LAYER_PICKER_IDS in order to click on the symbol and show the popup list too

### Context
after trying to get the multiple layers clicked, this method was skipping the event symbols, so that, it was counting only other types of layers. 
![image](https://user-images.githubusercontent.com/13925537/134259657-bd6028fd-a9d2-4fe1-8020-5acb38f9c302.png)

The constant `LAYER_PICKER_IDS` is only being use in this line

## Evidence
![gif](http://g.recordit.co/F05Xs38TvN.gif)
