### PR TITLE
ERA-8625: Auto Start/End checkbox gets updated across different patrols in the UI

### DIFF
--- a/src/PatrolDetailView/PlanSection/index.js
+++ b/src/PatrolDetailView/PlanSection/index.js
@@ -91,7 +91,7 @@ const PlanSection = ({
   const handleAutoEndChange = useCallback(() => {
     const newIsAutoEnd = !isAutoEnd;
 
-    if (!isNewPatrol){
+    if (isNewPatrol){
       dispatch(updateUserPreferences({ autoEndPatrols: newIsAutoEnd }));
     }
     setIsAutoEnd(newIsAutoEnd);
@@ -101,7 +101,7 @@ const PlanSection = ({
   const handleAutoStartChange = useCallback(() => {
     const newIsAutoStart = !isAutoStart;
 
-    if (!isNewPatrol){
+    if (isNewPatrol){
       dispatch(updateUserPreferences({ autoStartPatrols: newIsAutoStart }));
     }
     setIsAutoStart(newIsAutoStart);

--- a/src/PatrolDetailView/PlanSection/index.test.js
+++ b/src/PatrolDetailView/PlanSection/index.test.js
@@ -241,7 +241,6 @@ describe('PatrolDetailView - PlanSection', () => {
 
     const futurePatrol = {
       ...newPatrol,
-      id: 'someId',
       patrol_segments: [{
         ...newPatrol.patrol_segments[0],
         time_range: {
@@ -261,11 +260,11 @@ describe('PatrolDetailView - PlanSection', () => {
 
     const [, autoStartAction, autoEndAction] = mockedStore.getActions();
 
-    expect(autoStartAction).toStrictEqual({ payload: { autoStartPatrols: false }, type: 'UPDATE_USER_PREFERENCES' });
-    expect(autoEndAction).toStrictEqual({ payload: { autoEndPatrols: false }, type: 'UPDATE_USER_PREFERENCES' });
+    expect(autoStartAction).toStrictEqual({ payload: { autoStartPatrols: true }, type: 'UPDATE_USER_PREFERENCES' });
+    expect(autoEndAction).toStrictEqual({ payload: { autoEndPatrols: true }, type: 'UPDATE_USER_PREFERENCES' });
   });
 
-  test('prevent updating user preferences when user changes auto end/start value for a new patrol', async () => {
+  test('prevent updating user preferences when user changes auto end/start value for an existing', async () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
 
@@ -278,6 +277,7 @@ describe('PatrolDetailView - PlanSection', () => {
           start_time: tomorrow,
         },
       }],
+      id: '123456'
     };
 
     renderPlanSectionWithWrapper({ patrolForm: futurePatrol });

--- a/src/PatrolModal/index.js
+++ b/src/PatrolModal/index.js
@@ -260,14 +260,14 @@ const PatrolModal = (props) => {
   }, []);
 
   const handleAutoStartChange = useCallback((val) => {
-    if (!isNewPatrol){
+    if (isNewPatrol){
       updateUserPreferences({ autoStartPatrols: val });
     }
     setIsAutoStart(val);
   }, [isNewPatrol, updateUserPreferences]);
 
   const handleAutoEndChange = useCallback((val) => {
-    if (!isNewPatrol){
+    if (isNewPatrol){
       updateUserPreferences({ autoEndPatrols: val });
     }
     setIsAutoEnd(val);


### PR DESCRIPTION
### What does this PR do?
- It gives internal/independent state to the auto star/end patrol checkboxes
- It removes user-preferences logic of checkboxes from PatrolUI only

### Relevant link(s)
* [ERA-8625](https://allenai.atlassian.net/browse/ERA-8625)
* [Env](https://era-8625.pamdas.org)

### Where / how to start reviewing (optional)
- Creating/Editing patrols and all patrol status related stuff which are using auto start/end


[ERA-8625]: https://allenai.atlassian.net/browse/ERA-8625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ