### PR TITLE
ERA-8629: Open all Patrols Status change dropdown at the same time in Patrols Feed

### DIFF
--- a/src/PatrolListItem/index.js
+++ b/src/PatrolListItem/index.js
@@ -93,17 +93,20 @@ const PatrolListItem = ({
     return null;
   }, [isPatrolActiveOrDone, isPatrolScheduled, isPatrolCancelled, patrolElapsedTime, patrolsData, scheduledStartTime]);
 
-  const onLocationClick = useCallback(() => {
+  const onLocationClick = useCallback((event) => {
+    event.stopPropagation();
     patrolListItemTracker.track('Click "jump to location" from patrol list item');
   }, []);
 
-  const restorePatrolAndTrack = useCallback(() => {
+  const restorePatrolAndTrack = useCallback((event) => {
+    event.stopPropagation();
     patrolListItemTracker.track('Restore patrol from patrol list item');
 
     restorePatrol();
   }, [restorePatrol]);
 
-  const startPatrolAndTrack = useCallback(() => {
+  const startPatrolAndTrack = useCallback((event) => {
+    event.stopPropagation();
     patrolListItemTracker.track('Start patrol from patrol list item');
 
     startPatrol();
@@ -167,7 +170,7 @@ const PatrolListItem = ({
   }, [onSelfManagedStateChange, patrol, patrolState, setPatrolState]);
 
   const renderedControlsComponent = showControls
-    ? <div className={styles.controls} onClick={(event) => event.stopPropagation()}>
+    ? <div className={styles.controls}>
       <StateDependentControls />
       <PatrolMenu
         data-testid={`patrol-list-item-kebab-menu-${patrol.id}`}

--- a/src/PatrolMenu/index.js
+++ b/src/PatrolMenu/index.js
@@ -1,4 +1,4 @@
-import React, { memo, useMemo, useCallback } from 'react';
+import React, { memo, useMemo, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Dropdown from 'react-bootstrap/Dropdown';
 
@@ -11,7 +11,7 @@ import TextCopyBtn from '../TextCopyBtn';
 
 import styles from './styles.module.scss';
 
-const { Toggle, Menu, Item/* , Header, Divider */ } = Dropdown;
+const { Toggle, Menu, Item } = Dropdown;
 const patrolListItemTracker = trackEventFactory(PATROL_LIST_ITEM_CATEGORY);
 
 const PatrolMenu = (props) => {
@@ -81,8 +81,16 @@ const PatrolMenu = (props) => {
     }
   }, [canEnd, onPatrolChange, patrolStartStopTitle]);
 
-  return  <Dropdown align="end" className={styles.kebabMenu} {...rest}>
-    <Toggle as="button" className={styles.kebabToggle}>
+  const handleClickOutside = useCallback(() => menuRef?.current?.classList.remove('show'), []);
+  const onDropdownClick = useCallback((event) => event.stopPropagation(), []);
+
+  useEffect(() => {
+    window.addEventListener('click', handleClickOutside, true);
+    return () => window.removeEventListener('click', handleClickOutside);
+  }, []);
+
+  return  <Dropdown align='end' className={styles.kebabMenu} {...rest} onClick={onDropdownClick}>
+    <Toggle as='button' className={styles.kebabToggle} >
       <KebabMenuIcon />
     </Toggle>
     <Menu ref={menuRef}>

--- a/src/PatrolTrackControls/index.js
+++ b/src/PatrolTrackControls/index.js
@@ -27,7 +27,7 @@ const PatrolTrackControls = ({ patrol, className, onLocationClick }) => {
   const trackToggleButtonRef = useRef(null);
   const { leader } = patrolData;
 
-  const handleLocationClick = useCallback(() => {
+  const handleLocationClick = useCallback((event) => {
     const patrolTrackIsVisible = [...patrolTrackState.pinned, ...patrolTrackState.visible].includes(patrol.id);
     const leaderTrackIsVisible = !!leader && [...trackState.pinned, ...trackState.visible].includes(leader.id);
 
@@ -37,7 +37,7 @@ const PatrolTrackControls = ({ patrol, className, onLocationClick }) => {
     }
 
     fitMapBoundsForAnalyzer(map, patrolBounds);
-    onLocationClick();
+    onLocationClick(event);
   }, [leader, map, onLocationClick, patrol.id, patrolBounds, patrolTrackState, trackState]);
 
   return <div className={`${styles.patrolTrackControls} ${className}`}>

--- a/src/TrackToggleButton/PatrolAwareTrackToggleButton.js
+++ b/src/TrackToggleButton/PatrolAwareTrackToggleButton.js
@@ -21,12 +21,12 @@ const PatrolAwareTrackToggleButton = ({ buttonRef, dispatch: _dispatch, patrolDa
   const subjectTrackPinned = useMemo(() => !!leader && subjectTrackState.pinned.includes(leader.id), [leader, subjectTrackState.pinned]);
   const subjectTrackVisible = useMemo(() => !!leader && !subjectTrackPinned && subjectTrackState.visible.includes(leader.id), [leader, subjectTrackPinned, subjectTrackState.visible]);
   const subjectTrackHidden = useMemo(() => !subjectTrackPinned && !subjectTrackVisible, [subjectTrackPinned, subjectTrackVisible]);
-  // trackVisible={patrolTrackVisible} trackPinned={patrolTrackPinned} onClick={onTrackButtonClick}
 
   const patrolToggleStates = useMemo(() => [patrolTrackPinned, patrolTrackVisible, patrolTrackHidden], [patrolTrackHidden, patrolTrackPinned, patrolTrackVisible]);
   const subjectToggleStates = useMemo(() => [subjectTrackPinned, subjectTrackVisible, subjectTrackHidden], [subjectTrackHidden, subjectTrackPinned, subjectTrackVisible]);
 
-  const onTrackButtonClick = useCallback(() => {
+  const onTrackButtonClick = useCallback((event) => {
+    event.stopPropagation();
     const nextPatrolTrackStateIfToggled = patrolTrackPinned
       ? 'hidden'
       : patrolTrackHidden


### PR DESCRIPTION
### What does this PR do?
- It prevents the user to open several patrol menu at same time
- It fixes some event propagation issues among some components

### Relevant link(s)
* [ERA-8629](https://allenai.atlassian.net/browse/ERA-8629)
* [Hosted demo environments](https://era-8629.pamdas.org)

### Where / how to start reviewing (optional)
- Let's take a look to the patrol menu actions and patrol item controls, basically any control of a patrol item in the feed should be working as usual


[ERA-8629]: https://allenai.atlassian.net/browse/ERA-8629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ