### PR TITLE
fixing the usePatrols memory leak. 

### DIFF
--- a/src/ClustersLayer/utils.js
+++ b/src/ClustersLayer/utils.js
@@ -181,7 +181,7 @@ export const addNewClusterMarkers = (
     if (!marker) {
       const clusterFeatureCollection = featureCollection(clusterFeatures);
       const clusterPoint = centroid(clusterFeatureCollection);
-      const newClusterHTMLMarkerContainer = createClusterHTMLMarker(
+      let newClusterHTMLMarkerContainer = createClusterHTMLMarker(
         clusterFeatures,
         mapImages,
         onClusterClick(
@@ -200,6 +200,8 @@ export const addNewClusterMarkers = (
       marker = new mapboxgl.Marker(newClusterHTMLMarkerContainer)
         .setLngLat(clusterPoint.geometry.coordinates)
         .addTo(map);
+
+      newClusterHTMLMarkerContainer = null; // forcing garbage collection
     }
 
     renderedClusterMarkersHashMap[clusterHash] = { id: clusterId, marker };

--- a/src/hooks/useClusterBufferPolygon/index.js
+++ b/src/hooks/useClusterBufferPolygon/index.js
@@ -7,7 +7,7 @@ import simplify from '@turf/simplify';
 import { CLUSTERS_MAX_ZOOM } from '../../constants';
 import { MapContext } from '../../App';
 
-export default (layerConfiguration, layerId, sourceConfiguration, sourceId) => {
+const useClusterBufferPolygon = (layerConfiguration, layerId, sourceConfiguration, sourceId) => {
   const map = useContext(MapContext);
 
   const [clusterBufferPolygon, setClusterBufferPolygon] = useState(featureCollection([]));
@@ -50,3 +50,5 @@ export default (layerConfiguration, layerId, sourceConfiguration, sourceId) => {
 
   return { removeClusterPolygon, renderClusterPolygon, setClusterBufferPolygon };
 };
+
+export default useClusterBufferPolygon;

--- a/src/hooks/usePatrol/index.js
+++ b/src/hooks/usePatrol/index.js
@@ -18,6 +18,7 @@ import {
   patrolStateDetailsOverdueStartTime,
   patrolStateDetailsStartTime,
 } from '../../utils/patrols';
+
 import { createPatrolDataSelector } from '../../selectors/patrols';
 import { PATROL_API_STATES, PATROL_UI_STATES } from '../../constants';
 import { updatePatrol } from '../../ducks/patrols';
@@ -25,15 +26,12 @@ import { updatePatrol } from '../../ducks/patrols';
 const usePatrol = (patrolFromProps) => {
   const dispatch = useDispatch();
 
-  const { patrolData, patrolTrackState, trackState } = useSelector((state) => {
-    const getDataForPatrolFromProps = createPatrolDataSelector();
+  const getDataForPatrolFromProps = useMemo(createPatrolDataSelector, []);
+  const patrolFromPropsObject = useMemo(() => ({ patrol: patrolFromProps }), [patrolFromProps]);
 
-    return !!patrolFromProps && {
-      patrolData: getDataForPatrolFromProps(state, { patrol: patrolFromProps }),
-      patrolTrackState: state?.view?.patrolTrackState,
-      trackState: state?.view?.subjectTrackState,
-    };
-  });
+  const patrolData = useSelector((state) => getDataForPatrolFromProps(state, patrolFromPropsObject));
+  const patrolTrackState = useSelector(state =>  state?.view?.patrolTrackState);
+  const trackState = useSelector(state => state?.view?.subjectTrackState);
 
   const [patrolState, setPatrolState] = useState(calcPatrolState(patrolData.patrol));
 

--- a/src/selectors/patrols.js
+++ b/src/selectors/patrols.js
@@ -2,7 +2,7 @@ import uniq from 'lodash/uniq';
 import isAfter from 'date-fns/is_after';
 import { createSelector } from 'reselect';
 
-import { createEqualitySelector, getTimeSliderState } from './';
+import { getTimeSliderState } from './';
 import { getSubjectStore } from './subjects';
 
 import { trimmedVisibleTrackData, tracks } from './tracks';
@@ -17,7 +17,13 @@ export const getTrackForPatrolFromProps = ({ data: { tracks } }, { patrol }) =>
   && !!patrol.patrol_segments.length
   && !!patrol.patrol_segments[0].leader
   && tracks[patrol.patrol_segments[0].leader.id];
-export const getLeaderForPatrolFromProps = ({ data: { subjectStore } }, { patrol }) => getLeaderForPatrol(patrol, subjectStore);
+export const getLeaderForPatrolFromProps = (_store, { patrol }) => {
+  const [firstLeg] = patrol.patrol_segments;
+  const { leader }  = firstLeg;
+  if (!leader) return null;
+
+  return leader;
+};
 const getPatrolTrackState = ({ view: { patrolTrackState } }) => uniq([...patrolTrackState.visible, ...patrolTrackState.pinned]);
 
 
@@ -79,8 +85,8 @@ const generatePatrolStartStopData = (patrolData, rawTrack, timeSliderState) => {
   };
 };
 
-export const createPatrolDataSelector = () => createEqualitySelector(
-  [getPatrolFromProps, getLeaderForPatrolFromProps,  getTrackForPatrolFromProps, getTimeSliderState],
+export const createPatrolDataSelector = () => createSelector(
+  [getPatrolFromProps, getLeaderForPatrolFromProps, getTrackForPatrolFromProps, getTimeSliderState],
   assemblePatrolDataForPatrol,
 );
 


### PR DESCRIPTION
(also patching a smaller memory leak and some lint-based tweaks along the way.)

https://allenai.atlassian.net/browse/DAS-8065

The selector returned by createPatrolDataSelector is meant to threshold expensive operations related to calculating data necessary to display patrols on the map.

In the new implementation of usePatrols, moving this selector from a component selector to the useSelector hook inside of usePatrols resulted in the accidental re-execution of these expensive calculations during every render phase of a PatrolListItem, regardless of if any pertinent values had changed. 

This consumes a lot of CPU, and when changing date filters to a range that includes 40+ patrols it was completely freezing the web UI, or making user inputs such as clicks and scrolls have response times in the 10-20 second range.

For more information on the problem, read the section starting with “However, when the selector is used in multiple component instances…” [on this page from react-redux](https://react-redux.js.org/api/hooks#useselector-examples).

