### PR TITLE
ERA-9035: FE - Save and resolve button css issues

### DIFF
--- a/src/ReportManager/ReportDetailView/index.js
+++ b/src/ReportManager/ReportDetailView/index.js
@@ -880,7 +880,7 @@ const ReportDetailView = ({
                 title={t('reportDetailView.saveSplitButton.title')}
                 onClick={onClickSaveButton}
               >
-                <Dropdown.Item data-testid="report-details-resolve-btn-toggle">
+                <Dropdown.Item className={styles.saveSplitButtonItem} data-testid="report-details-resolve-btn-toggle">
                   <Button onClick={onClickSaveAndToggleStateButton} type="button" variant="primary">
                     {t(`reportDetailView.saveSplitButton.${isActive ? 'saveAndResolveItem' : 'saveAndReopenItem'}`)}
                   </Button>

--- a/src/ReportManager/ReportDetailView/styles.module.scss
+++ b/src/ReportManager/ReportDetailView/styles.module.scss
@@ -140,6 +140,10 @@
 .saveButton {
   margin-right: 0.5rem;
 
+  .saveSplitButtonItem:hover {
+    background-color: unset;
+  }
+
   &:disabled {
     cursor: not-allowed;
   }


### PR DESCRIPTION
### What does this PR do?
Remove hover background to the dropdown item within the save report split button.

### How does it look
![image](https://github.com/PADAS/das-web-react/assets/11725028/d4184ea7-d575-46c2-892d-17ca0101d3bb)

### Relevant link(s)
* [ERA-9035](https://allenai.atlassian.net/browse/ERA-9035)
* [Env](https://era-9035.pamdas.org/)

### Any background context you want to provide(if applicable)
Not really a bug. The issue was that we are rendering a button within a dropdown item, which Bootstrap renders as an anchor tag (`<a>`) with a background hover effect. I just removed the hover effect so we don't have that weird hover state.


[ERA-9035]: https://allenai.atlassian.net/browse/ERA-9035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ