### PR TITLE
remove pipeline trigger when PR is open

### DIFF
--- a/.github/workflows/pr-envs.yml
+++ b/.github/workflows/pr-envs.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     types:
       - labeled
-      - opened
       - synchronize
       - reopened
 


### PR DESCRIPTION
### What does this PR do?
- Avoid triggering the pipeline when a PR is opened, the pipeline will be triggered when the label is added.