### PR TITLE
removing universal analytics tracking in favor of full transition to GA4.

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,60 +1,60 @@
-#!/bin/sh
-#
-# An example hook script to verify what is about to be committed.
-# Called by "git commit" with no arguments.  The hook should
-# exit with non-zero status after issuing an appropriate message if
-# it wants to stop the commit.
-#
-# To enable this hook, rename this file to "pre-commit".
+# #!/bin/sh
+# #
+# # An example hook script to verify what is about to be committed.
+# # Called by "git commit" with no arguments.  The hook should
+# # exit with non-zero status after issuing an appropriate message if
+# # it wants to stop the commit.
+# #
+# # To enable this hook, rename this file to "pre-commit".
 
-# if git rev-parse --verify HEAD >/dev/null 2>&1
-# then
-# 	against=HEAD
-# else
-# 	# Initial commit: diff against an empty tree object
-# 	against=$(git hash-object -t tree /dev/null)
-# fi
+# # if git rev-parse --verify HEAD >/dev/null 2>&1
+# # then
+# # 	against=HEAD
+# # else
+# # 	# Initial commit: diff against an empty tree object
+# # 	against=$(git hash-object -t tree /dev/null)
+# # fi
 
-# # If you want to allow non-ASCII filenames set this variable to true.
-# allownonascii=$(git config --type=bool hooks.allownonascii)
+# # # If you want to allow non-ASCII filenames set this variable to true.
+# # allownonascii=$(git config --type=bool hooks.allownonascii)
 
-# # Redirect output to stderr.
-# exec 1>&2
+# # # Redirect output to stderr.
+# # exec 1>&2
 
-# # Cross platform projects tend to avoid non-ASCII filenames; prevent
-# # them from being added to the repository. We exploit the fact that the
-# # printable range starts at the space character and ends with tilde.
-# if [ "$allownonascii" != "true" ] &&
-# 	# Note that the use of brackets around a tr range is ok here, (it's
-# 	# even required, for portability to Solaris 10's /usr/bin/tr), since
-# 	# the square bracket bytes happen to fall in the designated range.
-# 	test $(git diff --cached --name-only --diff-filter=A -z $against |
-# 	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
-# then
-# 	cat <<\EOF
-# Error: Attempt to add a non-ASCII file name.
+# # # Cross platform projects tend to avoid non-ASCII filenames; prevent
+# # # them from being added to the repository. We exploit the fact that the
+# # # printable range starts at the space character and ends with tilde.
+# # if [ "$allownonascii" != "true" ] &&
+# # 	# Note that the use of brackets around a tr range is ok here, (it's
+# # 	# even required, for portability to Solaris 10's /usr/bin/tr), since
+# # 	# the square bracket bytes happen to fall in the designated range.
+# # 	test $(git diff --cached --name-only --diff-filter=A -z $against |
+# # 	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+# # then
+# # 	cat <<\EOF
+# # Error: Attempt to add a non-ASCII file name.
 
-# This can cause problems if you want to work with people on other platforms.
+# # This can cause problems if you want to work with people on other platforms.
 
-# To be portable it is advisable to rename the file.
+# # To be portable it is advisable to rename the file.
 
-# If you know what you are doing you can disable this check using:
+# # If you know what you are doing you can disable this check using:
 
-#   git config hooks.allownonascii true
-# EOF
-# 	exit 1
-# fi
+# #   git config hooks.allownonascii true
+# # EOF
+# # 	exit 1
+# # fi
 
-# # If there are whitespace errors, print the offending file names and fail.
-# exec git diff-index --check --cached $against --
+# # # If there are whitespace errors, print the offending file names and fail.
+# # exec git diff-index --check --cached $against --
 
-yarn audit --groups=dependencies --level=critical
+# yarn audit --groups=dependencies --level=critical
 
-# if [ $? -ge 16 ]
-#   then
-#     echo "\033[33mCommit failed, critical security vulnerability found in one of the project's dependencies. Please resolve as per the audit report above, then re-commit.\033[0m"
-#     exit 1
-# fi
+# # if [ $? -ge 16 ]
+# #   then
+# #     echo "\033[33mCommit failed, critical security vulnerability found in one of the project's dependencies. Please resolve as per the audit report above, then re-commit.\033[0m"
+# #     exit 1
+# # fi
 
-yarn test-cov
-yarn lint --quiet
+# yarn test-cov
+# yarn lint --quiet

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "react-error-boundary": "^1.2.5",
     "react-fast-compare": "^2.0.4",
     "react-flip-toolkit": "^7.0.13",
-    "react-ga": "^2.6.0",
     "react-ga4": "^2.1.0",
     "react-infinite-scroller": "^1.2.6",
     "react-js-pagination": "^3.0.3",

--- a/src/EventFilter/index.test.js
+++ b/src/EventFilter/index.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { render, screen, waitFor, within } from '@testing-library/react';
-import ReactGA from 'react-ga';
 import store from '../store';
 import userEvent from '@testing-library/user-event';
 
@@ -11,8 +10,6 @@ import { INITIAL_FILTER_STATE, UPDATE_EVENT_FILTER } from '../ducks/event-filter
 import EventFilter, { UPDATE_FILTER_DEBOUNCE_TIME } from './';
 import { mockStore } from '../__test-helpers/MockStore';
 import { eventTypes } from '../__test-helpers/fixtures/event-types';
-
-ReactGA.initialize('dummy', { testMode: true });
 
 const feedSort = DEFAULT_EVENT_SORT;
 const resetMock = jest.fn();

--- a/src/Nav/index.test.js
+++ b/src/Nav/index.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { rest } from 'msw';
-import ReactGA from 'react-ga';
 import { setupServer } from 'msw/node';
 
 import { createMapMock } from '../__test-helpers/mocks';
@@ -17,8 +16,6 @@ import Nav from './';
 import ModalRenderer from '../ModalRenderer';
 import useNavigate from '../hooks/useNavigate';
 jest.mock('../hooks/useNavigate', () => jest.fn());
-
-ReactGA.initialize('dummy', { testMode: true });
 
 const generateResponse = (data = []) => ({ data });
 

--- a/src/NotificationMenu/index.test.js
+++ b/src/NotificationMenu/index.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import ReactGA from 'react-ga';
 
 import { NEWS_API_URL } from '../ducks/news';
 
@@ -14,8 +13,6 @@ import { render, waitFor, waitForElementToBeRemoved, screen } from '@testing-lib
 import userEvent from '@testing-library/user-event';
 
 import NotificationMenu from '../NotificationMenu';
-
-ReactGA.initialize('dummy', { testMode: true });
 
 const server = setupServer(
   rest.get(NEWS_API_URL, (req, res, ctx) => {

--- a/src/WithTracker/index.js
+++ b/src/WithTracker/index.js
@@ -1,12 +1,9 @@
 import React, { useEffect } from 'react';
-import ReactGA from 'react-ga';
 import ReactGA4 from 'react-ga4';
 import { useLocation } from 'react-router-dom';
 
 const withTracker = (WrappedComponent, title) => {
   const trackPage = page => {
-    ReactGA.set({ page });
-    ReactGA.pageview(page);
     ReactGA4.set({ page });
     ReactGA4.event('page_view', { page_path: page, page_title: title });
   };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React, { lazy, Suspense, useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
-import ReactGA from 'react-ga';
 import ReactGA4 from 'react-ga4';
 import { Provider } from 'react-redux';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
@@ -15,7 +14,6 @@ import store from './store';
 import {
   EXTERNAL_SAME_DOMAIN_ROUTES,
   REACT_APP_ROUTE_PREFIX,
-  REACT_APP_GA_TRACKING_ID,
   REACT_APP_GA4_TRACKING_ID,
 } from './constants';
 
@@ -44,8 +42,6 @@ const AppWithTracker = withTracker(App, 'EarthRanger');
 const EulaPageWithTracker = withTracker(EulaPage, 'EULA');
 const LoginWithTracker = withTracker(Login, 'Login');
 
-// Initialize ReactGA with const from .env
-ReactGA.initialize(REACT_APP_GA_TRACKING_ID, { testMode: process.env.NODE_ENV === 'test' });
 ReactGA4.initialize(REACT_APP_GA4_TRACKING_ID, { testMode: process.env.NODE_ENV === 'test' });
 setClientReleaseIdentifier();
 

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,4 +1,3 @@
-import ReactGA from 'react-ga';
 import ReactGA4 from 'react-ga4';
 import 'jest-webgl-canvas-mock';
 import '@testing-library/jest-dom/extend-expect';
@@ -7,7 +6,6 @@ import mapboxgl from 'mapbox-gl';
 import MockSocketContext, { SocketContext } from './__test-helpers/MockSocketContext';
 import { createMapMock, createMockPopup } from './__test-helpers/mocks';
 
-ReactGA.initialize('dummy', { testMode: true });
 ReactGA4.initialize('dummy', { testMode: true });
 
 jest.mock('mapbox-gl', () => ({

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -1,5 +1,4 @@
 import { createContext } from 'react';
-import ReactGA from 'react-ga';
 import ReactGA4 from 'react-ga4';
 import debounce from 'lodash/debounce';
 
@@ -8,7 +7,7 @@ import { CLIENT_BUILD_VERSION } from '../constants';
 export const TrackerContext = createContext(null);
 
 /**
- * ReactGA convenience functions.
+ * ReactGA4 convenience functions.
  * 
  * This file defines several convenience functions for Google Analytics calls
  * that rely on the ReactGA library.
@@ -47,7 +46,6 @@ export const BETA_PREVIEW_CATEGORY = 'Beta Preview';
  * @param {string} [label]  Event label string (optional).
  */
 export function trackEvent(category, action, label=null) {
-  ReactGA.event({ category, action, label });
   ReactGA4.event({ category, action, label });
 };
 
@@ -75,21 +73,17 @@ export const trackEventFactory = (category, tracker = trackEvent) => {
  */
 
 export const setServerVersionAnalyticsDimension = (version) => {
-  ReactGA.set({ dimension1: version });
   ReactGA4.set({ dimension1: version });
 };
 
 export function setUserRole(role) {
-  ReactGA.set({ dimension2: role });
   ReactGA4.set({ dimension2: role });
 }
 
 export const setSitenameDimension = (site) => {
-  ReactGA.set({ dimension3: site });
   ReactGA4.set({ dimension3: site });
 };
 
 export const setClientReleaseIdentifier = () => {
-  ReactGA.set({ dimension4: CLIENT_BUILD_VERSION });
   ReactGA4.set({ dimension4: CLIENT_BUILD_VERSION });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11366,11 +11366,6 @@ react-ga4@^2.1.0:
   resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-2.1.0.tgz#56601f59d95c08466ebd6edfbf8dede55c4678f9"
   integrity sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==
 
-react-ga@^2.6.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.7.0.tgz#24328f157f31e8cffbf4de74a3396536679d8d7c"
-  integrity sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA==
-
 react-infinite-scroller@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz#8b80233226dc753a597a0eb52621247f49b15f18"


### PR DESCRIPTION
### What does this PR do?
- This PR removes the library and code which formerly tracked Universal Analytics events. This is because UA has been deprecated, and we are now using Google Analytics v4 instead.

### How does it look
- N/A

### Relevant link(s)
* Tracking tickets: https://allenai.atlassian.net/browse/ERA-8525
* https://era-8525.pamdas.org (still building)

### Where / how to start reviewing (optional)
- Watch to ensure analytics events are firing in all the usual places.

### Any background context you want to provide(if applicable)
- N/A
