### PR TITLE
ERA-8639: Refactor `ReportOverview` in das-web-react

### DIFF
--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -78,7 +78,7 @@ import PatrolTracks from '../PatrolTracks';
 import CursorGpsDisplay from '../CursorGpsDisplay';
 import RightClickMarkerDropper from '../RightClickMarkerDropper';
 import ReportGeometryDrawer from '../ReportGeometryDrawer';
-import ReportOverview from '../ReportGeometryDrawer/ReportOverview';
+import MapLocationSelectionOverview from '../MapLocationSelectionOverview';
 
 import './Map.scss';
 import { useFeatureFlag, useMapEventBinding } from '../hooks';
@@ -634,7 +634,7 @@ const Map = ({
       </DelayedUnmount>
 
       {isDrawingEventGeometry && <ReportGeometryDrawer />}
-      {isSelectingEventLocation && <ReportOverview />}
+      {isSelectingEventLocation && <MapLocationSelectionOverview />}
 
       <div className='map-legends'>
         <span className='compass-wrapper' onClick={onRotationControlClick} >

--- a/src/MapLocationSelectionOverview/index.test.js
+++ b/src/MapLocationSelectionOverview/index.test.js
@@ -4,15 +4,15 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import cloneDeep from 'lodash/cloneDeep';
 
-import MapDrawingToolsContextProvider, { MapDrawingToolsContext } from '../../MapDrawingTools/ContextProvider';
-import { MAP_LOCATION_SELECTION_MODES } from '../../ducks/map-ui';
-import { mockStore } from '../../__test-helpers/MockStore';
-import NavigationWrapper from '../../__test-helpers/navigationWrapper';
-import { report } from '../../__test-helpers/fixtures/reports';
-import ReportOverview from './';
+import MapDrawingToolsContextProvider, { MapDrawingToolsContext } from '../MapDrawingTools/ContextProvider';
+import { MAP_LOCATION_SELECTION_MODES } from '../ducks/map-ui';
+import { mockStore } from '../__test-helpers/MockStore';
+import NavigationWrapper from '../__test-helpers/navigationWrapper';
+import { report } from '../__test-helpers/fixtures/reports';
+import MapLocationSelectionOverview from '.';
 
-jest.mock('../../ducks/modals', () => ({
-  ...jest.requireActual('../../ducks/modals'),
+jest.mock('../ducks/modals', () => ({
+  ...jest.requireActual('../ducks/modals'),
   addModal: jest.fn(),
 }));
 
@@ -32,8 +32,8 @@ const mockGeometry = {
   },
 };
 
-describe('ReportOverview', () => {
-  const onClickDiscard = jest.fn(), onClickUndo = jest.fn(), onShowInformationModal = jest.fn();
+describe('MapLocationSelectionOverview', () => {
+  const onClickDiscard = jest.fn(), onClickUndo = jest.fn(), onShowInformation = jest.fn();
   let rerender, store;
 
   let mockReport;
@@ -60,12 +60,12 @@ describe('ReportOverview', () => {
       <Provider store={mockStore(store)}>
         <NavigationWrapper>
           <MapDrawingToolsContextProvider>
-            <ReportOverview
+            <MapLocationSelectionOverview
               isDiscardButtonDisabled={false}
               isUndoButtonDisabled={false}
               onClickDiscard={onClickDiscard}
               onClickUndo={onClickUndo}
-              onShowInformationModal={onShowInformationModal}
+              onShowInformation={onShowInformation}
             />
           </MapDrawingToolsContextProvider>
         </NavigationWrapper>
@@ -78,16 +78,16 @@ describe('ReportOverview', () => {
   });
 
   test('opens the report information modal when clicking the information icon', async () => {
-    expect(onShowInformationModal).toHaveBeenCalledTimes(0);
+    expect(onShowInformation).toHaveBeenCalledTimes(0);
 
     const informationIcon = await screen.findByText('information.svg');
     userEvent.click(informationIcon);
 
-    expect(onShowInformationModal).toHaveBeenCalledTimes(1);
+    expect(onShowInformation).toHaveBeenCalledTimes(1);
   });
 
   test('closes and opens the card', async () => {
-    const collapse = await screen.findByTestId('reportOverview-collapse');
+    const collapse = await screen.findByTestId('mapLocationSelectionOverview-collapse');
 
     expect(collapse).toHaveClass('show');
 
@@ -117,12 +117,12 @@ describe('ReportOverview', () => {
       rerender(<Provider store={mockStore(store)}>
         <NavigationWrapper>
           <MapDrawingToolsContextProvider>
-            <ReportOverview
+            <MapLocationSelectionOverview
             isDiscardButtonDisabled={false}
             isUndoButtonDisabled={false}
             onClickDiscard={onClickDiscard}
             onClickUndo={onClickUndo}
-            onShowInformationModal={onShowInformationModal}
+            onShowInformation={onShowInformation}
           />
           </MapDrawingToolsContextProvider>
         </NavigationWrapper>
@@ -146,7 +146,7 @@ describe('ReportOverview', () => {
         <Provider store={mockStore(store)}>
           <NavigationWrapper>
             <MapDrawingToolsContext.Provider value={{ mapDrawingData }}>
-              <ReportOverview
+              <MapLocationSelectionOverview
                 isDiscardButtonDisabled={false}
                 isUndoButtonDisabled={false}
                 onClickDiscard={onClickDiscard}
@@ -175,7 +175,7 @@ describe('ReportOverview', () => {
         <Provider store={mockStore(store)}>
           <NavigationWrapper>
             <MapDrawingToolsContextProvider>
-              <ReportOverview
+              <MapLocationSelectionOverview
                 isDiscardButtonDisabled={false}
                 isUndoButtonDisabled
                 onClickDiscard={onClickDiscard}
@@ -212,7 +212,7 @@ describe('ReportOverview', () => {
         <Provider store={mockStore(store)}>
           <NavigationWrapper>
             <MapDrawingToolsContextProvider>
-              <ReportOverview
+              <MapLocationSelectionOverview
                 isDiscardButtonDisabled
                 isUndoButtonDisabled={false}
                 onClickDiscard={onClickDiscard}

--- a/src/MapLocationSelectionOverview/styles.module.scss
+++ b/src/MapLocationSelectionOverview/styles.module.scss
@@ -1,6 +1,6 @@
-@import '../../common/styles/vars/colors';
-@import '../../common/styles/animations';
-@import '../../common/styles/layout';
+@import '../common/styles/vars/colors';
+@import '../common/styles/animations';
+@import '../common/styles/layout';
 
 .reportAreaOverview {
   @include fade-in;

--- a/src/ReportGeometryDrawer/index.js
+++ b/src/ReportGeometryDrawer/index.js
@@ -14,7 +14,7 @@ import { validateEventPolygonPoints } from '../utils/geometry';
 import CancelationConfirmationModal from './CancelationConfirmationModal';
 import Footer from './Footer';
 import InformationModal from './InformationModal';
-import ReportOverview from './ReportOverview';
+import MapLocationSelectionOverview from '../MapLocationSelectionOverview';
 import MapDrawingTools from '../MapDrawingTools';
 
 const VERTICAL_POLYGON_PADDING = 100;
@@ -111,7 +111,7 @@ const ReportGeometryDrawer = () => {
 
   const onHideCancellationConfirmationModal = useCallback(() => setShowCancellationConfirmationModal(false), []);
 
-  const onShowInformationModal = useCallback(() => setShowInformationModal(true), []);
+  const onShowInformation = useCallback(() => setShowInformationModal(true), []);
 
   const onHideInformationModal = useCallback(() => setShowInformationModal(false), []);
 
@@ -155,12 +155,12 @@ const ReportGeometryDrawer = () => {
   }, [event.geometry, map]);
 
   return <>
-    <ReportOverview
+    <MapLocationSelectionOverview
       isDiscardButtonDisabled={!points.length}
       isUndoButtonDisabled={!canUndo}
       onClickDiscard={onClickDiscard}
       onClickUndo={onUndo}
-      onShowInformationModal={onShowInformationModal}
+      onShowInformation={onShowInformation}
     />
     <MapDrawingTools
       drawing={isDrawing}


### PR DESCRIPTION
### What does this PR do?
- Move `ReportOverview` directly under `src` and change name to `MapLocationSelectionOverview` since that's the only scenario when we using it now: setting a report location, a report geometry or a patrol location.

### Relevant link(s)
* [ERA-8639](https://allenai.atlassian.net/browse/ERA-8639)
* [Env](https://era-8639.pamdas.org/)

### Where / how to start reviewing (optional)
Things should work exactly the same (just a few warnings less in the dev console).

[ERA-8639]: https://allenai.atlassian.net/browse/ERA-8639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ