### PR TITLE
ERA-8642: Can't access Beta Switches on Low Res Display

### DIFF
--- a/src/GlobalMenuDrawer/styles.module.scss
+++ b/src/GlobalMenuDrawer/styles.module.scss
@@ -2,11 +2,11 @@
 @import '../common/styles/vars/colors';
 
 .globalMenuDrawer {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
   background-color: $off-black;
   color: white;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
   width: 100vw;
 
   button {
@@ -81,6 +81,7 @@
 
 .footer {
   font-size: 0.6875rem;
+  margin-top: auto;
   padding: 0.5rem;
 }
 


### PR DESCRIPTION
### What does this PR do?
Fix drawer styles to keep the footer below the content.

### How does it look
Desktop:
![image](https://github.com/PADAS/das-web-react/assets/11725028/af7acfeb-ebe5-4b00-936e-85e4fcc909a8)

Smaller screen (no longer overlapping the footer cause now it has a scroll bar):
![image](https://github.com/PADAS/das-web-react/assets/11725028/41a2389f-24db-435e-96be-0b5ee59abf25)

Mobile (same here):
![image](https://github.com/PADAS/das-web-react/assets/11725028/7a92758d-20e7-47c7-ab96-6f91322998e2)

### Relevant link(s)
* [ERA-8642](https://allenai.atlassian.net/browse/ERA-8642)
🚨 CircleCI builds failing so the environment hasn't been deployed 🚨


[ERA-8642]: https://allenai.atlassian.net/browse/ERA-8642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ