### PR TITLE
ERA-9403: Broken Modal Appears when attempting to place marker on map

### DIFF
--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -139,6 +139,7 @@ const Map = ({
     && mapLocationSelection.mode  === MAP_LOCATION_SELECTION_MODES.EVENT_GEOMETRY;
 
   const isSelectingEventLocation = mapLocationSelection.isPickingLocation
+    && mapLocationSelection.event
     && !isDrawingEventGeometry;
 
   const [currentAnalyzerIds, setCurrentAnalyzerIds] = useState([]);

--- a/src/Map/index.test.js
+++ b/src/Map/index.test.js
@@ -77,6 +77,7 @@ describe('Map', () => {
     updatePatrolTrackStateMock,
     updateTrackStateMock,
     map,
+    renderMap,
     store;
   beforeEach(() => {
     clearEventDataMock = jest.fn(() => () => {});
@@ -145,6 +146,18 @@ describe('Map', () => {
         userPreferences: {},
       },
     };
+
+    renderMap = (props, overrideStore) => {
+      return render(<Provider store={mockStore(overrideStore || store)}>
+        <NavigationWrapper>
+          <MapDrawingToolsContextProvider>
+            <MapContext.Provider value={map}>
+              <Map map={map} socket={mockedSocket} {...props} />
+            </MapContext.Provider>
+          </MapDrawingToolsContextProvider>
+        </NavigationWrapper>
+      </Provider>);
+    };
   });
 
   afterEach(() => {
@@ -154,15 +167,7 @@ describe('Map', () => {
   test('shows the EventFilter', async () => {
     store.view.mapLocationSelection.isPickingLocation = false;
 
-    render(<Provider store={mockStore(store)}>
-      <NavigationWrapper>
-        <MapDrawingToolsContextProvider>
-          <MapContext.Provider value={map}>
-            <Map map={map} socket={mockedSocket} />
-          </MapContext.Provider>
-        </MapDrawingToolsContextProvider>
-      </NavigationWrapper>
-    </Provider>);
+    renderMap();
 
     await waitFor(() => {
       expect((screen.findByTestId('eventFilter-form'))).toBeDefined();
@@ -206,39 +211,29 @@ describe('Map', () => {
 
   test('does not show the EventFilter if user is picking a location on the map', async () => {
     store.view.mapLocationSelection.isPickingLocation = true;
-    render(<Provider store={mockStore(store)}>
-      <NavigationWrapper>
-        <MapDrawingToolsContextProvider>
-
-          <MapContext.Provider value={map}>
-            <Map map={map} socket={mockedSocket} />
-          </MapContext.Provider>
-
-        </MapDrawingToolsContextProvider>
-      </NavigationWrapper>
-    </Provider>);
+    renderMap();
 
     expect((await screen.queryByTestId('eventFilter-form'))).toBeNull();
   });
 
-  test('does not show the ReportAreaOverview if user is drawing a geometry on the map', async () => {
+  test('does not show the MapLocationSelectionOverview if user is drawing a geometry on the map', async () => {
     store.view.mapLocationSelection.mode = MAP_LOCATION_SELECTION_MODES.EVENT_GEOMETRY;
-    render(<Provider store={mockStore(store)}>
-      <NavigationWrapper>
-        <MapDrawingToolsContextProvider>
+    renderMap();
 
-          <MapContext.Provider value={map}>
-            <Map map={map} socket={mockedSocket} />
-          </MapContext.Provider>
-
-        </MapDrawingToolsContextProvider>
-      </NavigationWrapper>
-    </Provider>);
-
-    expect((await screen.queryByTestId('reportAreaOverview-wrapper'))).toBeNull();
+    expect((await screen.queryByTestId('mapLocationSelectionOverview-wrapper'))).toBeNull();
   });
 
-  test('shows the ReportAreaOverview', async () => {
+  test('does not show the MapLocationSelectionOverview if user is picking location for a marker or using the ruler', async () => {
+    store.view.mapLocationSelection = {
+      isPickingLocation: true,
+      mode: MAP_LOCATION_SELECTION_MODES.DEFAULT,
+    };
+    renderMap();
+
+    expect((await screen.queryByTestId('mapLocationSelectionOverview-wrapper'))).toBeNull();
+  });
+
+  test('shows the MapLocationSelectionOverview if user is drawing a geometry', async () => {
     const mockEvent = {
       id: 'hello',
       geometry: null,
@@ -253,21 +248,32 @@ describe('Map', () => {
       isPickingLocation: true,
       mode: MAP_LOCATION_SELECTION_MODES.EVENT_GEOMETRY,
     };
-    render(<Provider store={mockStore(store)}>
-      <NavigationWrapper>
-        <MapDrawingToolsContextProvider>
-
-          <MapContext.Provider value={map}>
-            <Map map={map} socket={mockedSocket} />
-          </MapContext.Provider>
-
-        </MapDrawingToolsContextProvider>
-      </NavigationWrapper>
-    </Provider>);
+    renderMap();
 
     await waitFor(() => {
-      expect(screen.findByTestId('reportAreaOverview-wrapper')).toBeDefined();
+      expect(screen.findByTestId('mapLocationSelectionOverview-wrapper')).toBeDefined();
     });
+  });
 
+  test('shows the MapLocationSelectionOverview if user is picking an event location', async () => {
+    const mockEvent = {
+      id: 'hello',
+      geometry: null,
+    };
+
+    store.data.eventStore = {
+      [mockEvent.id]: mockEvent
+    };
+
+    store.view.mapLocationSelection = {
+      event: mockEvent,
+      isPickingLocation: true,
+      mode: MAP_LOCATION_SELECTION_MODES.DEFAULT,
+    };
+    renderMap();
+
+    await waitFor(() => {
+      expect(screen.findByTestId('mapLocationSelectionOverview-wrapper')).toBeDefined();
+    });
   });
 });

--- a/src/MapLocationSelectionOverview/index.js
+++ b/src/MapLocationSelectionOverview/index.js
@@ -81,7 +81,7 @@ const MapLocationSelectionOverview = ({
     eventReportTracker.track('Clicks discard while drawing area');
   }, [onClickDiscardCallback]);
 
-  return <div className={styles.reportAreaOverview} data-testid="reportAreaOverview-wrapper">
+  return <div className={styles.mapLocationSelectionOverview} data-testid="mapLocationSelectionOverview-wrapper">
     <div className={styles.header} onClick={onClickHeader}>
       <h2>{isDrawingEventGeometry
         ? t('drawingReportGeometryHeader')

--- a/src/MapLocationSelectionOverview/styles.module.scss
+++ b/src/MapLocationSelectionOverview/styles.module.scss
@@ -2,7 +2,7 @@
 @import '../common/styles/animations';
 @import '../common/styles/layout';
 
-.reportAreaOverview {
+.mapLocationSelectionOverview {
   @include fade-in;
 
   background: white;


### PR DESCRIPTION
### What does this PR do?
Fix event location selection validation to only show the location picker overview in the right scenarios

### How does it look
Before (when dropping a marker or measuring with the ruler):
![image](https://github.com/PADAS/das-web-react/assets/11725028/b07ecfb8-15a9-46de-92e6-f8604bae2e0e)

After:
![image](https://github.com/PADAS/das-web-react/assets/11725028/111571ae-fe9e-44c5-8f13-b55b4a44b442)

### Relevant link(s)
* [ERA-9403](https://allenai.atlassian.net/browse/ERA-9403)
* [Env](https://era-9403.dev.pamdas.org/)

### Any background context you want to provide(if applicable)
We were showing the `MapLocationPickerOverview` every time the global variable `isPickingLocation` was `true`. However, that variable is true when the user is dropping a marker or measuring with the ruler, which makes sense, but the overview shouldn't show since there is no event associated to that action. This PR fixes that logic by simply checking if there is an event associated to the location being picked.

[ERA-9403]: https://allenai.atlassian.net/browse/ERA-9403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ