### PR TITLE
ERA-7818: International Date Line Issue

### DIFF
--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -51,7 +51,7 @@ import EarthRangerMap, { withMap } from '../EarthRangerMap';
 import EventsLayer from '../EventsLayer';
 import SubjectsLayer from '../SubjectsLayer';
 import StaticSensorsLayer from '../StaticSensorsLayer';
-import TrackLayers from '../TracksLayer';
+import TracksLayer from '../TracksLayer';
 import PatrolStartStopLayer from '../PatrolStartStopLayer';
 import FeatureLayer from '../FeatureLayer';
 import AnalyzerLayer from '../AnalyzersLayer';
@@ -672,7 +672,7 @@ const Map = ({
       {subjectHeatmapAvailable && <SubjectHeatLayer />}
       {showReportHeatmap && <ReportsHeatLayer />}
 
-      {subjectTracksVisible && <TrackLayers showTimepoints={showTrackTimepoints} onPointClick={onTimepointClick} />}
+      {subjectTracksVisible && <TracksLayer onPointClick={onTimepointClick} showTimepoints={showTrackTimepoints} />}
       {patrolTracksVisible && <PatrolStartStopLayer />}
 
       {patrolTracksVisible && <PatrolTracks onPointClick={onTimepointClick} />}

--- a/src/TracksLayer/track.js
+++ b/src/TracksLayer/track.js
@@ -78,17 +78,6 @@ const TrackLayer = ({ id, map, onPointClick, linePaint = {}, lineLayout = {}, tr
   useMapEventBinding('mouseleave', onSymbolMouseLeave, pointLayerId, showTimepoints);
 
   return null;
-  /* return <Fragment>
-
-    <Layer sourceId={sourceId} type='line' before={layerBefore}
-      paint={trackLinePaint} layout={trackLineLayout} id={layerId} {...rest} />
-
-    {showTimepoints && <DebouncedLayer sourceId={pointSourceId} type='symbol' before={layerBefore}
-      onMouseEnter={onSymbolMouseEnter}
-      onMouseLeave={onSymbolMouseLeave}
-      onClick={onPointClick} layout={timepointLayerLayout} paint={timepointLayerPaint} id={pointLayerId} {...rest} />}
-
-  </Fragment>; */
 };
 
 export default memo(TrackLayer);

--- a/src/ducks/tracks.js
+++ b/src/ducks/tracks.js
@@ -4,7 +4,12 @@ import isEqual from 'react-fast-compare';
 import globallyResettableReducer from '../reducers/global-resettable';
 import { API_URL } from '../constants';
 import { SOCKET_SUBJECT_STATUS } from './subjects';
-import { addSocketStatusUpdateToTrack, convertTrackFeatureCollectionToPoints, trackHasDataWithinTimeRange } from '../utils/tracks';
+import {
+  addSocketStatusUpdateToTrack,
+  convertTrackFeatureCollectionToPoints,
+  fixAntimeridianCrossing,
+  trackHasDataWithinTimeRange,
+} from '../utils/tracks';
 
 const TRACKS_API_URL = id => `${API_URL}subject/${id}/tracks/`;
 
@@ -45,10 +50,11 @@ export const fetchTracks = (dateParams, cancelToken = CancelToken.source(), ...i
       const responses = await Promise.all(ids.map(id => axios.get(TRACKS_API_URL(id), { params: dateParams, cancelToken: cancelToken.token })));
 
       const results = responses.reduce((accumulator, response, index) => {
-        const asPoints = convertTrackFeatureCollectionToPoints(response.data.data);
+        const trackFeatureCollection = fixAntimeridianCrossing(response.data.data);
+        const asPoints = convertTrackFeatureCollectionToPoints(trackFeatureCollection);
 
         accumulator[ids[index]] = {
-          track: response.data.data,
+          track: trackFeatureCollection,
           points: asPoints,
           fetchedDateRange: dateParams,
         };


### PR DESCRIPTION
Ticket: https://allenai.atlassian.net/browse/ERA-7818

**Root Cause**
This is a known (and common) issue happening with Mapbox, and maps in general. The map motor can't tell the direction of a line that crosses the "antimeridian".

**Solution**
A util function that iterates all the points in the fetched track feature collections in order to check if they should cross the antimeridian and do the proper calculations to show the line crossing it. It's important to notice that this fix has its own (extremely improbable) edge cases, where some lines longer than half of the world that were intended to not cross the antimeridian, will be rerouted to cross it.

**Evidence**
Subject with tracks crossing the antimeridian added by Dennis
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/11725028/194935821-d8187844-a2f2-401d-856f-bb48c65b238a.png">
