### PR TITLE
HOTFIX: adding patrol UI support for the draw tool ReportOverview

### DIFF
--- a/src/MapLocationPicker/index.js
+++ b/src/MapLocationPicker/index.js
@@ -91,7 +91,7 @@ const MapLocationPicker = (props) => {
             anchor="left"
             trackPointer={true}
         >
-        <p>Click to select a report location</p>
+        <p>Click to select a location</p>
       </Popup>
     }
   </>;

--- a/src/PatrolDetailView/PlanSection/index.js
+++ b/src/PatrolDetailView/PlanSection/index.js
@@ -12,6 +12,7 @@ import { displayEndTimeForPatrol, displayStartTimeForPatrol } from '../../utils/
 import { fetchTrackedBySchema } from '../../ducks/trackedby';
 import { getHoursAndMinutesString } from '../../utils/datetime';
 import { updateUserPreferences } from '../../ducks/user-preferences';
+import { setMapLocationSelectionPatrol } from '../../ducks/map-ui';
 import { useMatchMedia } from '../../hooks';
 
 import DatePicker from '../../DatePicker';
@@ -98,6 +99,10 @@ const PlanSection = ({
       dispatch(fetchTrackedBySchema());
     }
   }, [dispatch, patrolLeaders]);
+
+  useEffect(() => {
+    dispatch(setMapLocationSelectionPatrol(patrolForm));
+  }, [dispatch, patrolForm]);
 
   return <>
     <div className={styles.sectionHeader}>

--- a/src/PatrolModal/index.js
+++ b/src/PatrolModal/index.js
@@ -11,6 +11,7 @@ import { isEmpty } from 'lodash';
 
 import { createPatrolDataSelector } from '../selectors/patrols';
 import { addModal, removeModal, setModalVisibilityState } from '../ducks/modals';
+import { setMapLocationSelectionPatrol } from '../ducks/map-ui';
 import { updateUserPreferences } from '../ducks/user-preferences';
 import { fetchEvent } from '../ducks/events';
 import { filterDuplicateUploadFilenames, fetchImageAsBase64FromUrl } from '../utils/file';
@@ -85,6 +86,7 @@ const PatrolModal = (props) => {
     updateUserPreferences,
     autoStartPatrols,
     patrolLeaderSchema,
+    setMapLocationSelectionPatrol,
     autoEndPatrols,
     eventStore,
   } = props;
@@ -173,6 +175,10 @@ const PatrolModal = (props) => {
       return () => window.clearTimeout(debouncedTrackFetch.current);
     }
   }, [actualEndTime, actualStartTime, displayTrackingSubject]);
+
+  useEffect(() => {
+    setMapLocationSelectionPatrol(statePatrol);
+  }, [setMapLocationSelectionPatrol, statePatrol]);
 
 
   const displayTitle = useMemo(() => displayTitleForPatrol(statePatrol), [statePatrol]);
@@ -782,6 +788,7 @@ const ConnectedDistanceCovered = connect(makeMapStateToProps, null)(memo((props)
 
 export default connect(mapStateToProps, {
   addModal,
+  setMapLocationSelectionPatrol,
   fetchEvent: (...args) => fetchEvent(...args),
   fetchTrackedBySchema,
   removeModal,

--- a/src/ReportGeometryDrawer/ReportOverview/index.js
+++ b/src/ReportGeometryDrawer/ReportOverview/index.js
@@ -16,6 +16,7 @@ import { EVENT_REPORT_CATEGORY, trackEventFactory } from '../../utils/analytics'
 import { MapDrawingToolsContext } from '../../MapDrawingTools/ContextProvider';
 
 import ReportListItem from '../../ReportListItem';
+import PatrolListItem from '../../PatrolListItem';
 
 import { MAP_LOCATION_SELECTION_MODES } from '../../ducks/map-ui';
 import { useEventGeoMeasurementDisplayStrings } from '../../hooks/geometry';
@@ -34,8 +35,14 @@ const ReportOverview = ({
   onClickUndo: onClickUndoCallback,
   onShowInformationModal,
 }) => {
-  const event = useSelector((state) => state.view.mapLocationSelection.event);
-  const originalEvent = useSelector((state) => state.data.eventStore[event.id]);
+  const event = useSelector((state) => state.view.mapLocationSelection?.event);
+  const patrol = useSelector((state) => state.view.mapLocationSelection?.patrol);
+
+  const originalEvent = useSelector((state) =>
+    event
+    && state.data.eventStore[event.id]
+  );
+
   const mapLocationSelection = useSelector(({ view: { mapLocationSelection } }) => mapLocationSelection);
 
   const isDrawingEventGeometry =
@@ -80,7 +87,7 @@ const ReportOverview = ({
   const title =
   isDrawingEventGeometry
     ? 'Create report area'
-    : 'Choose report location';
+    : `Choose ${patrol ? 'patrol' : 'report'} location`;
 
   return <div className={styles.reportAreaOverview} data-testid="reportAreaOverview-wrapper">
     <div className={styles.header} onClick={onClickHeader}>
@@ -95,7 +102,11 @@ const ReportOverview = ({
 
     <Collapse data-testid="reportOverview-collapse" in={isOpen}>
       <div className={styles.body}>
-        <ReportListItem className={styles.reportItem} report={event} />
+        {!!event && <ReportListItem className={styles.reportItem} report={event} />}
+        {!!patrol && <PatrolListItem
+                patrol={patrol}
+                showControls={false}
+                 />}
 
         {isDrawingEventGeometry &&
           <div className={styles.measurements}>

--- a/src/ducks/map-ui.js
+++ b/src/ducks/map-ui.js
@@ -31,6 +31,7 @@ export const UPDATE_SUBJECT_TRACK_STATE = 'UPDATE_SUBJECT_TRACK_STATE';
 const SET_REPORT_HEATMAP_VISIBILITY = 'SET_REPORT_HEATMAP_VISIBILITY';
 
 const SET_MAP_LOCATION_SELECTION_EVENT = 'SET_MAP_LOCATION_SELECTION_EVENT';
+const SET_MAP_LOCATION_SELECTION_PATROL = 'SET_MAP_LOCATION_SELECTION_PATROL';
 const SET_IS_PICKING_LOCATION = 'SET_IS_PICKING_LOCATION';
 
 const SET_PRINT_TITLE = 'SET_PRINT_TITLE';
@@ -167,6 +168,11 @@ export const MAP_LOCATION_SELECTION_MODES = { EVENT_GEOMETRY: 'eventGeometry', D
 export const setMapLocationSelectionEvent = (event) => ({
   type: SET_MAP_LOCATION_SELECTION_EVENT,
   payload: { event },
+});
+
+export const setMapLocationSelectionPatrol = (patrol) => ({
+  type: SET_MAP_LOCATION_SELECTION_PATROL,
+  payload: { patrol },
 });
 
 export const setIsPickingLocation = (isPickingLocation, mode = MAP_LOCATION_SELECTION_MODES.DEFAULT) => ({
@@ -308,7 +314,10 @@ const INITIAL_MAP_LOCATION_SELECTION_STATE = {
 export const mapLocationSelectionReducer = (state = INITIAL_MAP_LOCATION_SELECTION_STATE, action) => {
   switch (action.type) {
   case SET_MAP_LOCATION_SELECTION_EVENT:
-    return { ...state, event: action.payload.event };
+    return { ...state, event: action.payload.event, patrol: null };
+
+  case SET_MAP_LOCATION_SELECTION_PATROL:
+    return { ...state, event: null, patrol: action.payload.patrol };
 
   case SET_IS_PICKING_LOCATION:
     return {


### PR DESCRIPTION
### What does this PR do?
- Hotfixes patrol support for the `ReportOverview` component

### How does it look
- N/A

### Relevant link(s)
* https://allenai.atlassian.net/browse/ERA-8637
* https://era-8637.pamdas.org/

### Where / how to start reviewing (optional)
- Ensure patrol location selection works as expected

### Any background context you want to provide(if applicable)
- This is a hotfix to unblock the release, so you're going to (rightfully) turn your nose up at the dissolution of name convention integrity. [I've filed a separate chore task](https://allenai.atlassian.net/browse/ERA-8639) to update the name and placement of ReportOverview
