### PR TITLE
ERA-8573: Update text for the Patrol scheduled checkboxes

### DIFF
--- a/src/PatrolDetailView/PlanSection/index.js
+++ b/src/PatrolDetailView/PlanSection/index.js
@@ -185,7 +185,7 @@ const PlanSection = ({
           onChange={handleAutoStartChange}
           type="checkbox"
         />
-        <span>Automatically start the patrol at this time</span>
+        <span>Automatically start the patrol in EarthRanger at this time</span>
       </label>
 
       <div className={styles.row}>
@@ -238,7 +238,7 @@ const PlanSection = ({
           onChange={handleAutoEndChange}
           type="checkbox"
         />
-        <span>Automatically end the patrol at this time</span>
+        <span>Automatically end the patrol in EarthRanger at this time</span>
       </label>
     </div>
   </>;


### PR DESCRIPTION
### What does this PR do?
- The text of both start/end Patrol scheduled checkboxes were changed from `Automatically start/end the patrol at this time` to `Automatically start/end the patrol in EarthRanger at this time`

### Relevant link(s)
* [ERA-8573](https://allenai.atlassian.net/browse/ERA-8573)

[ERA-8573]: https://allenai.atlassian.net/browse/ERA-8573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ