### PR TITLE
DAS-7751: Users without permission to edit an event still have the option to save and save/resolve

### DIFF
--- a/src/ReportForm/index.js
+++ b/src/ReportForm/index.js
@@ -167,7 +167,7 @@ const ReportForm = (props) => {
     const onSubmit = () => {
       return saveChanges()
         .then((results) => {
-          removeModal();
+          if (!!results) removeModal();
           return results;
         });
     };


### PR DESCRIPTION
Ticket: https://allenai.atlassian.net/browse/DAS-7751
Env: https://das-7751.pamdas.org/

**How to reproduce**
1. Open https://das-7751.pamdas.org/
2. Login with admin credentials
3. Create / modify different report types (like animal control)
4. Logout
5. Login with a user with restricted permissions to edit events:
```
user: ludwig
password: lud_password
```
6. Try to edit any value of one of the events created by the admin
The modal shouldn't close and there should be a error message.

**Evidence**
![image](https://user-images.githubusercontent.com/11725028/159585731-0343c7d0-a47c-4408-99d2-af2529977231.png)

Notes: 
- As Joshua mentioned in the ticket, this isn't really a solution to the problem, but a temporary workaround. This issue traces back to the way we handle permissions in the backend so the permanent solution involves a bigger effort.
- The user `ludwig` has the exact same permissions shown by Jes in the ticket.