### PR TITLE
ERA-8338:  Confirmation modal prompted for some event types without updating the report

### DIFF
--- a/src/ReportManager/ReportDetailView/index.js
+++ b/src/ReportManager/ReportDetailView/index.js
@@ -56,19 +56,22 @@ const QUICK_LINKS_SCROLL_TOP_OFFSET = 20;
 
 const ACTIVE_STATES = ['active', 'new'];
 
-const convertPrimitiveFieldsToObject = (reportFields) => reportFields.map((reportField) => {
-  const [key, value] = reportField;
-  const entries = Object.entries(value);
-  if (!entries.length){
-    return [key, { tmpValue: value }];
-  }
-  return reportField;
-});
+const calculateFormattedReportDiffs = (reportForm, originalReport) => {
+  const reportDifferences = Object.entries( extractObjectDifference(reportForm, originalReport) );
+  return reportDifferences.map((reportField) => {
+    const [key, value] = reportField;
+    const entries = Object.entries(value);
+    if (!entries.length){
+      return [key, { tmpValue: value }];
+    }
+    return reportField;
+  });
+};
 
 const extractReportFieldsChanges = (reportField, reportSchemaProps) => Object.entries(reportField).reduce((acc, [reportFieldKey, reportFieldValue]) => {
   const schemaDefaultValue = reportSchemaProps?.[reportFieldKey]?.default;
   const defValueHasChanged = schemaDefaultValue && reportFieldValue !== schemaDefaultValue;
-  const hasReportValue = !schemaDefaultValue && reportFieldValue;
+  const hasReportValue = !schemaDefaultValue && ( reportFieldValue !== null && reportFieldValue !== undefined && reportFieldValue !== '' );
   return defValueHasChanged || hasReportValue ? { ...acc, [reportFieldKey]: reportFieldValue } : acc;
 }, {});
 
@@ -179,8 +182,7 @@ const ReportDetailView = ({
       return {};
     }
     const { properties: schemaProps } = reportSchemas?.schema ?? {};
-    const reportDifferences = Object.entries( extractObjectDifference(reportForm, originalReport) );
-    const formattedReportDiffs = convertPrimitiveFieldsToObject(reportDifferences);
+    const formattedReportDiffs = calculateFormattedReportDiffs(reportForm, originalReport);
     return formattedReportDiffs.reduce((accumulator, [key, reportField]) => {
       const reportFieldsChanges = extractReportFieldsChanges(reportField, schemaProps);
       const reportFieldHasChanges = Object.entries(reportFieldsChanges).length > 0;


### PR DESCRIPTION
### What does this PR do?
- It ignores/takes out the default value of a report schema from the report changes variable.

### Relevant link(s)
* [ERA-8338](https://allenai.atlassian.net/browse/ERA-8338)
* [Env](https://era-8338.pamdas.org)

### Where / how to start reviewing (optional)
- There are some event types which has a default value for an specific form field, before this PR those default values were taking as changes, so it would be a good idea to test this with some of those event types.

### Any background context you want to provide(if applicable)
- The ticket description is making reference to the Reptile event type (in Dev) which is a proof of concept, as far as I understand that kind of report schema is not a regular thing, anyways, I added a fix for both scenarios: 
1. Handling a report schema with a pre-filled report field value (Reptile)
2. Handling a report schema with default values for fields (EventWithDefaultValue)


[ERA-8338]: https://allenai.atlassian.net/browse/ERA-8338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ