### PR TITLE
service worker build tweaks for updated dependency configs

### DIFF
--- a/src/sw-build.js
+++ b/src/sw-build.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const workboxBuild = require('workbox-build');
 
 const buildSW = () => {
@@ -6,9 +7,9 @@ const buildSW = () => {
   // Add a catch block to handle this scenario.
   return workboxBuild
     .injectManifest({
-      swSrc: 'src/sw-custom.js', // custom sw rule
-      swDest: 'build/sw.js', // sw output file (auto-generated)
-      globDirectory: 'build',
+      swSrc: path.join(process.cwd(), 'src/sw-custom.js'), // custom sw rule
+      swDest: path.join(process.cwd(), 'build/sw.js'), // sw output file (auto-generated)
+      globDirectory: path.join(process.cwd(), 'build'),
       globPatterns: ['**/*.{js,html,css,png,svg}'],
       globIgnores: ['**/*service-worker*.js', '**/*precache-manifest*.js'],
       maximumFileSizeToCacheInBytes: 50 * 1024 * 102,
@@ -17,6 +18,9 @@ const buildSW = () => {
       warnings.forEach(console.warn);
       console.info(`${count} files will be precached,
                   totaling ${size / (1024 * 1024)} MBs.`);
+    })
+    .catch((error) => {
+      console.error('could not build service worker', error);
     });
 };
 

--- a/src/sw-custom.js
+++ b/src/sw-custom.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 if ('function' === typeof importScripts) {
-  importScripts('https://storage.googleapis.com/workbox-cdn/releases/4.3.1/workbox-sw.js'); 
+  importScripts('https://storage.googleapis.com/workbox-cdn/releases/4.3.1/workbox-sw.js');
 
   // Global workbox
   if (workbox) {
@@ -14,8 +14,8 @@ if ('function' === typeof importScripts) {
     });
 
     self.addEventListener('activate', function(event) {
-    event.waitUntil(self.clients.claim()); // Become available to all pages
-});
+      event.waitUntil(self.clients.claim()); // Become available to all pages
+    });
 
     workbox.core.clientsClaim();
 
@@ -72,4 +72,7 @@ if ('function' === typeof importScripts) {
   } else {
     console.error('Workbox could not be loaded. No offline support');
   }
+
+  workbox.precaching.precacheAndRoute(self.__WB_MANIFEST);
+
 }


### PR DESCRIPTION
The service worker build was failing without the following line being added:

`workbox.precaching.precacheAndRoute(self.__WB_MANIFEST);`

This appears to be related to some underlying build changes we inherited when we recently updated our `react-scripts` bundle. The mechanism for reading the manifest changed, so we now need to explicitly declare `self.__WB_MANIFEST` as the manifest source.