### PR TITLE
DAS-7851: Add button is displayed outside the subject popover when using long subject names

### DIFF
--- a/src/SubjectPopup/index.js
+++ b/src/SubjectPopup/index.js
@@ -96,7 +96,7 @@ const SubjectPopup = ({ data, popoverPlacement, timeSliderState, addModal, showP
       </div>
       {coordProps.time && <div className={styles.dateTimeWrapper}>
         <DateTime date={coordProps.time} className={styles.dateTimeDetails} showElapsed={false}/>
-        <span>, </span>
+        <span className={styles.dateTimeComma}>, </span>
         <TimeAgo className={styles.timeAgo} date={coordProps.time} suffix="ago" />
       </div>}
     </div>

--- a/src/SubjectPopup/styles.module.scss
+++ b/src/SubjectPopup/styles.module.scss
@@ -42,6 +42,10 @@
       display: inline;
       color: white;
     }
+
+    .dateTimeComma {
+      margin-right: 0.25rem;
+    }
     
     .timeAgo {
       font-style: italic;


### PR DESCRIPTION
Ticket: https://allenai.atlassian.net/browse/DAS-7851
Env: https://das-7851.pamdas.org/

**Evidence**
![image](https://user-images.githubusercontent.com/11725028/159558559-608bb967-b911-48c8-87ed-cc7ab00f6a1e.png)

In this PR I also fix the exact same issue in the date line:
![image](https://user-images.githubusercontent.com/11725028/159544862-6d53876d-6474-443e-9809-04851c606037.png)
