### PR TITLE
[ERA-9226]: set `include_updates` param to `false` to reduce map request payload size

### DIFF
--- a/src/ducks/events.js
+++ b/src/ducks/events.js
@@ -416,7 +416,7 @@ export const fetchMapEvents = (map, parameters) => async (dispatch, getState) =>
   if (!map && !lastKnownBbox) return Promise.reject('no map available');
 
   const bbox = map ? await getBboxParamsFromMap(map) : lastKnownBbox;
-  const params = { bbox, page_size: 25, ...parameters };
+  const params = { bbox, page_size: 25, ...parameters, include_updates: false };
 
   if (shouldAppendLocationToRequest(state)) {
     params.location = calcLocationParamStringForUserLocationCoords(state.view.userLocation.coords);


### PR DESCRIPTION
### What does this PR do?
- The map event layer requests the full event data model, specifically its history, despite not needing that data for any practical purpose. This resolves that, to help with site performance and API load.

### How does it look
- N/A

### Relevant link(s)
* Tracking ticket: https://allenai.atlassian.net/browse/ERA-9226
* ENV TBD

### Where / how to start reviewing (optional)
- It's one line, I believe in you

### Any background context you want to provide(if applicable)
- @chrisj-er raised this suggestion and it made too much sense to not just fix. thanks 👍 
