### PR TITLE
ERA-8661: Add report/patrol button shows instantly

### DIFF
--- a/src/AddItemButton/AddItemModal/AddPatrolTab/index.js
+++ b/src/AddItemButton/AddItemModal/AddPatrolTab/index.js
@@ -1,5 +1,6 @@
 import React, { memo, useCallback, useContext, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 
 import { AddItemContext } from '../..';
 import { createNewPatrolForPatrolType, generatePseudoReportCategoryForPatrolTypes, openModalForPatrol } from '../../../utils/patrols';
@@ -8,7 +9,6 @@ import { MapContext } from '../../../App';
 import { trackEvent } from '../../../utils/analytics';
 import { useFeatureFlag } from '../../../hooks';
 import { uuid } from '../../../utils/string';
-import { useSelector } from 'react-redux';
 
 import SearchBar from '../../../SearchBar';
 import TypesList from '../TypesList';
@@ -20,8 +20,10 @@ const { ENABLE_PATROL_NEW_UI } = FEATURE_FLAG_LABELS;
 const AddPatrolTab = ({ navigate, onHideModal }) => {
   const map = useContext(MapContext);
   const { analyticsMetadata, formProps, onAddPatrol, patrolData } = useContext(AddItemContext);
-  const patrolTypes = useSelector((state) => state.data.patrolTypes);
+
   const enableNewPatrolUI = useFeatureFlag(ENABLE_PATROL_NEW_UI);
+
+  const patrolTypes = useSelector((state) => state.data.patrolTypes);
 
   const [searchText, setSearchText] = useState('');
 

--- a/src/AddItemButton/AddItemModal/AddReportTab/index.js
+++ b/src/AddItemButton/AddItemModal/AddReportTab/index.js
@@ -1,15 +1,15 @@
 import React, { memo, useCallback, useContext, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 
 import { AddItemContext } from '../..';
 import { createNewReportForEventType, openModalForReport } from '../../../utils/events';
 import { FEATURE_FLAG_LABELS, TAB_KEYS } from '../../../constants';
+import { getUserCreatableEventTypesByCategory } from '../../../selectors';
 import { MapContext } from '../../../App';
 import { trackEvent } from '../../../utils/analytics';
 import { useFeatureFlag } from '../../../hooks';
 import { uuid } from '../../../utils/string';
-import { useSelector } from 'react-redux';
-import { getUserCreatableEventTypesByCategory } from '../../../selectors';
 
 import SearchBar from '../../../SearchBar';
 import Select from '../../../Select';
@@ -24,9 +24,10 @@ const SCROLL_OFFSET_CORRECTION = 96;
 const AddReportTab = ({ navigate, onHideModal }) => {
   const map = useContext(MapContext);
   const { analyticsMetadata, formProps, onAddReport, reportData } = useContext(AddItemContext);
-  const eventsByCategory = useSelector(getUserCreatableEventTypesByCategory);
 
   const enableNewReportUI = useFeatureFlag(ENABLE_REPORT_NEW_UI);
+
+  const eventsByCategory = useSelector(getUserCreatableEventTypesByCategory);
 
   const reportTypesListRef = useRef(null);
 

--- a/src/AddItemButton/index.js
+++ b/src/AddItemButton/index.js
@@ -1,17 +1,16 @@
 import React, { createContext, memo, useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 
 import { ReactComponent as AddButtonIcon } from '../common/images/icons/add_button.svg';
 
 import { addReportFormProps } from '../proptypes';
 import { trackEvent } from '../utils/analytics';
-
+import { getUserCreatableEventTypesByCategory } from '../selectors';
 import AddItemModal from './AddItemModal';
 import DelayedUnmount from '../DelayedUnmount';
 
 import styles from './styles.module.scss';
-import { useSelector } from 'react-redux';
-import { getUserCreatableEventTypesByCategory } from '../selectors';
 
 export const AddItemContext = createContext();
 


### PR DESCRIPTION
### What does this PR do?
- Adding conditional rendering to `<AddItemButton />` to avoid showing empty modal


### Relevant link(s)
* [ERA-8661](https://allenai.atlassian.net/browse/ERA-8661)
* [Env](https://era-8661.pamdas.org)

### Where / how to start reviewing (optional)
- All places where where Add report/patrol button is used (as far as I remember): Report/Patrol feed, map controls and map context menu


[ERA-8661]: https://allenai.atlassian.net/browse/ERA-8661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ