### PR TITLE
[ERA-7782] BUGFIX - Map layer stacking context

### DIFF
--- a/src/AnalyzersLayer/index.js
+++ b/src/AnalyzersLayer/index.js
@@ -5,7 +5,7 @@ import { LAYER_IDS, SOURCE_IDS } from '../constants';
 import { useMapEventBinding, useMapLayer, useMapSource } from '../hooks';
 
 const { ANALYZER_POLYS_WARNING, ANALYZER_POLYS_CRITICAL, ANALYZER_LINES_WARNING,
-  ANALYZER_LINES_CRITICAL, SUBJECT_SYMBOLS } = LAYER_IDS;
+  ANALYZER_LINES_CRITICAL, SKY_LAYER } = LAYER_IDS;
 const { ANALYZER_POLYS_WARNING_SOURCE, ANALYZER_POLYS_CRITICAL_SOURCE,
   ANALYZER_LINES_CRITICAL_SOURCE, ANALYZER_LINES_WARNING_SOURCE } = SOURCE_IDS;
 
@@ -63,7 +63,7 @@ const AnalyzerLayer = (
   };
 
   const layerConfig = useMemo(() => ({
-    before: SUBJECT_SYMBOLS,
+    before: SKY_LAYER,
     minZoom,
     condition: !!isSubjectSymbolsLayerReady,
   }), [isSubjectSymbolsLayerReady, minZoom]);

--- a/src/BaseLayerRenderer/TileLayerRenderer.js
+++ b/src/BaseLayerRenderer/TileLayerRenderer.js
@@ -6,7 +6,7 @@ import { useMapLayer, useMapSource } from '../hooks';
 
 import { calcConfigForMapAndSourceFromLayer } from '../utils/layers';
 
-const { FEATURE_FILLS } = LAYER_IDS;
+const { TOPMOST_STYLE_LAYER } = LAYER_IDS;
 
 const RASTER_SOURCE_OPTIONS = {
   'type': 'raster',
@@ -56,7 +56,7 @@ const TileLayerRenderer = (props) => {
     `layer-source-${activeLayer?.id}`,
     undefined,
     undefined,
-    { before: FEATURE_FILLS, condition: !!activeLayer }
+    { before: TOPMOST_STYLE_LAYER, condition: !!activeLayer }
   );
 
   return layers

--- a/src/FeatureLayer/index.js
+++ b/src/FeatureLayer/index.js
@@ -12,7 +12,7 @@ import MarkerImage from '../common/images/icons/mapbox-blue-marker-icon.png';
 import RangerStationsImage from '../common/images/icons/ranger-stations.png';
 import { useMapEventBinding, useMapLayer, useMapSource } from '../hooks';
 
-const { FEATURE_FILLS, FEATURE_LINES, FEATURE_SYMBOLS, TOPMOST_STYLE_LAYER } = LAYER_IDS;
+const { FEATURE_FILLS, FEATURE_LINES, FEATURE_SYMBOLS, SKY_LAYER } = LAYER_IDS;
 
 const { MAP_FEATURES_LINES_SOURCE, MAP_FEATURES_POLYGONS_SOURCE, MAP_FEATURES_SYMBOLS_SOURCE } = SOURCE_IDS;
 
@@ -106,7 +106,7 @@ const FeatureLayer = ({ symbols, lines, polygons, onFeatureSymbolClick, mapUserL
     onFeatureSymbolClick(geojson);
   };
 
-  const layerConfig = { minZoom, before: TOPMOST_STYLE_LAYER };
+  const layerConfig = { minZoom, before: SKY_LAYER };
 
   useMapSource(MAP_FEATURES_LINES_SOURCE, lines);
   useMapSource(MAP_FEATURES_POLYGONS_SOURCE, polygons);

--- a/src/HeatLayer/index.js
+++ b/src/HeatLayer/index.js
@@ -9,7 +9,7 @@ import { metersToPixelsAtMaxZoom } from '../utils/map';
 import { uuid } from '../utils/string';
 import { useMapLayer, useMapSource } from '../hooks';
 
-const { HEATMAP_LAYER, TOPMOST_STYLE_LAYER } = LAYER_IDS;
+const { HEATMAP_LAYER, SKY_LAYER } = LAYER_IDS;
 
 const HeatLayer = ({ heatmapStyles, points }) => {
   const idRef = useRef(uuid());
@@ -29,7 +29,7 @@ const HeatLayer = ({ heatmapStyles, points }) => {
   }), [heatmapStyles.intensity, latitude, heatmapStyles.radiusInMeters]);
 
   useMapSource(`heatmap-source-${idRef.current}`, points);
-  useMapLayer(`${HEATMAP_LAYER}-${idRef.current}`, 'heatmap', `heatmap-source-${idRef.current}`, paint, null, { before: TOPMOST_STYLE_LAYER });
+  useMapLayer(`${HEATMAP_LAYER}-${idRef.current}`, 'heatmap', `heatmap-source-${idRef.current}`, paint, null, { before: SKY_LAYER });
 
   return null;
 };

--- a/src/SubjectsLayer/index.js
+++ b/src/SubjectsLayer/index.js
@@ -13,7 +13,7 @@ import { getMapSubjectFeatureCollectionWithVirtualPositioning } from '../selecto
 import { getShouldSubjectsBeClustered } from '../selectors/clusters';
 import { useMapSource } from '../hooks';
 
-const { SUBJECT_SYMBOLS } = LAYER_IDS;
+const { SUBJECT_SYMBOLS, SKY_LAYER } = LAYER_IDS;
 const { CLUSTERS_SOURCE_ID } = SOURCE_IDS;
 
 const unclusteredFilter = [
@@ -71,6 +71,7 @@ const SubjectsLayer = ({ map, mapImages, onSubjectClick }) => {
 
   return <>
     <LabeledPatrolSymbolLayer
+      before={SKY_LAYER}
       filter={unclusteredFilter}
       id={UNCLUSTERED_LAYER_ID}
       onClick={onSubjectSymbolClick}
@@ -81,6 +82,7 @@ const SubjectsLayer = ({ map, mapImages, onSubjectClick }) => {
 
     {!!map.getSource(CLUSTERS_SOURCE_ID) && <>
       <LabeledPatrolSymbolLayer
+        before={SKY_LAYER}
         filter={clusteredFilter}
         id={SUBJECT_SYMBOLS}
         onClick={onSubjectSymbolClick}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -92,6 +92,7 @@ export const BREAKPOINTS = {
 
 export const LAYER_IDS = {
   TOPMOST_STYLE_LAYER: 'feature-separation-layer',
+  SKY_LAYER: 'sky',
   CLUSTER_BUFFER_POLYGON_LAYER_ID: 'cluster-buffer-polygon-layer',
   CLUSTERS_LAYER_ID: 'clusters-layer',
   FEATURE_FILLS: 'feature-fills',


### PR DESCRIPTION
https://allenai.atlassian.net/browse/ERA-7782
https://era-7782.pamdas.org/

using the `sky` layer, which is added after the `feature-separation-layer`, to assert that tile layers stay under all other rendered features.

@Alcoto95  to test, view the "Krauty" subject off the coast of West Seattle and ensure it and its tracks stack well against other layers when changing the base layer.