### PR TITLE
remove static file redirect in nginx

### DIFF
--- a/mt-nginx.conf
+++ b/mt-nginx.conf
@@ -1,26 +1,8 @@
-# Let this container upstream /static/ to API if nothing's found locally.
-upstream app_server {
-	server das-server-earthranger-api.das-server:8000;
-}
 server {
 	listen 80;
 	listen [::]:80;
 	root /usr/share/nginx/html;
-	set $gcs "storage.googleapis.com";
 	server_name  $hostname localhost;
-
-	location ~ ^.*/static/((?:js|css)/.*chunk.*)$ {
-		resolver 8.8.8.8;
-		proxy_pass https://$gcs/er-static/static/$1;
-
-		proxy_set_header Host storage.googleapis.com;
-		proxy_http_version 1.1;
-		proxy_set_header Connection "";
-		proxy_intercept_errors on;
-
-		add_header X-Powered-By: 'Cloud-Storage';
-
-	}
 
 	location /static {
 		if ($request_method = 'OPTIONS') {
@@ -38,7 +20,7 @@ server {
 			add_header 'Content-Length' 0;
 			return 204;
 		}
-		try_files $uri @api;
+		try_files $uri =404;
 	}
 
 	location ~ ^/(login|reports|patrols|layers|settings|eula)(?:/(.*))?$ {
@@ -48,18 +30,6 @@ server {
 
 	location / {
 		index index.html index.htm;
-	}
-
-	location @api {
-		add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-		add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization';
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_set_header X-Forwarded-Proto $scheme;
-		proxy_set_header Host $http_host;
-		proxy_set_header   X-Real-IP $http_x_forwarded_for;
-		proxy_set_header   X-Forwarded-Host $server_name; 
-
-		proxy_pass http://app_server;
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
- Remove static file redirect to a gcp bucket. All files will be served from the container
- Delete redirecting /static to backend app. All files should be correctly routed from the nginx-ingress