### PR TITLE
definitive link to patrol details view for patrol link copy button

### DIFF
--- a/src/PatrolMenu/index.js
+++ b/src/PatrolMenu/index.js
@@ -2,7 +2,7 @@ import React, { memo, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import Dropdown from 'react-bootstrap/Dropdown';
 
-import { PATROL_UI_STATES, PATROL_API_STATES, PERMISSION_KEYS, PERMISSIONS } from '../constants';
+import { DAS_HOST, PATROL_UI_STATES, PATROL_API_STATES, PERMISSION_KEYS, PERMISSIONS } from '../constants';
 import { usePermissions } from '../hooks';
 import KebabMenuIcon from '../KebabMenuIcon';
 import { trackEventFactory, PATROL_LIST_ITEM_CATEGORY } from '../utils/analytics';
@@ -91,7 +91,7 @@ const PatrolMenu = (props) => {
       { !!patrol.id && <Item className={styles.copyBtn}>
         <TextCopyBtn
             label='Copy patrol link'
-            text={window.location.href}
+            text={`${DAS_HOST}/patrols/${patrol.id}`}
             icon={null}
             successMessage='Link copied'
             permitPropagation


### PR DESCRIPTION
### What does this PR do?
Ensures the "copy patrol link" button always links to a patrol's detail view

### How does it look
N/A

### Relevant link(s)
* https://allenai.atlassian.net/browse/ERA-8769
* No env - can we just test this in stage?

### Where / how to start reviewing (optional)
N/A

### Any background context you want to provide(if applicable)
N/A
