### PR TITLE
ERA-7914: TIMESLIDER BUG

### DIFF
--- a/src/EventsLayer/index.js
+++ b/src/EventsLayer/index.js
@@ -293,7 +293,6 @@ const EventsLayer = ({
 
 EventsLayer.defaultProps = {
   bounceEventIDs: [],
-  enableClustering: true, // Old events-only-clustering implementation
   mapImages: {},
   onClusterClick: () => {},
   onEventClick: () => {},
@@ -301,7 +300,6 @@ EventsLayer.defaultProps = {
 
 EventsLayer.propTypes = {
   bounceEventIDs: PropTypes.string,
-  enableClustering: PropTypes.bool, // Old events-only-clustering implementation
   map: PropTypes.object.isRequired,
   mapImages: PropTypes.object,
   mapUserLayoutConfigByLayerId: PropTypes.func,

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -148,7 +148,6 @@ const Map = ({
   const lngLatFromParams = useRef();
 
   const timeSliderActive = timeSliderState.active;
-  const enableEventClustering = timeSliderActive ? false : true;
   const isDrawingEventGeometry = mapLocationSelection.isPickingLocation
     && mapLocationSelection.mode  === MAP_LOCATION_SELECTION_MODES.EVENT_GEOMETRY;
 
@@ -622,7 +621,6 @@ const Map = ({
       <ClustersLayer onShowClusterSelectPopup={onShowClusterSelectPopup} />
 
       <EventsLayer
-          enableClustering={enableEventClustering}
           mapImages={mapImages}
           onEventClick={onEventSymbolClick}
           onClusterClick={onClusterClick}
@@ -635,7 +633,7 @@ const Map = ({
 
       <UserCurrentLocationLayer onIconClick={onCurrentUserLocationClick} />
 
-      <StaticSensorsLayer isTimeSliderActive={timeSliderActive}/>
+      <StaticSensorsLayer />
 
       <MessageBadgeLayer onBadgeClick={onMessageBadgeClick} />
 

--- a/src/StaticSensorsLayer/index.js
+++ b/src/StaticSensorsLayer/index.js
@@ -1,5 +1,4 @@
 import React, { useContext, memo, useCallback, useEffect, useMemo, useState } from 'react';
-import PropTypes from 'prop-types';
 import { connect, useSelector } from 'react-redux';
 
 import { featureCollection } from '@turf/helpers';
@@ -38,7 +37,7 @@ const IMAGE_DATA = {
 
 const layerIds = [CLUSTERED_STATIC_SENSORS_LAYER, UNCLUSTERED_STATIC_SENSORS_LAYER];
 
-const StaticSensorsLayer = ({ isTimeSliderActive, showMapNames, simplifyMapDataOnZoom: { enabled: isDataInMapSimplified }, showPopup }) => {
+const StaticSensorsLayer = ({ showMapNames, simplifyMapDataOnZoom: { enabled: isDataInMapSimplified }, showPopup }) => {
   const map = useContext(MapContext);
   const showMapStaticSubjectsNames = showMapNames[STATIC_SENSOR]?.enabled ?? false;
   const getStaticSensorLayer = useCallback((event) => map.queryRenderedFeatures(event.point)[0], [map]);
@@ -54,8 +53,8 @@ const StaticSensorsLayer = ({ isTimeSliderActive, showMapNames, simplifyMapDataO
   [isDataInMapSimplified, showMapStaticSubjectsNames]);
 
   const dynamicLabelLayerLayoutProps = useMemo(() =>
-    calcDynamicLabelLayerLayoutStyles(isDataInMapSimplified, showMapStaticSubjectsNames, isTimeSliderActive),
-  [isDataInMapSimplified, showMapStaticSubjectsNames, isTimeSliderActive]);
+    calcDynamicLabelLayerLayoutStyles(isDataInMapSimplified, showMapStaticSubjectsNames),
+  [isDataInMapSimplified, showMapStaticSubjectsNames]);
 
 
   /* watch the source data for updates, and add potential new icon images to the map if necessary */
@@ -217,7 +216,3 @@ const mapStatetoProps = (state) => ({
 });
 
 export default connect(mapStatetoProps, { showPopup })(memo(StaticSensorsLayer));
-
-StaticSensorsLayer.propTypes = {
-  isTimeSliderActive: PropTypes.bool,
-};

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -172,7 +172,8 @@ const setUpSubjectGeoJson = subjects =>
       const key = 'last_position';
 
       return addPropsToGeoJsonByKey(subject, key)[key];
-    });
+    })
+    .filter((subject) => !!subject);
 
 const featureCollectionFromGeoJson = geojson_array => {
   const flattened = geojson_array.reduce((array, item) => {


### PR DESCRIPTION
Ticket: https://allenai.atlassian.net/browse/ERA-7914

**Root Cause**
As frontend team, we have been taking for granted that every subject returned by the backend in a `api/v1.0/subjects` call with a valid `bbox` query parameter will include the `last_position` property. The issue comes from the fact that a call like this (copied from a recreation of the issue):
![image](https://user-images.githubusercontent.com/11725028/194620860-252dcc99-c68b-45ed-86a4-440aaaa437c6.png)

Returned a list of subjects with a few of them without the `last_position` property:
![image](https://user-images.githubusercontent.com/11725028/194621624-01a7861e-617a-4e1f-b8a7-27b304e3018a.png)

I couldn't tell if this is actually a backend bug and they should always return subjects with `last_position` in these types of calls. But for now I send an trivial fix that filters out subjects that don't include the mentioned property.

**Evidence**
(Filtering out prod data)
<img width="1282" alt="image" src="https://user-images.githubusercontent.com/11725028/194621388-ab0a62d1-ed5a-4b2c-85e3-e9c13a4154cb.png">
