### PR TITLE
fixing regression of antimeridian crossing issue with client-side track render transform

### DIFF
--- a/src/utils/tracks.js
+++ b/src/utils/tracks.js
@@ -20,34 +20,32 @@ const WORLD_TOTAL_LONGITUDE = 360;
 export const fixAntimeridianCrossing = (trackFeatureCollection) => {
   if (!trackFeatureCollection?.features?.length) return trackFeatureCollection;
 
-  return {
-    ...trackFeatureCollection,
-    features: trackFeatureCollection.features.map((feature) => {
-      if (feature?.geometry?.type !== 'LineString') return feature;
+  trackFeatureCollection.features = trackFeatureCollection.features.map((feature) => {
+    if (feature?.geometry?.type !== 'LineString') return feature;
 
-      return {
-        ...feature,
-        geometry: {
-          ...feature.geometry,
-          coordinates: feature.geometry.coordinates.map((coordinates, index) => {
-            if (index === 0) return coordinates;
+    feature.geometry.coordinates = feature.geometry.coordinates.reduce((accumulator, coordinates, index) => {
+      let fixedCoordinates = coordinates;
+      if (index !== 0) {
+        const longitudeDifference = coordinates[0] - accumulator.at(-1)[0];
 
-            const longitudeDifference = coordinates[0] - feature.geometry.coordinates[index - 1][0];
-
-            if (longitudeDifference > MAX_ABSOLUTE_LONGITUDE) {
-              return [coordinates[0] - WORLD_TOTAL_LONGITUDE, coordinates[1]];
-            }
-
-            if (longitudeDifference < -MAX_ABSOLUTE_LONGITUDE) {
-              return [coordinates[0] + WORLD_TOTAL_LONGITUDE, coordinates[1]];
-            }
-
-            return coordinates;
-          }, [])
+        if (longitudeDifference > MAX_ABSOLUTE_LONGITUDE) {
+          fixedCoordinates = [coordinates[0] - WORLD_TOTAL_LONGITUDE, coordinates[1]];
         }
-      };
-    }),
-  };
+
+        if (longitudeDifference < -MAX_ABSOLUTE_LONGITUDE) {
+          fixedCoordinates = [coordinates[0] + WORLD_TOTAL_LONGITUDE, coordinates[1]];
+        }
+      }
+
+      accumulator.push(fixedCoordinates);
+
+      return accumulator;
+    }, []);
+
+    return feature;
+  });
+
+  return trackFeatureCollection;
 };
 
 export const convertTrackFeatureCollectionToPoints = feature => {


### PR DESCRIPTION
### What does this PR do?
- Fixes a code regression that I introduced 🥴 which is supposed to correct the rendered track for subjects crossing the antemeridian line

### Relevant link(s)
* Tracking tickets: [ERA-7818](https://allenai.atlassian.net/browse/ERA-ERA-7818)
* Let's just test this in develop since it's such a small change @Alcoto95 is that ok?

### Where / how to start reviewing (optional)
- Look at any subject crossing the Antemeridian
- - In current code, it draws a track line all the way around the world
- - This fix allows the track to be rendered as originally conveyed

### Any background context you want to provide(if applicable)
- Important for our partners in places like New Zealand


[ERA-7818]: https://allenai.atlassian.net/browse/ERA-7818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ