### PR TITLE
including empty strings in considered values for report form change/update detection

### DIFF
--- a/src/ReportManager/ReportDetailView/index.js
+++ b/src/ReportManager/ReportDetailView/index.js
@@ -73,7 +73,7 @@ const calculateFormattedReportDiffs = (reportForm, originalReport) => {
 const calculateSchemaFieldsChanges = (reportField, reportSchemaProps, originalReport) => Object.entries(reportField).reduce((acc, [reportFieldKey, reportFieldValue]) => {
   const schemaDefaultValue = reportSchemaProps?.[reportFieldKey]?.default;
   const defValueHasChanged = schemaDefaultValue && reportFieldValue !== schemaDefaultValue;
-  const hasReportValue = !schemaDefaultValue && ( reportFieldValue !== null && reportFieldValue !== undefined && reportFieldValue !== '' );
+  const hasReportValue = !schemaDefaultValue && ( reportFieldValue !== null && reportFieldValue !== undefined);
   const defValueWasReset = reportFieldValue === schemaDefaultValue && reportFieldValue !== originalReport.event_details[reportFieldKey];
   return defValueHasChanged || hasReportValue || defValueWasReset ? { ...acc, [reportFieldKey]: reportFieldValue } : acc;
 }, {});


### PR DESCRIPTION
https://allenai.atlassian.net/browse/ERA-8697

---

### What does this PR do?
- The change validation logic for reports was preventing saved reports from including emptied strings. That means end users couldn't delete string values, as that deletion would be omitted and the original value would remain.

### How does it look
N/A

### Relevant link(s)
* Tracking tickets: https://allenai.atlassian.net/browse/ERA-8697
* env: it's a one-liner, let's just test in stage please @Alcoto95 @AlanCalvillo 

### Where / how to start reviewing (optional)
- It's a very brief change, and should be self-explanatory.

### Any background context you want to provide(if applicable)
- This is a P1 in production. We should bundle it with ERA-8696 as a hotfix.