### PR TITLE
ERA-7818: International Date Line Issue

### DIFF
--- a/src/utils/tracks.js
+++ b/src/utils/tracks.js
@@ -23,21 +23,22 @@ export const fixAntimeridianCrossing = (trackFeatureCollection) => {
   trackFeatureCollection.features = trackFeatureCollection.features.map((feature) => {
     if (feature?.geometry?.type !== 'LineString') return feature;
 
-    feature.geometry.coordinates = feature.geometry.coordinates.map((coordinates, index) => {
+    feature.geometry.coordinates = feature.geometry.coordinates.reduce((accumulator, coordinates, index) => {
+      let fixedCoordinates = coordinates;
       if (index !== 0) {
-        const longitudeDifference = coordinates[0] - feature.geometry.coordinates[index - 1][0];
+        const longitudeDifference = coordinates[0] - accumulator.at(-1)[0];
 
         if (longitudeDifference > MAX_ABSOLUTE_LONGITUDE) {
-          return [coordinates[0] - WORLD_TOTAL_LONGITUDE, coordinates[1]];
+          fixedCoordinates = [coordinates[0] - WORLD_TOTAL_LONGITUDE, coordinates[1]];
         }
 
         if (longitudeDifference < -MAX_ABSOLUTE_LONGITUDE) {
-          return [coordinates[0] + WORLD_TOTAL_LONGITUDE, coordinates[1]];
+          fixedCoordinates = [coordinates[0] + WORLD_TOTAL_LONGITUDE, coordinates[1]];
         }
       }
 
-      return coordinates;
-    });
+      return [...accumulator, fixedCoordinates];
+    }, []);
 
     return feature;
   });


### PR DESCRIPTION
Env: https://era-7818.pamdas.org/

Note: We were having an issue with the iteration of observations where we were comparing against the non yet mutated array, so we fixed it using a reduce instead of a map and reading the accumulator.