### PR TITLE
ERA-8483: New Patrol UI - Edit note - Cancel button is not turning off editing mode

### DIFF
--- a/src/PatrolDetailView/index.test.js
+++ b/src/PatrolDetailView/index.test.js
@@ -493,5 +493,21 @@ describe('PatrolDetailView', () => {
         expect(executeSaveActions).toHaveBeenCalledTimes(1);
       });
     });
+
+    test('showing a warning prompt for an ongoing note', async () => {
+      renderWithWrapper(<PatrolDetailView />);
+
+      const addNoteButton = await screen.findByTestId('addNoteButton');
+      userEvent.click(addNoteButton);
+
+      const textInput = await screen.findByTestId('activitySection-noteTextArea-');
+      userEvent.type(textInput, 'this is a new note');
+
+      const cancelButton = await screen.findByTestId('patrol-details-cancel-btn');
+      userEvent.click(cancelButton);
+
+      await screen.findByText('Unsaved Changes');
+      await screen.findByText('There are unsaved changes. Would you like to go back, discard the changes, or save and continue?');
+    });
   });
 });

--- a/src/ReportManager/ReportDetailView/index.js
+++ b/src/ReportManager/ReportDetailView/index.js
@@ -91,7 +91,7 @@ const ReportDetailView = ({
   const [notesToAdd, setNotesToAdd] = useState([]);
   const [reportForm, setReportForm] = useState(isNewReport ? newReport : eventStore[reportId]);
   const [saveError, setSaveError] = useState(null);
-  const [unsavedReportNotes, setUnsavedReportNotes] = useState([]);
+  const [unsavedNotes, setUnsavedNotes] = useState([]);
 
   const reportTracker = useContext(TrackerContext);
 
@@ -192,9 +192,9 @@ const ReportDetailView = ({
     if (isNewNote){
       backupUnsavedNote(note, updatedText, notesToAdd, setNotesToAdd);
     } else {
-      backupUnsavedNote(note, updatedText, unsavedReportNotes, setUnsavedReportNotes);
+      backupUnsavedNote(note, updatedText, unsavedNotes, setUnsavedNotes);
     }
-  }, [backupUnsavedNote, notesToAdd, unsavedReportNotes]);
+  }, [backupUnsavedNote, notesToAdd, unsavedNotes]);
 
   const shouldShowNavigationPrompt =
     !isSaving
@@ -204,7 +204,7 @@ const ReportDetailView = ({
       || attachmentsToAdd.length > 0
       || newNotesAdded
       || Object.keys(reportChanges).length > 0
-      || unsavedReportNotes.length > 0
+      || unsavedNotes.length > 0
     );
 
   const showAddReportButton = !isAddedReport
@@ -271,9 +271,9 @@ const ReportDetailView = ({
         reportToSubmit.reported_by = reportForm.reported_by;
       }
 
-      if (unsavedReportNotes.length > 0) {
+      if (unsavedNotes.length > 0) {
         reportToSubmit.notes = reportForm.notes.map((currentNote) => {
-          const unsavedReportNote = unsavedReportNotes.find(({ created_at }) => currentNote.created_at === created_at);
+          const unsavedReportNote = unsavedNotes.find(({ created_at }) => currentNote.created_at === created_at);
           if (unsavedReportNote){
             return {
               ...currentNote,
@@ -320,7 +320,7 @@ const ReportDetailView = ({
     reportChanges,
     reportForm,
     reportTracker,
-    unsavedReportNotes
+    unsavedNotes
   ]);
 
   const onChangeTitle = useCallback(
@@ -408,8 +408,8 @@ const ReportDetailView = ({
   }, [notesToAdd]);
 
   const onCancelNote = useCallback((note) => {
-    setUnsavedReportNotes(unsavedReportNotes.filter(({ id }) => id !== note.id));
-  }, [unsavedReportNotes]);
+    setUnsavedNotes(unsavedNotes.filter(({ id }) => id !== note.id));
+  }, [unsavedNotes]);
 
   const onSaveNote = useCallback((originalNote, updatedNote) => {
     const editedNote = { ...originalNote, text: updatedNote.text };
@@ -656,8 +656,6 @@ const ReportDetailView = ({
                 onNoteItemBlur={onNoteItemBlur}
                 onNoteItemCancel={onCancelNote}
                 onSaveNote={onSaveNote}
-                reportAttachments={reportAttachments}
-                reportNotes={reportNotes}
               />
             </QuickLinks.Section>
 
@@ -692,7 +690,13 @@ const ReportDetailView = ({
             </div>
 
             <div>
-              <Button data-testid='report-details-cancel-btn' className={styles.cancelButton} onClick={onClickCancelButton} type="button" variant="secondary">
+              <Button
+                className={styles.cancelButton}
+                data-testid='report-details-cancel-btn'
+                onClick={onClickCancelButton}
+                type="button"
+                variant="secondary"
+              >
                 Cancel
               </Button>
 


### PR DESCRIPTION
### What does this PR do?
Bring unsaved notes logic to patrols. Missing this logic was the root cause of the reported bug.

### Relevant link(s)
* [ERA-8483](https://allenai.atlassian.net/browse/ERA-8483)
* [Env](https://era-8483.pamdas.org/)

### Any background context you want to provide(if applicable)
@gaboDev implemented an unsaved notes tracking mechanism to show the navigation prompt in case an edited note wasn't saved. That required changes in the shared `ActivitySection` component, but we only applied the logic to the report detail view. This PR adds the required logic in the patrol detail view too.


[ERA-8483]: https://allenai.atlassian.net/browse/ERA-8483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ