### PR TITLE
ERA-9530: Date Format is messed up in map Reports

### DIFF
--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -14,7 +14,7 @@ import pluralize from 'pluralize';
 
 import dateLocales from './locales';
 
-export const EVENT_SYMBOL_DATE_FORMAT = 'DD MMM YY';
+export const EVENT_SYMBOL_DATE_FORMAT = 'dd MMM YY';
 
 export const SHORT_TIME_FORMAT = 'HH:mm';
 export const STANDARD_DATE_FORMAT = 'dd MMM YY HH:mm';


### PR DESCRIPTION
### What does this PR do?
- Updating date token for symbol date format

### How does it look
before
<img width="691" alt="image" src="https://github.com/PADAS/das-web-react/assets/20525031/4420169b-f204-4563-8d41-55fd30c262a5">


after
<img width="734" alt="image" src="https://github.com/PADAS/das-web-react/assets/20525031/802fa9aa-ad96-4e2c-9f92-1679dba1a6be">

### Relevant link(s)
* Tracking tickets: [ERA-9530](https://allenai.atlassian.net/browse/ERA-9530)
* [Env](https://era-9530.dev.pamdas.org/)


[ERA-9530]: https://allenai.atlassian.net/browse/ERA-9530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ