### PR TITLE
auth token management to prevent accidental login sharing

### DIFF
--- a/src/RequestConfigManager/index.js
+++ b/src/RequestConfigManager/index.js
@@ -141,7 +141,11 @@ const RequestConfigManager = ({
     if (token?.access_token) {
       axios.defaults.headers.common['Authorization'] = `Bearer ${token.access_token}`;
     }
-  }, [token]);
+
+    return () => {
+      delete axios.defaults.headers.common['Authorization'];
+    };
+  }, [token?.access_token]);
   /* end auth header */
 
   return null;

--- a/src/ducks/user.js
+++ b/src/ducks/user.js
@@ -88,7 +88,7 @@ export const setUserLocationAccessGranted = (granted = false) => ({
 
 // reducers
 const INITIAL_USER_STATE = {};
-const userReducer = (state = INITIAL_USER_STATE, action = {}) => {
+const userReducer = globallyResettableReducer((state = INITIAL_USER_STATE, action = {}) => {
   const { type, payload } = action;
 
   switch (type) {
@@ -99,7 +99,7 @@ const userReducer = (state = INITIAL_USER_STATE, action = {}) => {
     return state;
   }
   }
-};
+}, INITIAL_USER_STATE);
 
 export default userReducer;
 


### PR DESCRIPTION
What does this PR do?
A recent upgrade to the backend oAuth library has exposed a long-lived, formerly benign bug on the front end -- our Axios instance was holding onto the auth token after the user had logged out, and passing it as the Bearer token for logging in as a new user. With our oAuth library upgrade, that token now takes precedence over the username/password credentials, meaning if you log in as User1, then log out and log in as User2, you end up getting the token and user identity of User 1 all over again. That's a big security no no 😢
How does it look
N/A

Relevant link(s)
Tracking tickets: [ERA-8741](https://allenai.atlassian.net/browse/ERA-8741)
This is small enough to just test in stage 🙏 🙏 🙏
Where / how to start reviewing (optional)
Log in with a user, log out, log in with another, confirm no credentials have not leaked across user sessions

[ERA-8741]: https://allenai.atlassian.net/browse/ERA-8741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ