### PR TITLE
DAS-8176: User is not able lo logout in some cases.

### DIFF
--- a/src/ducks/auth.js
+++ b/src/ducks/auth.js
@@ -2,7 +2,7 @@ import axios, { CancelToken } from 'axios';
 import { REACT_APP_DAS_HOST, REACT_APP_DAS_AUTH_TOKEN_URL } from '../constants';
 import { clearUserProfile } from '../ducks/user';
 import { resetGlobalState } from '../reducers/global-resettable';
-import { deleteAuthTokenCookie, getAuthTokenFromCookies } from '../utils/auth';
+import { deleteAuthTokenCookie, deleteTemporaryAccessTokenCookie, getAuthTokenFromCookies } from '../utils/auth';
 
 const AUTH_URL = `${REACT_APP_DAS_HOST}${REACT_APP_DAS_AUTH_TOKEN_URL}`;
 
@@ -42,6 +42,7 @@ export const clearAuth = () => dispatch => {
   return new Promise((resolve) => {
 
     deleteAuthTokenCookie();
+    deleteTemporaryAccessTokenCookie();
     setTimeout(() => {
       dispatch(clearUserProfile());
       dispatch({

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -10,3 +10,5 @@ export const getTemporaryAccessTokenFromCookies = () => {
 export const deleteCookie = (name) => document.cookie = `${name}=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
 
 export const deleteAuthTokenCookie = () => deleteCookie('token');
+
+export const deleteTemporaryAccessTokenCookie = () => deleteCookie('temporaryAccessToken');


### PR DESCRIPTION
Ticket: https://allenai.atlassian.net/browse/DAS-8176

Note: There's no way to add evidence to this issue since even the repro steps are hard to define. But the conversation on this was closely followd by @YazzMagana and the logout issue seems to come from the fact that the EULA `temporaryAccessToken` was not being removed in the EULA page. This fix works just fine, we are clearing every session cookie on logout which makes sense. **However, it would be great to find the root cause of why this started happened.** The main files involved in this are `views/EULA/index.js` and `RequireEulaConfirmation/index.js`.