### PR TITLE
ERA-8956: Updating a patrol status from feed is breaking the patrol details view

### DIFF
--- a/src/PatrolDetailView/index.js
+++ b/src/PatrolDetailView/index.js
@@ -145,7 +145,7 @@ const PatrolDetailView = () => {
 
     const [segmentsFirstLeg] = patrolForm.patrol_segments;
 
-    const topLevelUpdates = patrolForm.updates ?? [];
+    const topLevelUpdates = patrolForm.updates;
     const { updates: segmentUpdates } = segmentsFirstLeg;
     const noteUpdates = extractAttachmentUpdates(patrolForm.notes);
     const fileUpdates = extractAttachmentUpdates(patrolForm.files);

--- a/src/hooks/usePatrol/index.js
+++ b/src/hooks/usePatrol/index.js
@@ -100,9 +100,10 @@ const usePatrol = (patrolFromProps) => {
 
   const onPatrolChange = useCallback((value) => {
     const merged = merge(patrolFromProps, value);
-    delete merged.updates;
+    const payload = { ...merged };
+    delete payload.updates;
 
-    dispatch(updatePatrol(merged));
+    dispatch(updatePatrol(payload));
   }, [dispatch, patrolFromProps]);
 
   const restorePatrol = useCallback(() => {


### PR DESCRIPTION
### What does this PR do?
- It adds default value to `topLevelUpdates` in case `patrol.updates` is undefined

### Relevant link(s)
* [ERA-8956](https://allenai.atlassian.net/browse/ERA-8956)
* [Env](https://era-8956.pamdas.org) 


[ERA-8956]: https://allenai.atlassian.net/browse/ERA-8956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ