### PR TITLE
ERA-8489: Order patrols by "last updated" in the patrols feed

### DIFF
--- a/src/utils/patrols.js
+++ b/src/utils/patrols.js
@@ -554,9 +554,9 @@ export const sortPatrolList = (patrols) => {
     return 6;
   };
 
-  const patrolDisplayTitleFunc = (patrol) => displayTitleForPatrol(patrol, patrol?.patrol_segments?.[0]?.leader).toLowerCase();
+  const patrolGetLastUpdate = ({ updates }) => Array.isArray(updates) && updates.length ? new Date(updates[0].time) : null;
 
-  return orderBy(patrols, [sortFunc, patrolDisplayTitleFunc], ['asc', 'asc']);
+  return orderBy(patrols, [sortFunc, patrolGetLastUpdate], ['asc', 'desc']);
 };
 
 export const makePatrolPointFromFeature = (label, coordinates, icon_id, stroke, time) => {

--- a/src/utils/patrols.test.js
+++ b/src/utils/patrols.test.js
@@ -104,16 +104,41 @@ describe('Patrols utils', () => {
 
   describe('sortPatrolList', () => {
     test('should return patrols in correct sort', async () => {
+      const donePatrolUpdate = {
+        time: '2023-06-18T22:12:24.207505+00:00'
+      };
+      const donePatrolWithLatestUpdate = {
+        ...donePatrol,
+        updates: [donePatrolUpdate]
+      };
+      const scheduledPatrolUpdate = {
+        time: '2023-06-20T22:12:24.207505+00:00'
+      };
+      const scheduledPatrolWithLatestUpdate = {
+        ...scheduledPatrol,
+        updates: [scheduledPatrolUpdate]
+      };
+      const cancelledPatrolUpdate = {
+        time: '2023-06-21T22:12:24.207505+00:00'
+      };
+      const cancelledPatrolWithLatestUpdate = {
+        ...cancelledPatrol,
+        updates: [cancelledPatrolUpdate]
+      };
 
-      const unorderedPatrols = [donePatrol, scheduledPatrol, activePatrol, cancelledPatrol, overduePatrol, readyToStartPatrol ];
+      const unorderedPatrols = [donePatrol, scheduledPatrol, activePatrol, cancelledPatrol, overduePatrol, readyToStartPatrol, cancelledPatrolWithLatestUpdate, donePatrolWithLatestUpdate, scheduledPatrolWithLatestUpdate ];
+      const expectedPatrolStateOrder = [READY_TO_START, START_OVERDUE, ACTIVE, SCHEDULED, SCHEDULED, DONE, DONE, CANCELLED, CANCELLED];
       const sortedPatrols = await sortPatrolList(unorderedPatrols);
 
-      expect(calcPatrolState(sortedPatrols[0])).toBe(READY_TO_START);
-      expect(calcPatrolState(sortedPatrols[1])).toBe(START_OVERDUE);
-      expect(calcPatrolState(sortedPatrols[2])).toBe(ACTIVE);
-      expect(calcPatrolState(sortedPatrols[3])).toBe(SCHEDULED);
-      expect(calcPatrolState(sortedPatrols[4])).toBe(DONE);
-      expect(calcPatrolState(sortedPatrols[5])).toBe(CANCELLED);
+      sortedPatrols.forEach((patrol, index) =>
+        expect(calcPatrolState(patrol)).toBe(expectedPatrolStateOrder[index])
+      );
+
+      const [,,, mostRecentScheduledPatrol,, mostRecentDonePatrol,, mostRecentCancelledPatrol] = sortedPatrols;
+
+      expect(mostRecentScheduledPatrol.updates[0].time).toBe(scheduledPatrolUpdate.time);
+      expect(mostRecentDonePatrol.updates[0].time).toBe(donePatrolUpdate.time);
+      expect(mostRecentCancelledPatrol.updates[0].time).toBe(cancelledPatrolUpdate.time);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
- It modify the patrol feed sort by adding last updated date as dimension 

### Relevant link(s)
* [ERA-8489](https://allenai.atlassian.net/browse/ERA-8489)
* [Env](https://era-8489.pamdas.org)

### Where / how to start reviewing (optional)
- Only the patrol feed has been affected, besides being grouped by state, each group should appear sorted by the last updated patrol.

e.g. 

_Unordered patrols:_
- cancelledPatrol
- readyToStartPatrol
- readyToStartPatrol
- activePatrol

_Sorted patrols by state and last updated:_
- readyToStartPatrol  `<- This one should be the last updated patrol within the READY_TO_START group`
- readyToStartPatrol
- activePatrol
- cancelledPatrol

[ERA-8489]: https://allenai.atlassian.net/browse/ERA-8489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ