### PR TITLE
style tweak to allow jira widget interactions without screen blocking

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -629,7 +629,7 @@ div.mapboxgl-popup-tip {
 }
 
 #jsd-widget {
-  pointer-events: none;
+  bottom: -30px !important;
 }
 
 /* --- OLD NAVIGATION STUFF STARTS HERE --- */


### PR DESCRIPTION
https://allenai.atlassian.net/browse/ERCS-268
https://allenai.atlassian.net/browse/DAS-8085

The wrong CSS property was being manipulated for our external support widget, making the form non-interactive. This is a less invasive way of preventing it from quietly overlapping the bottom of the UI, but also allowing it to be usable. 