### PR TITLE
[ERA-8613] HOTFIX - Guard clause for undefined `topLevelUpdates` prop

### DIFF
--- a/src/PatrolDetailView/index.js
+++ b/src/PatrolDetailView/index.js
@@ -145,7 +145,7 @@ const PatrolDetailView = () => {
 
     const [segmentsFirstLeg] = patrolForm.patrol_segments;
 
-    const topLevelUpdates = patrolForm.updates;
+    const topLevelUpdates = patrolForm?.updates ?? [];
     const { updates: segmentUpdates } = segmentsFirstLeg;
     const noteUpdates = extractAttachmentUpdates(patrolForm.notes);
     const fileUpdates = extractAttachmentUpdates(patrolForm.files);


### PR DESCRIPTION
### What does this PR do?
- Adds a guard clause for when `topLevelUpdates` is briefly undefined during patrol state transitions

### How does it look
N/A

### Relevant link(s)
* https://allenai.atlassian.net/browse/ERA-8613

### Where / how to start reviewing (optional)
- It's a one line change. Do we need a hosted environment @Alcoto95 ?

### Any background context you want to provide(if applicable)
- See bug description
