### PR TITLE
removing antiquated+slow fontawesome dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "buildbranch": "generated_by_build",
   "buildnum": "also_generated_by_build",
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.26",
-    "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@rjsf/bootstrap-4": "^5.0.0-beta.13",
     "@rjsf/core": "^5.0.0-beta.13",
     "@rjsf/utils": "^5.0.0-beta.13",

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,6 @@ import { Provider } from 'react-redux';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { persistStore } from 'redux-persist';
 import { PersistGate } from 'redux-persist/integration/react';
-import { library, dom } from '@fortawesome/fontawesome-svg-core';
-
-import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
-import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
-import { faArrowUp } from '@fortawesome/free-solid-svg-icons/faArrowUp';
-import { faArrowDown } from '@fortawesome/free-solid-svg-icons/faArrowDown';
 
 import JiraSupportWidget from './JiraSupportWidget';
 import GeoLocationWatcher from './GeoLocationWatcher';
@@ -43,10 +37,6 @@ const Login = lazy(() => import('./Login'));
 const AppWithTracker = withTracker(App);
 const EulaPageWithTracker = withTracker(EulaPage);
 const LoginWithTracker = withTracker(Login);
-
-// registering icons from fontawesome as needed
-library.add(faPlus, faTimes, faArrowUp, faArrowDown);
-dom.watch();
 
 // Initialize ReactGA with const from .env
 ReactGA.initialize(REACT_APP_GA_TRACKING_ID, { testMode: process.env.NODE_ENV === 'test' ? true : false });


### PR DESCRIPTION
### What does this PR do?
- This removes our zombie dependency on fontawesome from the app, and speeds up render performance considerably in the process. 

As seen in the screenshot below, for DOM-intensive operations (in this example, filtering the Map Layers list), the `querySelectorAll` operation in the mutation observer inside of fontawesome's library takes **more than half the total time** for a UI-locking change. Removing this helps significantly.

Even more, we no longer use a version of Bootstrap for our report forms which relies on fontawesome...so this code is totally useless. It's just cruft dragging around. Yikes.

<img width="428" alt="Screen Shot 2023-03-14 at 8 16 06 AM" src="https://user-images.githubusercontent.com/38018017/225047762-c2ff9eff-614d-423b-aafd-7d6b86bef96f.png">

### How does it look
- N/A, just a speedier web app.

### Relevant link(s)
* https://allenai.atlassian.net/browse/ERA-8399

### Where / how to start reviewing (optional)
- It's a tiny change

### Any background context you want to provide(if applicable)
@AlanCalvillo @Alcoto95 can we just review this in develop since it's such a small but mighty change?
