### PR TITLE
HOTFIX [ERA-7950]

### DIFF
--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -22,7 +22,8 @@ const addItemPropsToFeatureByKey = (item, feature, key) => {
     properties: {
       ...clone,
       ...feature.properties,
-    }
+      id: clone?.id ?? feature?.properties?.id, // preserving original ID in case of integration interference
+    },
   };
 };
 


### PR DESCRIPTION
Preserving event ID rather than integration-defined incoming GeoJSON `id` prop for event store reference consistency