### PR TITLE
undoing ducks logic which 'manages' patrol state erroneously

### DIFF
--- a/src/ducks/patrols.js
+++ b/src/ducks/patrols.js
@@ -155,13 +155,10 @@ export const createPatrol = (patrol) => (dispatch) => {
     }); */
 };
 
-export const updatePatrol = (patrol) => (dispatch) => {
+export const updatePatrol = (patrol) => {
 
-  let patrolResults;
-  let resp;
-
-  return axios.patch(`${PATROLS_API_URL}${patrol.id}`, patrol)
-    .then((response) => {
+  return axios.patch(`${PATROLS_API_URL}${patrol.id}`, patrol);
+  /* .then((response) => {
       patrolResults = response.data.data;
       resp = response;
       return true;
@@ -181,7 +178,7 @@ export const updatePatrol = (patrol) => (dispatch) => {
       }
       return resp;
     });
-/*     .catch((error) => {
+     .catch((error) => {
       dispatch({
         type: UPDATE_PATROL_ERROR,
         payload: error,


### PR DESCRIPTION
As you can see from the removed code, `updatePatrol` was returning an always-true value as to if we should update a patrol in state or remove it from state. Let's just rely on the socket and its `matches_current_filter` prop to manage this. 

@luixlive in the near future we should consider re-instating this logic as per the way it works with events as per the `validateReportAgainstCurrentEventFilter` function, but that's wayyy out of scope for fixing the bug currently  