### PR TITLE
ERA-9687: Geopermissions - Profile with geopermission assigned, accessed using PIN don't honor their permissions.

### DIFF
--- a/src/ducks/events.js
+++ b/src/ducks/events.js
@@ -63,7 +63,10 @@ export const SOCKET_EVENT_DATA = 'SOCKET_EVENT_DATA';
 const UPDATE_EVENT_STORE = 'UPDATE_EVENT_STORE';
 
 const shouldAppendLocationToRequest = (state) => {
-  return userIsGeoPermissionRestricted(state?.data?.user) && !!state?.view?.userLocation?.coords;
+  const currentUser = state?.data?.selectedUserProfile?.username
+    ? state?.data?.selectedUserProfile
+    : state?.data?.user;
+  return userIsGeoPermissionRestricted(currentUser) && !!state?.view?.userLocation?.coords;
 };
 
 export const socketEventData = (payload) => (dispatch) => {

--- a/src/ducks/events.js
+++ b/src/ducks/events.js
@@ -105,6 +105,7 @@ const fetchNamedFeedActionCreator = (name) => {
   let cancelToken = CancelToken.source();
 
   const fetchFn = (config, paramString) => (dispatch, getState) => {
+    const state = getState();
 
     cancelToken.cancel();
     cancelToken = CancelToken.source();
@@ -113,6 +114,11 @@ const fetchNamedFeedActionCreator = (name) => {
       name,
       type: FEED_FETCH_START,
     });
+
+    if (shouldAppendLocationToRequest(state)) {
+      paramString = paramString + `&location=${calcLocationParamStringForUserLocationCoords(state.view.userLocation.coords)}`;
+    }
+
 
     return axios.get(`${EVENTS_API_URL}?${paramString}`, {
       ...config,


### PR DESCRIPTION
### What does this PR do?
The bug was that we always check if the location parameter should be appended to the events request from the active `user`. When we are under a profile, the active `user` is still the main user, so the permissions may not match, resulting in no location parameter being added to the request when it should. This PR does the geo-restriction permissions check from the `selectedUserProfile` instead when there is an active profile.

### Relevant link(s)
* [ERA-9687](https://allenai.atlassian.net/browse/ERA-9687)
* [Env](https://era-9687.dev.pamdas.org/login)

[ERA-9687]: https://allenai.atlassian.net/browse/ERA-9687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ