### PR TITLE
Fix time issue with jest in FriendlyFilterString tests

### DIFF
--- a/src/FriendlyFilterString/index.test.js
+++ b/src/FriendlyFilterString/index.test.js
@@ -6,7 +6,10 @@ import { EVENT_SORT_OPTIONS, SORT_DIRECTION } from '../utils/event-filter';
 
 describe('FriendlyFilterString', () => {
   beforeAll(() => {
-    jest.useFakeTimers('modern').setSystemTime(new Date('February 20 2022 12:30 GMT-0600').getTime());
+    const mockSystemTime = new Date('2022-02-20');
+    mockSystemTime.setUTCHours(20);
+
+    jest.useFakeTimers('modern').setSystemTime(mockSystemTime.getTime());
   });
 
   test('prints a friendly string for a non-filtered case', async () => {


### PR DESCRIPTION
Mock time features in Jest to avoid any timezones related issues in tests.

**Evidence**
![image](https://user-images.githubusercontent.com/11725028/159808208-86c90609-7cd5-491e-9f84-8bbf52310c76.png)

Note: Should we mock this globally instead of in every test file that needs it?? 🤔 🤔 🤔 🤔