### PR TITLE
ERA-8287: Fixing side effects of date/time fields styles when viewing in ReportSummary

### DIFF
--- a/src/ReportFormSummary/styles.module.scss
+++ b/src/ReportFormSummary/styles.module.scss
@@ -8,6 +8,7 @@
         border: none;
         padding: 0;
         height: auto;
+        background: transparent;
       }
     }
 
@@ -57,7 +58,7 @@
     button,
     input,
     [class*=control] {
-      background-color: transparent;
+      background-color: transparent !important;
       border: transparent;
       font-size: 1rem;
       height: 1.5rem !important;


### PR DESCRIPTION
### What does this PR do?
There was a side effect of the recents changes made to the Date/Time picker component, both field types were showed as 'disabled' within the ReportSummary view   

### How does it look
before:
![Screen Shot 2023-02-27 at 16 12 10](https://user-images.githubusercontent.com/20525031/221698988-f321df19-874b-4b45-9d07-f4907f651e43.png)

Now:
![Screen Shot 2023-02-27 at 16 12 38](https://user-images.githubusercontent.com/20525031/221699061-049ed67c-3e37-448e-a17a-ee8d0404fa86.png)



### Relevant link(s)
Ticket: https://allenai.atlassian.net/browse/ERA-8287
Env: https://era-8287.pamdas.org/

