### PR TITLE
[ERA-8838] adding related subject to subject popup report form data

### DIFF
--- a/src/SubjectPopup/index.js
+++ b/src/SubjectPopup/index.js
@@ -1,6 +1,6 @@
 import React, { memo, Fragment, useCallback, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import format from 'date-fns/format';
 import Button from 'react-bootstrap/Button';
 
@@ -19,8 +19,11 @@ import styles from './styles.module.scss';
 
 const STORAGE_KEY = 'showSubjectDetailsByDefault';
 
-const SubjectPopup = ({ data, timeSliderState }) => {
+const SubjectPopup = ({ data }) => {
   const  { geometry, properties } = data;
+
+  const timeSliderState = useSelector(state => state.view.timeSliderState);
+
   const  { active: isTimeSliderActive } = timeSliderState;
 
   const device_status_properties =
@@ -69,7 +72,7 @@ const SubjectPopup = ({ data, timeSliderState }) => {
         <AddItemButton
           analyticsMetadata={{ category: MAP_INTERACTION_CATEGORY, location: 'subject popover' }}
           className={styles.addReport}
-          reportData={{ location: locationObject, reportedById }}
+          reportData={{ location: locationObject, reportedById, related_subjects: [reportedById] }}
           showLabel={false}
           variant="secondary"
         />
@@ -109,8 +112,7 @@ const SubjectPopup = ({ data, timeSliderState }) => {
   </>;
 };
 
-const mapStateToProps = ({ view: { timeSliderState } }) => ({ timeSliderState });
-export default connect(mapStateToProps, null)(memo(SubjectPopup));
+export default memo(SubjectPopup);
 
 SubjectPopup.propTypes = {
   data: PropTypes.object.isRequired,

--- a/src/SubjectPopup/index.test.js
+++ b/src/SubjectPopup/index.test.js
@@ -1,78 +1,84 @@
 
 
 import React from 'react';
-import { Provider } from 'react-redux';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { addModal } from '../ducks/modals';
-import { mockStore } from '../__test-helpers/MockStore';
-import NavigationWrapper from '../__test-helpers/navigationWrapper';
-import { createMapMock } from '../__test-helpers/mocks';
-import { subjectFeatureWithMultipleDeviceProps, subjectFeatureWithOneDeviceProp, staticSubjectFeature } from '../__test-helpers/fixtures/subjects';
+import { Provider, useSelector }  from 'react-redux';
 
 import { GPS_FORMATS } from '../utils/location';
+
+import { subjectFeatureWithMultipleDeviceProps, subjectFeatureWithOneDeviceProp, staticSubjectFeature } from '../__test-helpers/fixtures/subjects';
+
 import { getSubjectDefaultDeviceProperty } from '../utils/subjects';
+
+import { mockStore } from '../__test-helpers/MockStore';
 
 import SubjectPopup from './';
 
-jest.mock('../ducks/modals', () => ({
-  ...jest.requireActual('../ducks/modals'),
-  addModal: jest.fn(),
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
 }));
 
-let store = mockStore({
-  data: {
-    eventFilter: {
-      filter: {
-        date_range: {
-          lower: null,
-          upper: null,
-        },
-      },
-    },
-    tracks: {},
-  },
-  view: {
-    featureFlagOverrides: {},
-    heatmapSubjectIDs: [],
-    timeSliderState: {
-      active: false,
-      virtualDate: null,
-    },
-    trackLength: {
-      origin: 'customLength',
-      length: 21,
-    },
-    subjectTrackState: {
-      visible: [],
-      pinned: [],
-    },
-    patrolTrackState: {
-      visible: [],
-      pinned: [],
-    },
-    userPreferences: {
-      gpsFormat: GPS_FORMATS.DEG,
-    },
-  },
-});
 
 describe('SubjectPopup', () => {
+  let renderWithWrapper, Wrapper, state;
+  beforeEach(() => {
+    state = {
+      data: {
+        eventFilter: {
+          filter: {
+            date_range: {
+              lower: null,
+              upper: null,
+            },
+          },
+        },
+        tracks: {},
+      },
+      view: {
+        featureFlagOverrides: {},
+        heatmapSubjectIDs: [],
+        timeSliderState: {
+          active: false,
+          virtualDate: null,
+        },
+        trackLength: {
+          origin: 'customLength',
+          length: 21,
+        },
+        subjectTrackState: {
+          visible: [],
+          pinned: [],
+        },
+        patrolTrackState: {
+          visible: [],
+          pinned: [],
+        },
+        userPreferences: {
+          gpsFormat: GPS_FORMATS.DEG,
+        },
+      },
+    };
+
+    useSelector.mockImplementation(selectorFn => selectorFn(state));
+
+  });
+
   describe('generic popup', () => {
-    let map;
     beforeEach(() => {
       jest.spyOn(document, 'querySelector').mockImplementation(() => ({
         clientHeight: 1000,
         clientWidth: 1000,
       }));
 
-      map = createMapMock();
-      render(<Provider store={store}>
-        <NavigationWrapper>
-          <SubjectPopup data={subjectFeatureWithMultipleDeviceProps} map={map} />
-        </NavigationWrapper>
-      </Provider>);
+      /* eslint-disable-next-line react/display-name */
+      Wrapper = ({ children }) => <Provider store={mockStore({})}>{children}</Provider>;
+
+      renderWithWrapper = (Component) => render(Component, { wrapper: Wrapper });
+
+      renderWithWrapper(<SubjectPopup data={subjectFeatureWithMultipleDeviceProps} />);
     });
 
     test('showing the subject name', () => {
@@ -97,13 +103,7 @@ describe('SubjectPopup', () => {
     });
 
     test('listing individual device properties', async () => {
-      render(
-        <Provider store={store}>
-          <NavigationWrapper>
-            <SubjectPopup data={subjectFeatureWithOneDeviceProp} />
-          </NavigationWrapper>
-        </Provider>
-      );
+      renderWithWrapper(<SubjectPopup data={subjectFeatureWithOneDeviceProp} />);
 
       const [statusProp] = subjectFeatureWithOneDeviceProp.properties.device_status_properties;
       const additionalProps = await screen.getByTestId('additional-props');
@@ -114,13 +114,7 @@ describe('SubjectPopup', () => {
     });
 
     test('render additional props with boolean values', async () => {
-      render(
-        <Provider store={store}>
-          <NavigationWrapper>
-            <SubjectPopup data={subjectFeatureWithOneDeviceProp} />
-          </NavigationWrapper>
-        </Provider>
-      );
+      renderWithWrapper(<SubjectPopup data={subjectFeatureWithOneDeviceProp} />);
 
       const additionalPropsValues = await screen.findAllByTestId('additional-props-value');
       expect(additionalPropsValues[1]).toHaveTextContent('false');
@@ -133,11 +127,7 @@ describe('SubjectPopup', () => {
     staticSubjectFeature.properties.default_status_value = defaultSubjectValue;
 
     beforeEach(() => {
-      render(<Provider store={store}>
-        <NavigationWrapper>
-          <SubjectPopup data={staticSubjectFeature} />
-        </NavigationWrapper>
-      </Provider>);
+      renderWithWrapper(<SubjectPopup data={staticSubjectFeature} />);
     });
 
     test('render default featured property for stationary subjects', async () => {


### PR DESCRIPTION
Also, refactoring code+tests for simpler test harnessing and cleaner use of redux.

### What does this PR do?
- Adds the `related_subjects` property to report form data filed from a subject popup

### How does it look
- N/A

### Relevant link(s)
* Tracking tickets: [ERA-8838](https://allenai.atlassian.net/browse/ERA-8838)


### Where / how to start reviewing (optional)
- It's such a small change, we can probably just test in dev unless y'all feel compelled to spin up a feature env.


The testing mimics the pattern [I introduced here](https://github.com/PADAS/das-web-react/pull/1004) to significantly simplify the component file and its tests by stubbing `useSelector` instead of all the elaborate `mockStore` fun.


[ERA-8338]: https://allenai.atlassian.net/browse/ERA-8338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ERA-8838]: https://allenai.atlassian.net/browse/ERA-8838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ