### PR TITLE
[ERA-8606] - Compounding parameters on Message API calls

### DIFF
--- a/src/ducks/messaging.js
+++ b/src/ducks/messaging.js
@@ -41,7 +41,7 @@ export const fetchMessages = (params = {}) => {
     { include_additional_data: false, page_size: 25, ...params },
   );
 
- return get(`${MESSAGING_API_URL}?${paramString}`);
+  return get(`${MESSAGING_API_URL}?${paramString}`);
 };
 
 export const fetchAllMessages = (params = {}) =>


### PR DESCRIPTION
### What does this PR do?
- This PR removes the parameters of message API calls from the request config and into the URL string. Since `recursivePaginatedQuery` propagates request/response config downwards into subsequent calls, but the response's `next` prop also pre-includes the parameters, this prevents duplicated/compounding parameters from being appended to recursive pagination through the Message API.

### How does it look
N/A

### Relevant link(s)
* https://allenai.atlassian.net/browse/ERA-8606
* Do we really need an environment for this change??

### Where / how to start reviewing (optional)
- Should be very straightforward

### Any background context you want to provide(if applicable)
- N/A
