### PR TITLE
fix:request param string util was deleting new param.

### DIFF
--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -1,5 +1,6 @@
 import axios, { isCancel } from 'axios';
 import toString from 'lodash/toString';
+import isArrayLike from 'lodash/isArrayLike';
 import isEmpty from 'lodash/isEmpty';
 import isNil from 'lodash/isNil';
 
@@ -65,7 +66,8 @@ export const cleanedUpFilterObject = (filter) =>
       }
 
       if (!!value
-      || (!isNil(value) && !isEmpty(value))) {
+        || (isArrayLike(value) && !isEmpty(value))
+        || !isNil(value)) {
         return {
           ...accumulator,
           [key]: value,


### PR DESCRIPTION
### What does this PR do?
- Our new `include_updates=false` param was getting stripped from the request for map events due to some old and now buggy logic in the parameter string util which calculated the final params. This fixes that.

