### PR TITLE
ERA-8314: Patrols not showing the controls to set its status, nor the tracking or jump to location

### DIFF
--- a/src/PatrolListItem/index.js
+++ b/src/PatrolListItem/index.js
@@ -220,18 +220,20 @@ const PatrolListItem = ({
   />;
 };
 
-PatrolListItem.defaulProps = {
+const PatrolListItemForwardRef = forwardRef(PatrolListItem);
+
+PatrolListItemForwardRef.defaultProps = {
   onClick: null,
   showControls: true,
   showStateTitle: true,
   showTitleDetails: true,
 };
 
-PatrolListItem.propTypes = {
+PatrolListItemForwardRef.propTypes = {
   onClick: PropTypes.func,
   showControls: PropTypes.bool,
   showStateTitle: PropTypes.bool,
   showTitleDetails: PropTypes.bool,
 };
 
-export default memo(forwardRef(PatrolListItem));
+export default memo(PatrolListItemForwardRef);


### PR DESCRIPTION
Ticket: https://allenai.atlassian.net/browse/ERA-8314

**Description**
The issue was that `showControls` prop in `PatrolListItem` should be `true` by default, but after the latest changes we accidentally broke that default value so it was getting a `undefined` which is read as falsy by JS. Two things were necessary to fix this:
1- Fix a typo in `defaultProps` so they are properly injected
2- Inject the defaultProps to the component after the forward ref, since it was bypassing the values

There's no env, I think this is trivial enough to be merged and tested in stage. I made sure locally that it works 🤠 