### PR TITLE
ERA-9374: Unable to log in to https://stage.pamdas.org/ 

### DIFF
--- a/src/withSocketConnection/useRealTimeImplementation/index.js
+++ b/src/withSocketConnection/useRealTimeImplementation/index.js
@@ -124,7 +124,9 @@ const useRealTimeImplementation = () => {
       } else {
         socketIO = await import('socket.io-client');
       }
-      setSocketIOPackage(socketIO);
+      setSocketIOPackage({
+        io: (...args) => socketIO.default(...args)
+      });
     };
     importSocketIOPackage();
   }, []);


### PR DESCRIPTION
### What does this PR do?
- It creates a proper package of the imported socket.io library no matter which version is in use

### Relevant link(s)
* [ERA-9374](https://allenai.atlassian.net/browse/ERA-9374)
* Env: still building

### Any background context you want to provide(if applicable)
- The problem was that `io` constructor was not being found inside the imported package for legacy library, this was not a problem before, both versions where exposing the same constructor function, I'm still not sure what changed, so in order to avoid this to happen again, I added a little object wrapper around the default export of the package instead of trying to access directly to the `io` function 


[ERA-9374]: https://allenai.atlassian.net/browse/ERA-9374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ