### PR TITLE
Restoring "save and resolve" to the report details view

### DIFF
--- a/src/ReportManager/ReportDetailView/index.js
+++ b/src/ReportManager/ReportDetailView/index.js
@@ -1,5 +1,7 @@
 import React, { memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import Button from 'react-bootstrap/Button';
+import Dropdown from 'react-bootstrap/Dropdown';
+import SplitButton from 'react-bootstrap/SplitButton';
 import debounce from 'lodash/debounce';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
@@ -47,6 +49,8 @@ import activitySectionStyles from '../ActivitySection/styles.module.scss';
 const CLEAR_ERRORS_TIMEOUT = 7000;
 const FETCH_EVENT_DEBOUNCE_TIME = 300;
 const QUICK_LINKS_SCROLL_TOP_OFFSET = 20;
+
+const ACTIVE_STATES = ['active', 'new'];
 
 const ReportDetailView = ({
   className,
@@ -96,6 +100,7 @@ const ReportDetailView = ({
   } = formProps || {};
 
   const originalReport = isNewReport ? newReport : eventStore[reportId];
+  const isActive = ACTIVE_STATES.includes(originalReport?.state);
 
   const isCollection = !!reportForm?.is_collection;
   const isCollectionChild = eventBelongsToCollection(reportForm);
@@ -442,6 +447,13 @@ const ReportDetailView = ({
     }
   }, [onSaveReport, reportForm?.is_collection, reportTracker]);
 
+  const onClickSaveAndToggleStateButton = useCallback(() => {
+    setReportForm({ ...reportForm, state: isActive ? 'resolved' : 'active' });
+    setTimeout(() => {
+      onClickSaveButton();
+    });
+  }, [isActive, onClickSaveButton, reportForm]);
+
   const trackDiscard = useCallback(() => {
     reportTracker.track(`Discard changes to ${isNewReport ? 'new' : 'existing'} report`);
   }, [isNewReport, reportTracker]);
@@ -594,13 +606,13 @@ const ReportDetailView = ({
                 Cancel
               </Button>
 
-              <Button
-                  className={styles.saveButton}
-                  onClick={onClickSaveButton}
-                  type="button"
-                >
-                Save
-              </Button>
+              <SplitButton className={styles.saveButton} drop='down' variant='primary' type='button' title='Save' onClick={onClickSaveButton}>
+                <Dropdown.Item data-testid='report-details-resolve-btn-toggle'>
+                  <Button  type='button' variant='primary' onClick={onClickSaveAndToggleStateButton}>
+                    {isActive ? 'Save and resolve' : 'Save and reopen'}
+                  </Button>
+                </Dropdown.Item>
+              </SplitButton>
             </div>
           </div>
         </div>

--- a/src/ReportManager/ReportDetailView/index.test.js
+++ b/src/ReportManager/ReportDetailView/index.test.js
@@ -84,6 +84,7 @@ describe('ReportManager - ReportDetailView', () => {
     useNavigateMock,
     Wrapper,
     renderWithWrapper,
+    state,
     store;
 
   beforeEach(() => {
@@ -105,7 +106,7 @@ describe('ReportManager - ReportDetailView', () => {
 
     map = createMapMock();
 
-    Wrapper = ({ children }) => <Provider store={mockStore(store)}> {/* eslint-disable-line react/display-name */}
+    Wrapper = ({ children }) => <Provider store={store}> {/* eslint-disable-line react/display-name */}
       <NavigationWrapper>
         <MapContext.Provider value={map}>
           <TrackerContext.Provider value={{ track: jest.fn() }}>
@@ -115,7 +116,7 @@ describe('ReportManager - ReportDetailView', () => {
       </NavigationWrapper>
     </Provider>;
 
-    store = {
+    state = {
       data: {
         subjectStore: {},
         eventStore: { 456: mockReport },
@@ -132,6 +133,8 @@ describe('ReportManager - ReportDetailView', () => {
         userPreferences: { gpsFormat: GPS_FORMATS.DEG },
       },
     };
+
+    store = mockStore(() => state);
 
     renderWithWrapper = (Component, wrapper = Wrapper) => render(Component, { wrapper });
   });
@@ -356,7 +359,7 @@ describe('ReportManager - ReportDetailView', () => {
     AddReport.mockImplementation(AddReportMock);
 
 
-    store.data.eventStore = { initial: mockReport };
+    state.data.eventStore = { initial: mockReport };
 
     renderWithWrapper(
       <ReportDetailView isNewReport={false} onAddReport={onAddReport} reportId="initial" />
@@ -387,7 +390,7 @@ describe('ReportManager - ReportDetailView', () => {
     fetchEventMock = jest.fn(() => () => initialReport[0]);
     fetchEvent.mockImplementation(fetchEventMock);
 
-    store.data.eventStore = { initial: { ...mockReport, id: 'initial', is_collection: true } };
+    state.data.eventStore = { initial: { ...mockReport, id: 'initial', is_collection: true } };
 
     renderWithWrapper(
       <ReportDetailView isNewReport={false} reportId="initial" />
@@ -604,7 +607,7 @@ describe('ReportManager - ReportDetailView', () => {
     expect((await screen.findAllByText('note.svg'))).toHaveLength(2);
   });
 
-  test('does not display neither the activity section nor its anchor if there are no items to show', async () => {
+  test('does not display the activity section nor its anchor if there are no items to show', async () => {
     renderWithWrapper(
       <ReportDetailView
             isNewReport
@@ -672,7 +675,7 @@ describe('ReportManager - ReportDetailView', () => {
   });
 
   test('does not show add report button if report belongs to a collection', async () => {
-    store.data.eventStore = { 456: { ...mockReport, is_contained_in: [{ related_event: { id: '987' } }] } };
+    state.data.eventStore = { 456: { ...mockReport, is_contained_in: [{ related_event: { id: '987' } }] } };
 
     renderWithWrapper(
       <ReportDetailView isNewReport={false} reportId="456" />
@@ -682,7 +685,7 @@ describe('ReportManager - ReportDetailView', () => {
   });
 
   test('does not show add report button if report belongs to patrol', async () => {
-    store.data.eventStore = { 456: { ...mockReport, patrols: ['123'] } };
+    state.data.eventStore = { 456: { ...mockReport, patrols: ['123'] } };
 
     cleanup();
     renderWithWrapper(
@@ -711,6 +714,45 @@ describe('ReportManager - ReportDetailView', () => {
     );
 
     expect((await screen.findByTestId('reportManager-addReportButton'))).toBeDefined();
+  });
+
+
+  test('clicking "save and resolve" to update both the state and form data', async () => {
+    executeSaveActionsMock.mockImplementation(jest.requireActual('../../utils/save').executeSaveActions);
+    const onSaveSuccess = jest.fn();
+
+    renderWithWrapper(
+      <ReportDetailView
+          formProps={{ onSaveSuccess }}
+          isNewReport
+          newReportTypeId="6c90e5f5-ae8e-4e7f-a8dd-26e5d2909a74"
+          reportId="456"
+        />
+    );
+
+    const titleTextBox = await screen.findByTestId('reportManager-header-title');
+    userEvent.type(titleTextBox, '2');
+    userEvent.tab();
+
+
+    const saveButtonGroup = await screen.findByRole('group');
+    expect(saveButtonGroup).toHaveTextContent('Save');
+
+    const saveBtnDropdownToggle = saveButtonGroup.querySelector('.dropdown-toggle');
+    saveBtnDropdownToggle.click();
+
+    const saveAndResolveBtn = await screen.findByText('Save and resolve');
+
+    saveAndResolveBtn.click();
+
+    await waitFor(() => {
+      expect(createEventMock).toHaveBeenCalledTimes(1);
+
+      const eventCreated = createEventMock.mock.calls[0][0];
+
+      expect(eventCreated.state).toBe('resolved');
+      expect(eventCreated.title).toBe('2ccident');
+    });
   });
 
   describe('the warning prompt', () => {


### PR DESCRIPTION
### What does this PR do?
- This adds "save and resolve"/"save and reopen" back to the UI for report details.

### How does it look
![save-and-resolve-demo](https://user-images.githubusercontent.com/38018017/226995983-4fecb33c-4064-4a65-b6a3-fe97d22872c3.gif)


### Relevant link(s)
* https://allenai.atlassian.net/browse/ERA-8279
* https://era-8279.pamdas.org/

### Any background context you want to provide(if applicable)
- This was consistently desired by users during UX feedback sessions.
