### PR TITLE
[ERA-7798] Fixing "blank page on logout error"

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -174,7 +174,7 @@ export const useMapLayer = (layerId, type, sourceId, paint, layout, config) => {
         try {
           map.getLayer(layerId) && map.removeLayer(layerId);
         } catch (error) {
-          console.warn('map unmount error', error);
+          // console.warn('map unmount error', error);
         }
       }
     };


### PR DESCRIPTION
[As per one of Mapbox's main developers' recommendations](https://github.com/mapbox/mapbox-gl-js/issues/7775), this PR simply prevents lifecycle mismatch based errors between React and MapboxGL from bubbling up and causing the app to crash when the map unmounts at logout. 

🤷 