### PR TITLE
ERA-8848 The admin fails to load CSS

### DIFF
--- a/prod-nginx-default.conf
+++ b/prod-nginx-default.conf
@@ -57,7 +57,7 @@ server {
 		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_set_header Host $http_host;
 		proxy_set_header   X-Real-IP $http_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Host $server_name; 
+		proxy_set_header   X-Forwarded-Host $server_name; 
 
 		proxy_pass http://app_server;
 	}


### PR DESCRIPTION
### What does this PR do?
fix: set the nginx proxy headers including host name so that the receiving API server that has the css static files knows what the real hostname was. Previously it was gettin app_server as the hostname which breaks MT.

