### PR TITLE
ERA-8823: Setting a user profile switches to the main user automatically

### DIFF
--- a/src/Nav/index.js
+++ b/src/Nav/index.js
@@ -28,6 +28,17 @@ import './Nav.scss';
 const mainToolbarTracker = trackEventFactory(MAIN_TOOLBAR_CATEGORY);
 const MessageMenu = lazy(() => import('./MessageMenu'));
 
+const reloadOnceProfileIsPersisted = (isMainUser) => {
+  setTimeout(() => {
+    const isProfilePersisted = !!window.localStorage.getItem('persist:userProfile')?.includes('username');
+    if (isMainUser ? !isProfilePersisted : isProfilePersisted) {
+      window.location.reload(true);
+    } else {
+      reloadOnceProfileIsPersisted();
+    }
+  }, [250]);
+};
+
 const Nav = ({
   addModal,
   clearAuth,
@@ -70,9 +81,8 @@ const Nav = ({
       mainToolbarTracker.track('Select to operate as a user profile');
       setUserProfile(profile, isMainUser ? false : true);
     }
-    setTimeout(() => {
-      window.location.reload(true);
-    }, [1000]);
+
+    reloadOnceProfileIsPersisted(isMainUser);
   }, [clearUserProfile, setUserProfile, user.username]);
 
   const onProfileClick = useCallback((profile) => {

--- a/src/Nav/index.test.js
+++ b/src/Nav/index.test.js
@@ -126,6 +126,7 @@ describe('the Nav component', () => {
       delete window.location;
       window.location = { reload: jest.fn() };
 
+      window.localStorage.setItem('persist:userProfile', '{"username":""profile""}');
       window.location.reload = reloadMock;
 
       renderWithWrapper(
@@ -148,12 +149,9 @@ describe('the Nav component', () => {
 
       expect(state.data.selectedUserProfile).toEqual(userWithoutPin);
 
-      jest.runAllTimers();
+      jest.advanceTimersByTime(500);
 
-      await waitFor(() => {
-        expect(reloadMock).toHaveBeenCalled();
-      });
-
+      expect(reloadMock).toHaveBeenCalled();
     });
 
     test('selecting a PIN-protected profile', async () => {
@@ -181,11 +179,31 @@ describe('the Nav component', () => {
 
       expect(state.data.selectedUserProfile).toEqual(anotherPinProfile);
 
-      jest.runAllTimers();
+      jest.advanceTimersByTime(500);
 
-      await waitFor(() => {
-        expect(reloadMock).toHaveBeenCalled();
+      expect(reloadMock).toHaveBeenCalled();
+    });
+
+    test('does not redirect until the profile is persisted', async () => {
+      window.localStorage.removeItem('persist:userProfile');
+      const nonPinProfileLink = await screen.getByRole('button', {
+        name: userWithoutPin.username,
       });
+      nonPinProfileLink.click();
+
+      const state = store.getState();
+
+      expect(state.data.selectedUserProfile).toEqual(userWithoutPin);
+
+      jest.advanceTimersByTime(500);
+
+      expect(reloadMock).not.toHaveBeenCalled();
+
+      window.localStorage.setItem('persist:userProfile', '{"username":""profile""}');
+
+      jest.advanceTimersByTime(500);
+
+      expect(reloadMock).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Fixes bug when switching to a profile. We used to reload the page after one second, but in certain conditions that may not be enough time for Redux to persist its profile reducer in local storage. Instead of giving a fixed amount of time, we check every 250 ms if the reducer was persisted so we can reload the page.