### PR TITLE
ERA-8561: Sensor Icon Does not Appear on Cluster List

### DIFF
--- a/src/LayerSelectorPopup/index.js
+++ b/src/LayerSelectorPopup/index.js
@@ -75,7 +75,7 @@ const LayerSelectorPopup = ({ id, data, hidePopup, mapImages }) => {
           <img
             alt={layer.properties.display_title || layer.properties.name || layer.properties.title}
             src={imgSrc}
-            style={{ ...(subjectIsStatic(layer) ? { filter: 'invert(1) opacity(60%)' } : {}) }}
+            style={{ ...(subjectIsStatic(layer) ? { filter: 'brightness(0) opacity(60%)' } : {}) }}
           />
           <span>{layer.properties.display_title || layer.properties.name || layer.properties.title}</span>
         </li>;


### PR DESCRIPTION
### What does this PR do?
Change CSS filter in cluster selector popup icons from `invert(1)` to `brightness(0)` in the case of static subjects, so those icons are always black.

### How does it look
Before
![image](https://github.com/PADAS/das-web-react/assets/11725028/3d79f3f9-16dc-4680-aa7a-c55f53f80c46)

After
![image](https://github.com/PADAS/das-web-react/assets/11725028/8c69ac0b-c0e4-4f04-96ef-e3d049f39727)

### Relevant link(s)
* [ERA-8561](https://allenai.atlassian.net/browse/ERA-8561)
* [Env](https://era-8561.pamdas.org/)


[ERA-8561]: https://allenai.atlassian.net/browse/ERA-8561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ