### PR TITLE
ERA-7911: GPS update not working 

### DIFF
--- a/src/ReportForm/index.js
+++ b/src/ReportForm/index.js
@@ -117,6 +117,10 @@ const ReportForm = (props) => {
           ...originalReport.event_details,
           ...(!!changes && changes.event_details),
         },
+        location: {
+          ...originalReport.location,
+          ...(!!changes && changes.location),
+        }
       };
 
       /* reported_by requires the entire object. bring it over if it's changed and needs updating. */


### PR DESCRIPTION
Ticket: https://allenai.atlassian.net/browse/ERA-7911
Env: https://era-7911.pamdas.org

**Root Cause**
We have a mechanism to extract the differences between the original report and the updated one, so we know what values to send in the PATCH request when updating a report. However, when changing the location manually, we were extracting the difference of the latitude or longitude values without appending the other value, which was causing the request to be rejected by the backend.