### PR TITLE
[ERA-8950] nginx routing rules to forward supported deep links to das-web-react

### DIFF
--- a/mt-nginx.conf
+++ b/mt-nginx.conf
@@ -41,7 +41,7 @@ server {
 		try_files $uri @api;
 	}
 
-	location ~ ^/(login|reports|patrols|layers)(?:/(.*))?$ {
+	location ~ ^/(login|reports|patrols|layers|settings|eula)(?:/(.*))?$ {
 		alias /usr/share/nginx/html;
 		try_files /index.html =404;
 	}

--- a/prod-nginx-default.conf
+++ b/prod-nginx-default.conf
@@ -41,7 +41,7 @@ server {
 		try_files $uri @api;
 	}
 
-	location ~ ^/(login|reports|patrols|layers|settings)(?:/(.*))?$ {
+	location ~ ^/(login|reports|patrols|layers|settings|eula)(?:/(.*))?$ {
 		alias /usr/share/nginx/html;
 		try_files /index.html =404;
 	}


### PR DESCRIPTION
### What does this PR do?
- Adds new supported deep links ("settings" and "eula") to our routing rules

### How does it look
- N/A

### Relevant link(s)
* https://allenai.atlassian.net/browse/ERA-8950
* We don't need a hosted environment for this do we?

### Where / how to start reviewing (optional)
- N/A

### Any background context you want to provide(if applicable)
- I wonder if there's a way we can do this without a manual change each time we add a route to the web app...
