### PR TITLE
ERA-8327: Updating latitude or longitude (not both) sends only the modified property on the location object [2]

### DIFF
--- a/src/ReportManager/ReportDetailView/index.js
+++ b/src/ReportManager/ReportDetailView/index.js
@@ -211,11 +211,13 @@ const ReportDetailView = ({
         ...reportChanges,
         id: reportForm.id,
         event_details: { ...originalReport.event_details, ...reportChanges.event_details },
-        location: { ...originalReport.location, ...reportChanges.location }
+        location: originalReport.location,
       };
 
-      if (reportChanges.hasOwnProperty('location') && !reportChanges.location) {
-        reportToSubmit.location = null;
+      if (reportChanges.hasOwnProperty('location')) {
+        reportToSubmit.location = !!reportChanges.location
+          ? { ...originalReport.location, ...reportChanges.location }
+          : null;
       }
 
       if (reportChanges.hasOwnProperty('reported_by')) {


### PR DESCRIPTION
### What does this PR do?
Fixes a bug in logic to set a `null` location.

### Relevant link(s)
Ticket: https://allenai.atlassian.net/browse/ERA-8327
Env: https://era-8327.pamdas.org

### Any background context you want to provide(if applicable)
Previously, we fixed the issue of changing the value of latitude / longitude in an existing report with a location. However, the solution was erroneously injecting always an object in the `location` field when saving an existing report. The issue showed up when updating an existing report that didn't have a location without setting a location yet). Naturally, that would happen with incidents every single time. 
