### PR TITLE
ERA-9045: Subjects pop-up coordinates bar mismatching background design

### DIFF
--- a/src/GpsFormatToggle/styles.module.scss
+++ b/src/GpsFormatToggle/styles.module.scss
@@ -9,11 +9,10 @@
 
   li {
     align-items: center;
-    background-color: $very-light-gray;
     color: $dark-gray;
     cursor: pointer;
     display: flex;
-    height: 2rem;
+    height: 1.5rem;
     justify-content: center;
     width: 100%;
 


### PR DESCRIPTION
### What does this PR do?
- Updates CSS style of GPS choices of GPSFormatToggle to match design

### How does it look
- before
<img width="344" alt="Screen Shot 2024-01-26 at 13 52 21" src="https://github.com/PADAS/das-web-react/assets/20525031/3b1d6d8a-b63b-4969-818d-556cc528195c">

- after
<img width="414" alt="Screen Shot 2024-01-26 at 13 51 44" src="https://github.com/PADAS/das-web-react/assets/20525031/18ad6323-30dd-4536-9e2b-5df9c9b9e883">


### Relevant link(s)
* [ERA-9045](https://allenai.atlassian.net/browse/ERA-9045)
* [Env](https://era-9045.pamdas.org) building 🕐 🔧 

[ERA-9045]: https://allenai.atlassian.net/browse/ERA-9045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ