### PR TITLE
[DAS-7418] making the scale control use metric units.

### DIFF
--- a/src/EarthRangerMap/index.js
+++ b/src/EarthRangerMap/index.js
@@ -43,7 +43,6 @@ const EarthRangerMap = (props) => {
 
       const scale = new mapboxgl.ScaleControl({
         maxWidth: 80,
-        unit: 'imperial'
       });
 
       map.addControl(scale, 'bottom-right');


### PR DESCRIPTION
No ticket for this yet, will backfill when one is made in Jira. Everything else is in metric units, why are we rendering the scale control (bottom right) in imperial units? 🤷 