### PR TITLE
ERA-7709: Notes not being displayed when a report is created

### DIFF
--- a/src/ReportForm/index.js
+++ b/src/ReportForm/index.js
@@ -164,10 +164,14 @@ const ReportForm = (props) => {
             .map(contained => contained.related_event.id)
             .map(id => setEventState(id, toSubmit.state)));
         }
+
+        const createdReport = results.length ? results[0] : results;
+        fetchEvent(createdReport.data.data.id);
+
         return results;
       })
       .catch(handleSaveError);
-  }, [filesToUpload, handleSaveError, notesToAdd, onSaveSuccess, originalReport, report, reportIsNew, reportTracker, setEventState]);
+  }, [fetchEvent, filesToUpload, handleSaveError, notesToAdd, onSaveSuccess, originalReport, report, reportIsNew, reportTracker, setEventState]);
 
   useEffect(() => {
     if (!initialized) {


### PR DESCRIPTION
Ticket: https://allenai.atlassian.net/browse/ERA-7709
Env: https://era-7709.pamdas.org/login

**Root cause**
Real time API does not update an event after adding a note to it. The solution was to simply force a fetching of a created report after all saving actions.
This may also fix tickets https://allenai.atlassian.net/browse/ERA-7710 and https://allenai.atlassian.net/browse/ERA-7712 .