### PR TITLE
DAS-7987: Disabling field choices from event types are not being filtered, still being displayed in the field. 

### DIFF
--- a/src/SchemaFields/index.js
+++ b/src/SchemaFields/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback, useEffect, useState, useRef } from 'react';
+import React, { Fragment, useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import Select, { components } from 'react-select';
 import DateTimePickerPopover from '../DateTimePickerPopover';
 import isString from 'lodash/isString';
@@ -55,7 +55,11 @@ const SelectField = (props) => {
     return (label || name);
   };
   const getOptionValue = (val) => isPlainObject(val) ? val.value : val;
-  const isOptionDisabled = (option) => schema.inactive_enum && schema.inactive_enum.includes(option.value.toLowerCase());
+  const schemaInactiveEnumLowercase = useMemo(
+    () => (schema.inactive_enum || []).map((inactiveOption) => inactiveOption.toLowerCase()),
+    [schema]
+  );
+  const isOptionDisabled = (option) => schemaInactiveEnumLowercase.includes(option.value.toLowerCase());
 
   const selected = enumOptions.find((item) => value ?
     item.value ===


### PR DESCRIPTION
Ticket: https://allenai.atlassian.net/browse/DAS-7987

**Description**
Schemas include a property called `inactive_enum` which contains an array with the strings of the choices that shouldn't be listed in a dropdown. The issue was that `inactive_enum` has the choice strings exactly as they are named, but before checking if they were in the array, we were first making all letters in the choice lowercase. So we were looking for `certain` in `['Certain']` and we couldn't find it.

Since I guess that we were lowercasing the choice letters for some reason, I didn't want to remove that and instead I created a memoized array with all the inactive values in lowercase.