### PR TITLE
ERA-8327: Updating latitude or longitude (not both) sends only the modified property on the location object

### DIFF
--- a/src/ReportManager/ReportDetailView/index.js
+++ b/src/ReportManager/ReportDetailView/index.js
@@ -202,29 +202,33 @@ const ReportDetailView = ({
     let reportToSubmit;
     if (isNewReport) {
       reportToSubmit = reportForm;
+
+      if (reportToSubmit.hasOwnProperty('location') && !reportToSubmit.location) {
+        reportToSubmit.location = null;
+      }
     } else {
       reportToSubmit = {
         ...reportChanges,
         id: reportForm.id,
         event_details: { ...originalReport.event_details, ...reportChanges.event_details },
+        location: { ...originalReport.location, ...reportChanges.location }
       };
 
-      /* reported_by requires the entire object. bring it over if it's changed and needs updating. */
-      if (reportChanges.reported_by) {
-        reportToSubmit.reported_by = { ...reportForm.reported_by, ...reportChanges.reported_by };
+      if (reportChanges.hasOwnProperty('location') && !reportChanges.location) {
+        reportToSubmit.location = null;
       }
-      /* the API doesn't handle inline PATCHes of notes reliably, so if a note change is detected just bring the whole Array over */
+
+      if (reportChanges.hasOwnProperty('reported_by')) {
+        reportToSubmit.reported_by = reportForm.reported_by;
+      }
+
       if (reportChanges.notes) {
         reportToSubmit.notes = reportForm.notes;
       }
-      /* the API doesn't handle PATCHes of `contains` prop for incidents */
+
       if (reportToSubmit.contains) {
         delete reportToSubmit.contains;
       }
-    }
-
-    if (reportToSubmit.hasOwnProperty('location') && !reportToSubmit.location) {
-      reportToSubmit.location = null;
     }
 
     const newNotes = notesToAdd.reduce(
@@ -244,7 +248,8 @@ const ReportDetailView = ({
     notesToAdd,
     onSaveError,
     onSaveSuccess,
-    originalReport?.event_details,
+    originalReport.event_details,
+    originalReport.location,
     reportChanges,
     reportForm,
     reportTracker,


### PR DESCRIPTION
### What does this PR do?
Brings the code fix that we added in the modals implementation of the report detail view for modifications on latitude / longitude values of an existing report to the new UI.

### Relevant link(s)
Ticket: https://allenai.atlassian.net/browse/ERA-8327
Env: https://era-8327.pamdas.org

### Any background context you want to provide(if applicable)
This bug was reported previously and we fixed it but just in the modals implementation. We just had to bring the changes to the new UI. Old related tickets: 
https://allenai.atlassian.net/browse/ERA-8184
https://allenai.atlassian.net/browse/ERA-7911
