### PR TITLE
ERA-8314 (2): Fix controls click in patrol list item

### DIFF
--- a/src/PatrolListItem/index.js
+++ b/src/PatrolListItem/index.js
@@ -165,7 +165,7 @@ const PatrolListItem = ({
   }, [onSelfManagedStateChange, patrol, patrolState, setPatrolState]);
 
   const renderedControlsComponent = showControls
-    ? <>
+    ? <div className={styles.controls} onClick={(event) => event.stopPropagation()}>
       <StateDependentControls />
       <PatrolMenu
         data-testid={`patrol-list-item-kebab-menu-${patrol.id}`}
@@ -173,7 +173,7 @@ const PatrolListItem = ({
         onPatrolChange={onPatrolChange}
         patrol={patrol}
       />
-    </>
+    </div>
     : null;
 
   const renderedDateComponent = <div

--- a/src/PatrolListItem/styles.module.scss
+++ b/src/PatrolListItem/styles.module.scss
@@ -41,6 +41,10 @@
   @include unstyledButton;
 }
 
+.controls {
+  display: flex;
+}
+
 .statusInfo {
   display: flex;
   flex-flow: column;


### PR DESCRIPTION
**Description**
For a better UX we changed the `onClick` callback that opens the patrol from the title of the patrol to the entire `<li>`, causing the click event propagation to open the patrol when the controls were clicked. Naturally, a `event.stopPropagation()` fixed the issue.

Note: `FeedListItem` component adds a ´cursor: default´ overwriting the `cursor: pointer` from the `<li>`, resulting in a cursor not suggesting the clickability of the component if the user hovers the status section. We should fix that somehow, but I think that's out of the scope of this hotfix. I don't want to add noise.