### PR TITLE
ERA-8839: Fixing height of date picker

### DIFF
--- a/src/DatePicker/index.js
+++ b/src/DatePicker/index.js
@@ -268,6 +268,7 @@ const CustomDatePicker = ({
     timeInputLabel={DEFAULT_TIME_INPUT_LABEL}
     showTimeInput={showTimeInput}
     customTimeInput={showTimeInput ? <CustomTimePicker/> : null}
+    fixedHeight
     {...rest}
   />;
 };


### PR DESCRIPTION
### What does this PR do?
- It adds [fixedHeight prop](https://reactdatepicker.com/#example-fixed-height-of-calendar) to date picker control

### How does it look
- Before

https://github.com/PADAS/das-web-react/assets/20525031/75194b6c-0c9e-4ad4-b788-e690559e81ab

- After

https://github.com/PADAS/das-web-react/assets/20525031/c8670aad-a7c0-4235-8aa7-ce942450baae



### Relevant link(s)
* [ERA-8839](https://allenai.atlassian.net/browse/ERA-8839)
* [Env](https://era-8839.pamdas.org) 🔧 building


[ERA-8839]: https://allenai.atlassian.net/browse/ERA-8839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ