### PR TITLE
DAS-7460: Remove constraint to add non human subjects to the patrol filters

### DIFF
--- a/src/PatrolFilter/FiltersPopover/index.js
+++ b/src/PatrolFilter/FiltersPopover/index.js
@@ -10,7 +10,6 @@ import uniq from 'lodash/uniq';
 import { fetchTrackedBySchema } from '../../ducks/trackedby';
 import { iconTypeForPatrol } from '../../utils/patrols';
 import { INITIAL_FILTER_STATE, updatePatrolFilter } from '../../ducks/patrol-filter';
-import { reportedBy } from '../../selectors';
 import { trackEventFactory, PATROL_FILTER_CATEGORY } from '../../utils/analytics';
 
 import CheckboxList from '../../CheckboxList';
@@ -49,7 +48,6 @@ const FiltersPopover = React.forwardRef(({
   patrolFilter,
   patrolLeaderSchema,
   patrolTypes,
-  reporters,
   updatePatrolFilter,
   ...rest
 }, ref) => {
@@ -128,7 +126,7 @@ const FiltersPopover = React.forwardRef(({
   const patrolLeaderFilterOptions = patrolLeaderSchema?.trackedbySchema?.properties?.leader?.enum_ext?.map(({ value }) => value)
     || [];
   const selectedLeaders = !!selectedLeaderIds?.length ?
-    selectedLeaderIds.map(id => reporters.find(reporter => reporter.id === id)).filter(item => !!item)
+    selectedLeaderIds.map(id => patrolLeaderFilterOptions.find(leader => leader.id === id))
     : [];
 
   const statusFilterOptions = PATROL_FILTERS_STATUS_OPTIONS.map(status => ({
@@ -287,7 +285,6 @@ FiltersPopover.propTypes = {
     id: PropTypes.string,
     icon_id: PropTypes.string,
   })).isRequired,
-  reporters: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.string })).isRequired,
   updatePatrolFilter: PropTypes.func.isRequired,
 };
 
@@ -297,7 +294,6 @@ const mapStateToProps = (state) => ({
   patrolFilter: state.data.patrolFilter,
   patrolLeaderSchema: state.data.patrolLeaderSchema,
   patrolTypes: state.data.patrolTypes,
-  reporters: reportedBy(state),
 });
 
 export default connect(

--- a/src/PatrolFilter/FiltersPopover/styles.module.scss
+++ b/src/PatrolFilter/FiltersPopover/styles.module.scss
@@ -1,10 +1,10 @@
 @import '../../common/styles/vars/colors';
 
 .popover {
-  overflow: visible !important;
+  overflow: auto !important;
 
   [class*=popover-body] {
-    overflow: visible !important;
+    overflow: auto !important;
   }
 }
 

--- a/src/ReportedBySelect/index.js
+++ b/src/ReportedBySelect/index.js
@@ -34,6 +34,11 @@ const ReportedBySelect = (props) => {
   const optionalProps = {};
   const selectStyles = {
     ...DEFAULT_SELECT_STYLES,
+    valueContainer: (provided) => ({
+      ...provided,
+      maxHeight: '12rem',
+      overflowY: 'auto',
+    }),
   };
 
   if (menuRef) {

--- a/src/ReportedBySelect/styles.module.scss
+++ b/src/ReportedBySelect/styles.module.scss
@@ -43,6 +43,7 @@
 
   .label {
     margin-right: 0.5rem;
+    max-width: 11rem;
   }
 }
 


### PR DESCRIPTION
Ticket: https://allenai.atlassian.net/browse/DAS-7460

**Evidence**
![image](https://user-images.githubusercontent.com/11725028/145425992-ed326ffc-388f-41e2-a9fe-4b733ce59399.png)
Notice non humans subjects added to the selector and the vertical scroll bars in the selector container and the popover.