### PR TITLE
ERA-8472: Patrol feed reloads when navigating state away from patrol detail view

### DIFF
--- a/.env
+++ b/.env
@@ -10,4 +10,4 @@ REACT_APP_BASE_MAP_STYLES='mapbox://styles/vjoelm/ciobuir0n0061bdnj1c54oakh?opti
 
 # Feature flags
 REACT_APP_ENABLE_PATROL_NEW_UI=true
-REACT_APP_ENABLE_REPORT_NEW_UI=true
+REACT_APP_ENABLE_REPORT_NEW_UI=false

--- a/src/SideBar/index.js
+++ b/src/SideBar/index.js
@@ -13,7 +13,8 @@ import { getCurrentIdFromURL, getCurrentTabFromURL } from '../utils/navigation';
 import { MapContext } from '../App';
 import { SocketContext } from '../withSocketConnection';
 import { useSystemConfigFlag, usePermissions } from '../hooks';
-import useFetchFeed from './useFetchFeed';
+import useFetchPatrolsFeed from './useFetchPatrolsFeed';
+import useFetchReportsFeed from './useFetchReportsFeed';
 import useNavigate from '../hooks/useNavigate';
 
 import AddReport, { STORAGE_KEY as ADD_BUTTON_STORAGE_KEY } from '../AddReport';
@@ -42,9 +43,10 @@ const SideBar = () => {
 
   const sideBar = useSelector((state) => state.view.sideBar);
 
+  const patrolsFeed = useFetchPatrolsFeed();
+  const reportsFeed = useFetchReportsFeed();
   const patrolFlagEnabled = useSystemConfigFlag(SYSTEM_CONFIG_FLAGS.PATROL_MANAGEMENT);
   const hasPatrolViewPermissions = usePermissions(PERMISSION_KEYS.PATROLS, PERMISSIONS.READ);
-  const { patrolsFetchFeed, reportsFetchFeed } = useFetchFeed();
 
   const map = useContext(MapContext);
   const socket = useContext(SocketContext);
@@ -183,18 +185,18 @@ const SideBar = () => {
 
               <Route path="reports">
                 <Route index element={<ReportsFeedTab
-                  feedSort={reportsFetchFeed.feedSort}
-                  loadFeedEvents={reportsFetchFeed.loadFeedEvents}
-                  loadingEventFeed={reportsFetchFeed.loadingEventFeed}
-                  setFeedSort={reportsFetchFeed.setFeedSort}
-                  shouldExcludeContained={reportsFetchFeed.shouldExcludeContained}
+                  feedSort={reportsFeed.feedSort}
+                  loadFeedEvents={reportsFeed.loadFeedEvents}
+                  loadingEventFeed={reportsFeed.loadingEventFeed}
+                  setFeedSort={reportsFeed.setFeedSort}
+                  shouldExcludeContained={reportsFeed.shouldExcludeContained}
                 />} />
 
                 <Route path=":id/*" element={<ReportManager />} />
               </Route>
 
               <Route path="patrols">
-                <Route index element={<PatrolsFeedTab loadingPatrolsFeed={patrolsFetchFeed.loadingPatrolsFeed} />} />
+                <Route index element={<PatrolsFeedTab loadingPatrolsFeed={patrolsFeed.loadingPatrolsFeed} />} />
 
                 <Route path=":id/*" element={<PatrolDetailView />} />
               </Route>

--- a/src/SideBar/useFetchPatrolsFeed/index.js
+++ b/src/SideBar/useFetchPatrolsFeed/index.js
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import cloneDeep from 'lodash/cloneDeep';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { fetchPatrols } from '../../ducks/patrols';
+
+const useFetchPatrolsFeed = () => {
+  const dispatch = useDispatch();
+
+  const patrolFilter = useSelector((state) => state.data.patrolFilter);
+
+  const patrolFetchRef = useRef(null);
+
+  const [loadingPatrolsFeed, setLoadingPatrolsFeed] = useState(true);
+
+  const patrolFilterParams = useMemo(() => {
+    const filterParams = cloneDeep(patrolFilter);
+    delete filterParams.filter.overlap;
+
+    return filterParams;
+  }, [patrolFilter]);
+
+  const fetchAndLoadPatrolData = useCallback(() => {
+    patrolFetchRef.current = dispatch(fetchPatrols());
+
+    patrolFetchRef.current.request.finally(() => {
+      setLoadingPatrolsFeed(false);
+      patrolFetchRef.current = null;
+    });
+  }, [dispatch]);
+
+  useEffect(() => {
+    setLoadingPatrolsFeed(true);
+    fetchAndLoadPatrolData();
+
+    return () => {
+      const priorRequestCancelToken = patrolFetchRef?.current?.cancelToken;
+
+      if (priorRequestCancelToken) {
+        priorRequestCancelToken.cancel();
+      }
+    };
+  }, [fetchAndLoadPatrolData, patrolFilterParams]);
+
+  return { loadingPatrolsFeed };
+};
+
+export default useFetchPatrolsFeed;

--- a/src/SideBar/useFetchPatrolsFeed/index.test.js
+++ b/src/SideBar/useFetchPatrolsFeed/index.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { renderHook } from '@testing-library/react-hooks';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { waitFor } from '@testing-library/react';
+
+import { INITIAL_FILTER_STATE as INITIAL_PATROL_FILTER_STATE } from '../../ducks/patrol-filter';
+import { mockStore } from '../../__test-helpers/MockStore';
+import patrols from '../../__test-helpers/fixtures/patrols';
+import { PATROLS_API_URL } from '../../ducks/patrols';
+import useFetchPatrolsFeed from '.';
+
+const patrolFeedResponse = { data: { results: patrols, next: null, count: patrols.length, page: 1 } };
+
+const server = setupServer(
+  rest.get(PATROLS_API_URL, (req, res, ctx) => res(ctx.json(patrolFeedResponse))),
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('useFetchPatrolsFeed', () => {
+  let capturedRequestURLs, store;
+
+  const logRequest = (req) => {
+    capturedRequestURLs = [...capturedRequestURLs, req.url.toString()];
+  };
+
+  beforeEach(() => {
+    capturedRequestURLs = [];
+    store = { data: { patrolFilter: INITIAL_PATROL_FILTER_STATE }, view: {} };
+  });
+
+  server.events.on('request:match', (req) => {
+    logRequest(req);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    server.events.removeListener('request:match', logRequest);
+  });
+
+  test('returns the patrolsFetchFeed properties and methods', async () => {
+    const wrapper = ({ children }) => <Provider store={mockStore(store)}>{children}</Provider>;
+    const { result } = renderHook(() => useFetchPatrolsFeed(), { wrapper });
+
+    const patrolsFetchFeed = result.current;
+
+    expect(patrolsFetchFeed.loadingPatrolsFeed).toBe(true);
+  });
+
+
+  test('loads the patrols feed', async () => {
+    const wrapper = ({ children }) => <Provider store={mockStore(store)}>{children}</Provider>;
+    renderHook(() => useFetchPatrolsFeed(), { wrapper });
+
+    await waitFor(() => {
+      expect(capturedRequestURLs.find(item => item.includes(PATROLS_API_URL))).toBeDefined();
+    });
+  });
+});

--- a/src/SideBar/useFetchReportsFeed/index.js
+++ b/src/SideBar/useFetchReportsFeed/index.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import debounce from 'lodash/debounce';
 import isEqual from 'react-fast-compare';
@@ -7,16 +7,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import { calcEventFilterForRequest, DEFAULT_EVENT_SORT } from '../../utils/event-filter';
 import { calcLocationParamStringForUserLocationCoords } from '../../utils/location';
 import { fetchEventFeed, fetchEventFeedCancelToken } from '../../ducks/events';
-import { fetchPatrols } from '../../ducks/patrols';
 import { getFeedEvents } from '../../selectors';
 import { INITIAL_FILTER_STATE } from '../../ducks/event-filter';
 import { objectToParamString } from '../../utils/query';
 import { userIsGeoPermissionRestricted } from '../../utils/geo-perms';
 
-const useFetchFeed = () => {
+const useFetchReportsFeed = () => {
   const dispatch = useDispatch();
-
-  // Reports feed
 
   const eventFilter = useSelector((state) => state.data.eventFilter);
   const events = useSelector((state) => getFeedEvents(state));
@@ -82,54 +79,13 @@ const useFetchFeed = () => {
     }
   }, [events.error, loadingEventFeed]);
 
-  const reportsFetchFeed = {
+  return {
     feedSort,
     loadFeedEvents,
     loadingEventFeed,
     setFeedSort,
     shouldExcludeContained,
   };
-
-  // Patrols feed
-
-  const patrolFilter = useSelector((state) => state.data.patrolFilter);
-
-  const patrolFetchRef = useRef(null);
-
-  const [loadingPatrolsFeed, setLoadingPatrolsFeed] = useState(true);
-
-  const patrolFilterParams = useMemo(() => {
-    const filterParams = cloneDeep(patrolFilter);
-    delete filterParams.filter.overlap;
-
-    return filterParams;
-  }, [patrolFilter]);
-
-  const fetchAndLoadPatrolData = useCallback(() => {
-    patrolFetchRef.current = dispatch(fetchPatrols());
-
-    patrolFetchRef.current.request.finally(() => {
-      setLoadingPatrolsFeed(false);
-      patrolFetchRef.current = null;
-    });
-  }, [dispatch]);
-
-  useEffect(() => {
-    setLoadingPatrolsFeed(true);
-    fetchAndLoadPatrolData();
-
-    return () => {
-      const priorRequestCancelToken = patrolFetchRef?.current?.cancelToken;
-
-      if (priorRequestCancelToken) {
-        priorRequestCancelToken.cancel();
-      }
-    };
-  }, [fetchAndLoadPatrolData, patrolFilterParams]);
-
-  const patrolsFetchFeed = { loadingPatrolsFeed };
-
-  return { patrolsFetchFeed, reportsFetchFeed };
 };
 
-export default useFetchFeed;
+export default useFetchReportsFeed;

--- a/src/SideBar/useFetchReportsFeed/index.test.js
+++ b/src/SideBar/useFetchReportsFeed/index.test.js
@@ -9,19 +9,14 @@ import { DEFAULT_EVENT_SORT } from '../../utils/event-filter';
 import { events, eventWithPoint } from '../../__test-helpers/fixtures/events';
 import { EVENTS_API_URL, EVENT_API_URL } from '../../ducks/events';
 import { INITIAL_FILTER_STATE as INITIAL_EVENT_FILTER_STATE } from '../../ducks/event-filter';
-import { INITIAL_FILTER_STATE as INITIAL_PATROL_FILTER_STATE } from '../../ducks/patrol-filter';
 import { mockStore } from '../../__test-helpers/MockStore';
-import patrols from '../../__test-helpers/fixtures/patrols';
-import { PATROLS_API_URL } from '../../ducks/patrols';
 import useFetchReportsFeed from '.';
 
 const eventFeedResponse = { data: { results: events, next: null, count: events.length, page: 1 } };
-const patrolFeedResponse = { data: { results: patrols, next: null, count: patrols.length, page: 1 } };
 
 const server = setupServer(
   rest.get(EVENTS_API_URL, (req, res, ctx) => res(ctx.json(eventFeedResponse))),
   rest.get(`${EVENT_API_URL}:id`, (req, res, ctx) => res(ctx.json({ data: eventWithPoint }))),
-  rest.get(PATROLS_API_URL, (req, res, ctx) => res(ctx.json(patrolFeedResponse))),
 );
 
 beforeAll(() => server.listen());
@@ -44,7 +39,6 @@ describe('useFetchReportsFeed', () => {
           results: [],
         },
         eventStore: {},
-        patrolFilter: INITIAL_PATROL_FILTER_STATE,
         user: {
           permissions: {
             '_geographic_distance': {},
@@ -75,7 +69,7 @@ describe('useFetchReportsFeed', () => {
     const wrapper = ({ children }) => <Provider store={mockStore(store)}>{children}</Provider>;
     const { result } = renderHook(() => useFetchReportsFeed(), { wrapper });
 
-    const { reportsFetchFeed } = result.current;
+    const reportsFetchFeed = result.current;
 
     expect(reportsFetchFeed.feedSort).toBe(DEFAULT_EVENT_SORT);
     expect(typeof reportsFetchFeed.loadFeedEvents).toBe('function');
@@ -101,25 +95,6 @@ describe('useFetchReportsFeed', () => {
     await waitFor(() => {
       expect(capturedRequestURLs.find(item => item.includes(EVENTS_API_URL))).toBeDefined();
       expect(capturedRequestURLs.find(item => item.includes(EVENTS_API_URL))).not.toContain('location');
-    });
-  });
-
-  test('returns the patrolsFetchFeed properties and methods', async () => {
-    const wrapper = ({ children }) => <Provider store={mockStore(store)}>{children}</Provider>;
-    const { result } = renderHook(() => useFetchReportsFeed(), { wrapper });
-
-    const { patrolsFetchFeed } = result.current;
-
-    expect(patrolsFetchFeed.loadingPatrolsFeed).toBe(true);
-  });
-
-
-  test('loads the patrols feed', async () => {
-    const wrapper = ({ children }) => <Provider store={mockStore(store)}>{children}</Provider>;
-    renderHook(() => useFetchReportsFeed(), { wrapper });
-
-    await waitFor(() => {
-      expect(capturedRequestURLs.find(item => item.includes(PATROLS_API_URL))).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Lifts up the patrol feed fetching responsibility to the `SideBar` so we don't load that data every time the `PatrolsFeedTab` component is mounted.

### How does it look
You should be able to open the patrol feed, see the patrols in there, and navigate back and forward without seeing the feed being reloaded.

### Relevant link(s)
* [ERA-8472](https://allenai.atlassian.net/browse/ERA-8472)
* [Env](https://era-8472.pamdas.org/)

### Any background context you want to provide(if applicable)
This fix was already applied to the reports feed, so I followed a very similar approach, even renaming the `useReportFetchFeed` to `useFetchFeed` so we can handle both feeds in a single hook.


[ERA-8472]: https://allenai.atlassian.net/browse/ERA-8472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ