### PR TITLE
[ERA-8476] - Updating incident child state when incident state changes

### DIFF
--- a/src/ReportManager/ReportDetailView/index.js
+++ b/src/ReportManager/ReportDetailView/index.js
@@ -254,11 +254,20 @@ const ReportDetailView = ({
     const newAttachments = attachmentsToAdd.map((attachmentToAdd) => attachmentToAdd.file);
     const saveActions = generateSaveActionsForReportLikeObject(reportToSubmit, 'report', newNotes, newAttachments);
     return executeSaveActions(saveActions)
+      .then((results) => {
+        if (reportForm.is_collection && reportChanges.state) {
+          return Promise.all((reportForm?.contains ?? [])
+            .map(contained => contained.related_event.id)
+            .map(id => dispatch(setEventState(id, reportChanges.state))));
+        }
+        return results;
+      })
       .then(onSaveSuccess(reportToSubmit, shouldRedirectAfterSave ? `/${TAB_KEYS.REPORTS}` : undefined))
       .catch(onSaveError)
       .finally(() => setIsSaving(false));
   }, [
     attachmentsToAdd,
+    dispatch,
     isNewReport,
     isSaving,
     notesToAdd,


### PR DESCRIPTION
### What does this PR do?
- Migrates existing logic from the prior report form into the new UI, to ensure an incident's children are resolved/reopened when that incident is resolved/reopened

### How does it look
-  N/A

### Relevant link(s)
* https://allenai.atlassian.net/browse/ERA-8476


### Any background context you want to provide(if applicable)
- Nice catch @AlanCalvillo  😬 
