### PR TITLE
ERA-8361: New UI: Notes and attachments not appearing in real time while creating an event

### DIFF
--- a/src/ReportManager/ReportDetailView/index.js
+++ b/src/ReportManager/ReportDetailView/index.js
@@ -213,7 +213,7 @@ const ReportDetailView = ({
 
   const onClearErrors = useCallback(() => setSaveError(null), []);
 
-  const onSaveSuccess = useCallback((reportToSubmit, redirectTo, shouldFetchReport) => (results) => {
+  const onSaveSuccess = useCallback((reportToSubmit, redirectTo) => (results) => {
     onSaveSuccessCallback?.(results);
 
     if (isAddedReport) {
@@ -226,11 +226,6 @@ const ReportDetailView = ({
       return Promise.all(reportToSubmit.contains
         .map(contained => contained.related_event.id)
         .map(id => dispatch(setEventState(id, reportToSubmit.state))));
-    }
-
-    if (shouldFetchReport) {
-      const createdReport = results.length ? results[0] : results;
-      dispatch(fetchEvent(createdReport.data.data.id));
     }
 
     return results;
@@ -309,11 +304,14 @@ const ReportDetailView = ({
         }
         return results;
       })
-      .then(onSaveSuccess(
-        reportToSubmit,
-        shouldRedirectAfterSave ? `/${TAB_KEYS.REPORTS}` : undefined,
-        shouldFetchAfterSave
-      ))
+      .then(onSaveSuccess(reportToSubmit, shouldRedirectAfterSave ? `/${TAB_KEYS.REPORTS}` : undefined))
+      .then((results) => {
+        if (shouldFetchAfterSave) {
+          const createdReport = results.length ? results[0] : results;
+          dispatch(fetchEvent(createdReport.data.data.id));
+        }
+        return results;
+      })
       .catch(onSaveError)
       .finally(() => setIsSaving(false));
   }, [
@@ -502,7 +500,6 @@ const ReportDetailView = ({
           reportTracker.track('Added report to report');
           onSaveSuccess({}, `/${TAB_KEYS.REPORTS}/${collectionId}`)(collectionRefreshedResults);
         }
-
       });
     } catch (e) {
       setIsSaving(false);


### PR DESCRIPTION
### What does this PR do?
Reports are now fetched always after being saved, just like in the new UI. However, it's important to make sure that they are loaded at the right moment depending on the flow. For example, in order to avoid cache issues with links to incidents, a report that is part of an incident should be fetched after the incident relation is created.

### Relevant link(s)
* [ERA-8361](https://allenai.atlassian.net/browse/ERA-8361)
* [Env](https://era-8361.pamdas.org/)

### Where / how to start reviewing (optional)
The magic is in line `233`. That's the new line that fetches a report after being saved. But it's inside a conditional. From there you can go backwards to see how when a report is part of an incident, the it won't be fetched here to avoid the cache stuff.

### Any background context you want to provide(if applicable)
In the old implementation the exact same line is in there, without conditional. I don't know if it works properly, but I guess it's possible that some of the issues that lead us to adding it could be present in there.


[ERA-8361]: https://allenai.atlassian.net/browse/ERA-8361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ