### PR TITLE
Hotfix: Report detail view add event button translations

### DIFF
--- a/public/locales/es/details-view.json
+++ b/public/locales/es/details-view.json
@@ -8,7 +8,8 @@
     "timeLabel": "Tiempo"
   },
   "addAttachmentButton": "Adjuntar",
-  "addReportButton": "Evento",
+  "addReportButtonLabel": "Crear Evento",
+  "addReportButtonTitle": "Evento",
   "addNoteButton": "Nota",
   "attachmentControls": {
     "addNoteTitle": "Agregar Nota",

--- a/public/locales/fr/details-view.json
+++ b/public/locales/fr/details-view.json
@@ -8,7 +8,8 @@
     "timeLabel": "Heure"
   },
   "addAttachmentButton": "Pièce jointe",
-  "addReportButton": "Événements",
+  "addReportButtonLabel": "Créer un Évènement",
+  "addReportButtonTitle": "Événements",
   "addNoteButton": "Commentaire",
   "attachmentControls": {
     "addNoteTitle": "Ajouter un commentaire",

--- a/public/locales/pt/details-view.json
+++ b/public/locales/pt/details-view.json
@@ -8,7 +8,8 @@
         "timeLabel": "Hora"
     },
     "addAttachmentButton": "Arquivo anexo",
-    "addReportButton": "Evento",
+    "addReportButtonLabel": "Criar Evento",
+    "addReportButtonTitle": "Evento",
     "addNoteButton": "Anotação",
     "attachmentControls": {
         "addNoteTitle": "Adicionar anotação",


### PR DESCRIPTION
### What does this PR do?
Hotfix for missing translations for the "Add Event" button in the footer of the Report Detail View.