### PR TITLE
[ERA-8980] - Keeping stationary subjects' featured properties visible

### DIFF
--- a/src/ducks/subjects.js
+++ b/src/ducks/subjects.js
@@ -7,7 +7,7 @@ import { API_URL } from '../constants';
 import globallyResettableReducer from '../reducers/global-resettable';
 import { getBboxParamsFromMap } from '../utils/query';
 import { calcUrlForImage } from '../utils/img';
-import { getUniqueSubjectGroupSubjects, updateSubjectLastPositionFromSocketStatusUpdate } from '../utils/subjects';
+import { getUniqueSubjectGroupSubjects, updateDeviceStatusProperties, updateSubjectLastPositionFromSocketStatusUpdate } from '../utils/subjects';
 
 const SUBJECTS_API_URL = `${API_URL}subjects`;
 export const SUBJECT_GROUPS_API_URL = `${API_URL}subjectgroups`;
@@ -198,11 +198,9 @@ export const subjectStoreReducer = globallyResettableReducer((state = SUBJECT_ST
     if (subjectFromState.device_status_properties
       && payload.device_status_properties
     ) {
-      cloned.device_status_properties =  Object.values(
-        {
-          ...keyBy(subjectFromState.device_status_properties, 'label'),
-          ...keyBy(cloned.device_status_properties, 'label'),
-        }
+      cloned.device_status_properties = updateDeviceStatusProperties(
+        subjectFromState.device_status_properties,
+        cloned.device_status_properties,
       );
     }
 

--- a/src/utils/subjects.js
+++ b/src/utils/subjects.js
@@ -3,6 +3,7 @@ import differenceInSeconds from 'date-fns/difference_in_seconds';
 import set from 'lodash/set';
 import isEmpty from 'lodash/isEmpty';
 import cloneDeep from 'lodash/cloneDeep';
+import keyBy from 'lodash/keyBy';
 
 import { findTimeEnvelopeIndices } from './tracks';
 import { getActivePatrolsForLeaderId } from './patrols';
@@ -194,6 +195,14 @@ export const pinMapSubjectsToVirtualPosition = (mapSubjectFeatureCollection, tra
       }),
   };
 };
+
+export const updateDeviceStatusProperties = (existing, incoming, matchProp = 'label') =>
+  Object.values(
+    {
+      ...keyBy(existing, matchProp),
+      ...keyBy(incoming, matchProp),
+    }
+  );
 
 /**
  * filterSubjects is a function to drill down a given subject group array tree 


### PR DESCRIPTION
### What does this PR do?
- I noticed during some demos at the conference that a stationary subject's featured property value would disappear from its marker when it received a realtime update.  Displaying that value relies on the `default: true` being present for that status property, but our realtime API doesn't send that property through so we need to merge+match it by key when we receive a subject update.

### How does it look
- N/A

### Relevant link(s)
* https://allenai.atlassian.net/browse/ERA-8980
* https://era-8980.pamdas.org/

### Where / how to start reviewing (optional)
- Easter Island is a good place to repro the bug, and then run the fix locally against any site with stationary subjects which regularly update.
