### PR TITLE
ERA-8831: Lack of whitespace between columns in report form fields

### DIFF
--- a/src/ReportManager/DetailsSection/styles.module.scss
+++ b/src/ReportManager/DetailsSection/styles.module.scss
@@ -132,19 +132,15 @@
     display: none;
   }
 
-  [class*=row] {
-    padding: 0;
-
+  [class='fieldset row'] {
     & > [class*=col-]:nth-child(odd){
       padding-right: 0.5rem;
     }
+  }
 
+  [class*=row] {
     & > [class*=col-]:nth-child(even){
-      padding-left: 0.5rem;
-    }
-
-    > * {
-      padding: 0;
+      padding-right: 0.5rem;
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
- It extends CSS rules for adding padding to report form field

### How does it look
- before
![image](https://github.com/PADAS/das-web-react/assets/20525031/101b4c6d-73bf-4875-a6cc-6ba6f849c37c)

- after
![image](https://github.com/PADAS/das-web-react/assets/20525031/f94c82c3-1270-465d-8ca7-c9a83537125b)

### Relevant link(s)
* Tracking tickets: [ERA-8331>](https://allenai.atlassian.net/browse/ERA-8331)
* [Env](https://era-8331.pamdas.org) Building 🔧 
