### PR TITLE
DAS-8190 SubjectGroups in MapLayers tab disappear when a Report date filter is set 

### DIFF
--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -524,7 +524,7 @@ const Map = ({
       const { zoom, center } = homeMap;
       jumpToLocation(lngLatFromParams.current || center, zoom);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [homeMap, map]);
 
   useEffect(() => {


### PR DESCRIPTION
### [Ticket](https://allenai.atlassian.net/browse/DAS-8190?atlOrigin=eyJpIjoiZWFkZTAxOTJjZTU1NGVlYWJjY2VjOTI3M2VjNDZlODgiLCJwIjoiaiJ9)

### [Test Environment](https://das-8190.pamdas.org/)

## What I did:
I separate the clear data useEffect when unmounting the component to avoid sharing the dependencies.
This changed after the update of the **React-router-dom Library** because this component used to be a class instead of a functional one.

#### [Here you can find some React explaination](https://reactjs.org/docs/hooks-reference.html#cleaning-up-an-effect) for the non react developers 😅 that are helping me on this review

### Evidence:
![gif](http://g.recordit.co/SyLFuoAf2y.gif)
