### PR TITLE
add docker reusable workflow

### DIFF
--- a/.github/workflows/_build_docker.yml
+++ b/.github/workflows/_build_docker.yml
@@ -1,0 +1,75 @@
+name: Build the application
+
+on:
+  workflow_call:
+    inputs:
+      # Provide environment or workload_identity_provider and service account
+      environment:
+        type: string
+      repository:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+      dockerfile:
+        type: string
+        default: docker/Dockerfile
+      no-cache:
+        type: boolean
+        default: false
+      artifact-download:
+        type: boolean
+        default: false
+      artifact-name:
+        type: string
+      workload_identity_provider:
+        type: string
+      service_account:
+        type: string
+
+env:
+  WORKLOAD_IDENTITY_PROVIDER: ${{ inputs.workload_identity_provider || vars.WORKLOAD_IDENTITY_PROVIDER }}
+  SERVICE_ACCOUNT: ${{ inputs.service_account || vars.SERVICE_ACCOUNT }}
+
+jobs:
+  build:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      if: ${{ inputs.artifact-download }}
+      with:
+        name: ${{ inputs.artifact-name }}
+    - name: GCP Auth
+      id: auth
+      uses: google-github-actions/auth@v2
+      with:
+        token_format: 'access_token'
+        workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ env.SERVICE_ACCOUNT }}
+    - name: Login to GAR
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.repository }}
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        push: true
+        context: .
+        file: ${{ inputs.dockerfile }}
+        tags: "${{ inputs.repository }}:${{ inputs.tag }}"
+        no-cache: ${{ inputs.no-cache }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/develop-workflow.yml
+++ b/.github/workflows/develop-workflow.yml
@@ -3,10 +3,8 @@ on:
   push:
     branches:
       - "das-2-*-*"
-      - "ERA-*"
-      - "era-*"
+      - "legacy-era-*"
       - "develop*"
-      - "eruc-*"
 
 env:
   BUILD_BRANCH: ${{ github.ref_name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
   config:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -17,13 +17,13 @@ jobs:
       - run: |
           npm pkg set "buildbranch"="${{ github.head_ref || github.ref_name }}"
           npm pkg set "buildnum"="${{ github.run_number }}"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: npm-config
           path: package.json
   build:
     needs: config
-    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v1-stable
+    uses: ./.github/workflows/_build_docker.yml
     with:
       environment: padas-app
       repository: europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react

--- a/.github/workflows/pr-envs.yml
+++ b/.github/workflows/pr-envs.yml
@@ -14,7 +14,7 @@ jobs:
       name: ${{ github.head_ref }}
       url: "https://${{ github.head_ref }}.dev.pamdas.org"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -22,14 +22,14 @@ jobs:
       - run: |
           npm pkg set "buildbranch"="${{ github.event.pull_request.head.sha }}"
           npm pkg set "buildnum"="${{ github.run_number }}"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: npm-config
           path: package.json
   build:
     if: contains(github.event.pull_request.labels.*.name, 'deploy')
     needs: config
-    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v1-stable
+    uses: ./.github/workflows/_build_docker.yml
     with:
       environment: padas-app
       repository: europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react


### PR DESCRIPTION
### What does this PR do?
- Because this repository is public, it can't use the reusable workflows in a private repository. Moving the reusable workflow to this repository as a workaround
- Updating the workflow versions to the latest one.
- Avoid building and deploying to single tenant clusters with every ticket