### PR TITLE
ERA-8593: User is not able to select 11:45 on any of the time fields

### DIFF
--- a/src/TimePicker/OptionsPopover/index.js
+++ b/src/TimePicker/OptionsPopover/index.js
@@ -105,10 +105,6 @@ const OptionsPopover = ({
       arrayIndex++;
     }
 
-    if (options.slice(-1)?.[0]?.value === value) {
-      options.pop();
-    }
-
     if ( nearestHourIndex > -1 ){
       options[nearestHourIndex].ref = defaultTimeRef;
     }


### PR DESCRIPTION
### What does this PR do?
- It prevents to define the nearest hour the same as the current value of the control, that was causing that the reference was being assigned to a nonexistent option item due the miscalculation 

* Tracking tickets: [ERA-8593](https://allenai.atlassian.net/browse/ERA-8593)
* [Env](https://era-8593.pamdas.org)


[ERA-8593]: https://allenai.atlassian.net/browse/ERA-8593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ