### PR TITLE
explicit and non-deprecated import and use of Buffer for image downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "axios": "^0.21.1",
     "axios-progress-bar": "^1.2.0",
     "bootstrap": "4.3.1",
+    "buffer": "^6.0.3",
     "date-fns": "^1.30.1",
     "geodesy": "^2.0.1",
     "humanize-duration": "^3.27.1",

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -1,4 +1,5 @@
 import { post, get } from 'axios';
+import { Buffer } from 'buffer';
 
 export const uploadFile = (url, file, progressHandler = () => null) => {
   const formData = new FormData();
@@ -23,7 +24,7 @@ export const fetchImageAsBase64FromUrl = async (url) => {
     responseType: 'arraybuffer',
   });
 
-  return `data:image/png;base64, ${new Buffer(response.data, 'binary').toString('base64')}`;
+  return `data:image/png;base64, ${new Buffer.from(response.data, 'binary').toString('base64')}`;
 };
 
 export const filterDuplicateUploadFilenames = (currentFiles, newFilesToUpload) => newFilesToUpload.filter((file) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4543,6 +4543,14 @@ buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 builtin-modules@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
@@ -7384,7 +7392,7 @@ identity-obj-proxy@^3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ieee754@^1.1.12, ieee754@^1.1.13:
+ieee754@^1.1.12, ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==


### PR DESCRIPTION
Surprise! The way the `Buffer` interface is compiled by webpack changed just in time for this release 🙃 

To stabilize it, I'm importing the package explicitly and using `Buffer.from` instead of the deprecated `Buffer`

Otherwise, image attachment downloads won't work anymore.  It's a spicy release!