### PR TITLE
ERA-8566: Selecting a time in the past makes the patrol overdue

### DIFF
--- a/src/PatrolDetailView/PlanSection/index.js
+++ b/src/PatrolDetailView/PlanSection/index.js
@@ -21,6 +21,8 @@ import TimePicker from '../../TimePicker';
 
 import styles from './styles.module.scss';
 
+const shouldScheduleDate = (date, isAuto) => !isAuto && isFuture(date);
+
 const PlanSection = ({
   onPatrolEndDateChange,
   onPatrolEndLocationChange,
@@ -59,11 +61,11 @@ const PlanSection = ({
     ?.map(({ value }) => value) ?? [];
 
   const handleEndDateChange = useCallback((date) => {
-    onPatrolEndDateChange(date < startDate ? startDate : date, isAutoEnd);
-  }, [isAutoEnd, onPatrolEndDateChange, startDate]);
+    onPatrolEndDateChange(date, shouldScheduleDate(date, isAutoEnd));
+  }, [isAutoEnd, onPatrolEndDateChange]);
 
   const handleStartDateChange = useCallback((date) => {
-    onPatrolStartDateChange(date, isAutoStart);
+    onPatrolStartDateChange(date, shouldScheduleDate(date, isAutoStart));
   }, [isAutoStart, onPatrolStartDateChange]);
 
   const handleEndTimeChange = useCallback((endTime) => {
@@ -71,7 +73,7 @@ const PlanSection = ({
     const updatedEndDateTime = endDate ? new Date(endDate) : new Date();
     updatedEndDateTime.setHours(newEndTimeParts[0], newEndTimeParts[1], '00');
 
-    onPatrolEndDateChange(updatedEndDateTime, isAutoEnd);
+    onPatrolEndDateChange(updatedEndDateTime, shouldScheduleDate(updatedEndDateTime, isAutoEnd));
   }, [endDate, isAutoEnd, onPatrolEndDateChange]);
 
   const handleStartTimeChange = useCallback((startTime) => {
@@ -79,17 +81,19 @@ const PlanSection = ({
     const updatedStartDateTime = startDate ? new Date(startDate) : new Date();
     updatedStartDateTime.setHours(newStartTimeParts[0], newStartTimeParts[1], '00');
 
-    onPatrolStartDateChange(updatedStartDateTime, isAutoStart);
+    onPatrolStartDateChange(updatedStartDateTime, shouldScheduleDate(updatedStartDateTime, isAutoStart));
   }, [isAutoStart, onPatrolStartDateChange, startDate]);
 
   const handleAutoEndChange = useCallback(() => {
     dispatch(updateUserPreferences({ autoEndPatrols: !isAutoEnd }));
-    onPatrolEndDateChange(endDate, !isAutoEnd);
+    onPatrolEndDateChange(endDate, shouldScheduleDate(endDate, isAutoEnd));
   }, [dispatch, isAutoEnd, onPatrolEndDateChange, endDate]);
 
   const handleAutoStartChange = useCallback(() => {
-    dispatch(updateUserPreferences({ autoStartPatrols: !isAutoStart }));
-    onPatrolStartDateChange(startDate, !isAutoStart);
+    const newIsAutoStart = !isAutoStart;
+    dispatch(updateUserPreferences({ autoStartPatrols: newIsAutoStart }));
+
+    onPatrolStartDateChange(startDate, shouldScheduleDate(startDate, newIsAutoStart));
   }, [dispatch, isAutoStart, onPatrolStartDateChange, startDate]);
 
   useEffect(() => {

--- a/src/PatrolDetailView/index.js
+++ b/src/PatrolDetailView/index.js
@@ -237,14 +237,14 @@ const PatrolDetailView = () => {
     [patrolForm, setPatrolForm]
   );
 
-  const onPatrolEndDateChange = useCallback((endDate, isAutoEnd) => {
+  const onPatrolEndDateChange = useCallback((endDate, shouldSchedule) => {
     const [segment] = patrolForm.patrol_segments;
     setPatrolForm({
       ...patrolForm,
       patrol_segments: [{
         ...segment,
-        scheduled_end: !endDate || isAutoEnd ? null : endDate,
-        time_range: { ...segment.time_range, end_time: endDate && isAutoEnd ? endDate : null },
+        scheduled_end: endDate && shouldSchedule ? endDate : null,
+        time_range: { ...segment.time_range, end_time: !endDate || shouldSchedule ? null : endDate },
       }],
     });
 
@@ -308,14 +308,14 @@ const PatrolDetailView = () => {
     patrolDetailViewTracker.track(`${selection ? 'Set' : 'Unset'} patrol tracked subject`);
   }, [isNewPatrol, patrolForm]);
 
-  const onPatrolStartDateChange = useCallback((startDate, isAutoStart) => {
+  const onPatrolStartDateChange = useCallback((startDate, shouldSchedule) => {
     const [segment] = patrolForm.patrol_segments;
     setPatrolForm({
       ...patrolForm,
       patrol_segments: [{
         ...segment,
-        scheduled_start: isAutoStart ? null : startDate,
-        time_range: { ...segment.time_range, start_time: isAutoStart ? startDate : null },
+        scheduled_start: shouldSchedule ? startDate : null,
+        time_range: { ...segment.time_range, start_time: shouldSchedule ?  null : startDate },
       }],
     });
 
@@ -375,7 +375,7 @@ const PatrolDetailView = () => {
     } else {
       setPatrolForm({ ...patrolForm, notes: updatedNotes });
     }
-  }, [notesToAdd, onDeleteNote, patrolForm, patrolNotes]);
+  }, [notesToAdd, patrolForm, patrolNotes]);
 
   const onChangeNote = useCallback((originalNote, { target: { value } }) => {
     const editedNote = {


### PR DESCRIPTION
### What does this PR do?
We were missing an importante piece of logic when setting scheduled vs non-scheduled (aka automatic) patrol start and end dates. I'm adding it here, with more explicit variable names.

### Relevant link(s)
* [ERA-8566](https://allenai.atlassian.net/browse/ERA-8566)
* [Env](https://era-8566.pamdas.org)

### Any background context you want to provide(if applicable)
The normal way to set a patrol date (either start or end) is to set it inside the patrol segment in the property `time_range`. However, we support an alternative way to set the start date without automatically assuming that the patrol was started, which is the `scheduled date`. It's kind of counterintuitive, because we have a checkbox that gives the impression that normal state is to have them scheduled while setting the automatic start is a functionality. But the reality is that "automatic" start is not a functionality, it's just setting the start date normally, while scheduling it is not setting it normally, but in a different property so the frontend code thinks the patrol hasn't started yet, setting it as overdue. 
All these are technical implementation details that I just learned while working on this. So it's not important to know this for others than the dev team. However, given that we missed it and now we are fixing it for both start and end dates, I strongly suggest the QA team @Alcoto95 @AlanCalvillo to do regressions on every usecase we have for start / end dates of patrols (scheduled patrols, overdue patrols, active patrols, cancelled, done, automatic vs scheduled, etc...)


[ERA-8566]: https://allenai.atlassian.net/browse/ERA-8566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ