### PR TITLE
Do not require smoke tests to execute in a linear way

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,9 +114,7 @@ workflows:
   docker_build_workflow:
     jobs:
       - execute_smoke_tests
-      - production_build:
-          requires:
-            - execute_smoke_tests
+      - production_build
       - push_to_storage:
           requires:
             - production_build


### PR DESCRIPTION
Remove dependency for smoke tests.