### PR TITLE
ERA-9032: Don't mutate patrol from memory when doing an update

### DIFF
--- a/src/hooks/usePatrol/index.js
+++ b/src/hooks/usePatrol/index.js
@@ -100,9 +100,10 @@ const usePatrol = (patrolFromProps) => {
 
   const onPatrolChange = useCallback((value) => {
     const merged = merge(patrolFromProps, value);
-    delete merged.updates;
+    const payload = { ...merged };
+    delete payload.updates;
 
-    dispatch(updatePatrol(merged));
+    dispatch(updatePatrol(payload));
   }, [dispatch, patrolFromProps]);
 
   const restorePatrol = useCallback(() => {


### PR DESCRIPTION
Don't mutate patrol from memory when doing an update.

This was already hot-fixed here https://github.com/PADAS/das-web-react/pull/1012 but it never got merged down to develop.