### PR TITLE
ERA-9660: Close event details view when hitting the escape key

### DIFF
--- a/src/DatePicker/index.js
+++ b/src/DatePicker/index.js
@@ -256,6 +256,12 @@ const CustomDatePicker = ({
     onCalendarClose?.();
   }, [onCalendarClose]);
 
+  const onKeyDown = useCallback((event) => {
+    if (event.key === 'Escape' && isOpen) {
+      event.stopPropagation();
+    }
+  }, [isOpen]);
+
   const CustomHeader = useMemo(() => renderCustomHeader(rest?.maxDate, rest?.minDate, language, locale), [rest?.maxDate, rest?.minDate, language, locale]);
 
   return <DatePicker
@@ -263,6 +269,7 @@ const CustomDatePicker = ({
     dateFormat={dateFormat}
     onCalendarClose={handleCalendarClose}
     onCalendarOpen={handleCalendarOpen}
+    onKeyDown={onKeyDown}
     placeholderText={placeholderText || (dateFormat).toUpperCase()}
     ref={ref}
     renderCustomHeader={CustomHeader}

--- a/src/DatePicker/index.test.js
+++ b/src/DatePicker/index.test.js
@@ -165,4 +165,15 @@ describe('DatePicker', () => {
     expect(onChangeMock).toHaveBeenCalledTimes(1);
     expect(onChangeMock.mock.calls[0][0].toISOString()).toMatch(/^2020-02-11/);
   });
+
+  test('closes the picker when pressing escape', async () => {
+    const datePickerInput = await screen.findByTestId('datePicker-input');
+    userEvent.click(datePickerInput);
+
+    expect(onCalendarCloseMock).toHaveBeenCalledTimes(0);
+
+    userEvent.keyboard('{Escape}');
+
+    expect(onCalendarCloseMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/KebabMenu/index.js
+++ b/src/KebabMenu/index.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useCallback, useState } from 'react';
 import { Dropdown } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 
@@ -12,26 +12,46 @@ const Option = ({ className = '', children, ...rest }) => (
   </Dropdown.Item>
 );
 
-const Menu = ({ children, className, ...rest }, ref) => (
-  <Dropdown className={`${styles.kebabMenu} ${className}`} {...rest} >
-    <Dropdown.Toggle as='button'>
-      <KebabMenuIcon />
-    </Dropdown.Toggle>
-    <Dropdown.Menu ref={ref} className={styles.menuDropdown}>
-      {children}
-    </Dropdown.Menu>
-  </ Dropdown>
-);
+const Menu = ({ children, className, defaultShow, ...rest }, ref) => {
+  const [show, setShow] = useState(defaultShow);
+
+  const onKeyDown = useCallback((event) => {
+    if (event.key === 'Escape') {
+      setShow(false);
+      event.stopPropagation();
+    }
+  }, []);
+
+  return (
+    <Dropdown
+        className={`${styles.kebabMenu} ${className}`}
+        onKeyDown={onKeyDown}
+        onToggle={(nextShow) => setShow(nextShow)}
+        show={show}
+        {...rest}
+      >
+      <Dropdown.Toggle as='button'>
+        <KebabMenuIcon />
+      </Dropdown.Toggle>
+
+      <Dropdown.Menu ref={ref} className={styles.menuDropdown}>
+        {children}
+      </Dropdown.Menu>
+    </ Dropdown>
+  );
+};
 
 const MenuForwardRef = forwardRef(Menu);
 
 MenuForwardRef.defaultProps = {
-  className: ''
+  className: '',
+  defaultShow: false,
 };
 
 MenuForwardRef.propTypes = {
   children: PropTypes.oneOfType([PropTypes.array, PropTypes.element]).isRequired,
-  className: PropTypes.string
+  defaultShow: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 const KebabMenu = {

--- a/src/PrioritySelect/index.js
+++ b/src/PrioritySelect/index.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useCallback, useState } from 'react';
 import { components } from 'react-select';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
@@ -43,7 +43,23 @@ const Option = ({ data, ...props }) => <components.Option {...props} >
 const PrioritySelect = ({ className, isDisabled, onChange, placeholder, priority }) => {
   const { t } = useTranslation('reports', { keyPrefix: 'prioritySelect' });
 
+  const [isMenuOpen, setMenuOpen] = useState(false);
+
   const priorityValue = REPORT_PRIORITIES.find((reportPriority) => reportPriority.value === priority);
+
+  const onMenuClose = useCallback(() => {
+    setMenuOpen(false);
+  }, []);
+
+  const onMenuOpen = useCallback(() => {
+    setMenuOpen(true);
+  }, []);
+
+  const onKeyDown = useCallback((event) => {
+    if (event.key === 'Escape' && isMenuOpen) {
+      event.stopPropagation();
+    }
+  }, [isMenuOpen]);
 
   return <Select
     className={`${styles.select} ${className}`}
@@ -52,6 +68,9 @@ const PrioritySelect = ({ className, isDisabled, onChange, placeholder, priority
     getOptionValue={(option) => option.value}
     isDisabled={isDisabled}
     onChange={onChange}
+    onKeyDown={onKeyDown}
+    onMenuClose={onMenuClose}
+    onMenuOpen={onMenuOpen}
     options={REPORT_PRIORITIES}
     placeholder={placeholder || t('placeholder')}
     styles={{

--- a/src/PrioritySelect/index.test.js
+++ b/src/PrioritySelect/index.test.js
@@ -42,4 +42,18 @@ describe('PrioritySelect', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith(highLevel, onChangePartialArgs);
   });
+
+  it('closes the menu when pressing escape', () => {
+    renderPrioritySelect();
+
+    const list = screen.getByText(selectedPriority.display);
+    userEvent.click(list);
+
+    userEvent.keyboard('{Escape}');
+
+    REPORT_PRIORITIES.forEach(({ key }) => {
+      const currentTestId = `priority-select-${key}`;
+      expect(screen.queryByTestId(currentTestId)).toBeNull();
+    });
+  });
 });

--- a/src/ReportManager/DetailsSection/index.js
+++ b/src/ReportManager/DetailsSection/index.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, memo, useCallback, useEffect, useMemo } from 'react';
+import React, { forwardRef, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import Dropdown from 'react-bootstrap/Dropdown';
 import Form from '@rjsf/bootstrap-4';
 import { isToday } from 'date-fns';
@@ -68,6 +68,8 @@ const DetailsSection = ({
 
   const eventTypes = useSelector((state) => state.data.eventTypes);
 
+  const [showStateDropdown, setShowStateDropdown] = useState(false);
+
   const reportLocation = !!reportForm.location ? [reportForm.location.longitude, reportForm.location.latitude] : null;
   const reportState = reportForm.state === EVENT_FORM_STATES.NEW_LEGACY ? EVENT_FORM_STATES.ACTIVE : reportForm.state;
   const reportTime = new Date(reportForm?.time);
@@ -77,6 +79,13 @@ const DetailsSection = ({
     && eventTypes
     && calcGeometryTypeForReport(reportForm, eventTypes)
   , [eventTypes, reportForm]);
+
+  const onStateDropdownKeyDown = useCallback((event) => {
+    if (event.key === 'Escape') {
+      setShowStateDropdown(false);
+      event.stopPropagation();
+    }
+  }, []);
 
   const transformErrors = useCallback((errors) => {
     const filteredErrors = filterOutErrorsForHiddenProperties(
@@ -104,7 +113,13 @@ const DetailsSection = ({
       </div>
 
       <div>
-        <Dropdown className={`${styles.stateDropdown} ${styles[reportForm.state]}`} onSelect={onReportStateChange}>
+        <Dropdown
+          className={`${styles.stateDropdown} ${styles[reportForm.state]}`}
+          onKeyDown={onStateDropdownKeyDown}
+          onToggle={(nextShow) => setShowStateDropdown(nextShow)}
+          show={showStateDropdown}
+          onSelect={onReportStateChange}
+        >
           <Dropdown.Toggle variant="success">
             {t(`stateDropdown.${reportState}`)}
           </Dropdown.Toggle>

--- a/src/ReportedBySelect/index.js
+++ b/src/ReportedBySelect/index.js
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, useCallback, useMemo, useState } from 'react';
 import { components } from 'react-select';
 import { FixedSizeList } from 'react-window';
 import PropTypes from 'prop-types';
@@ -152,6 +152,8 @@ const ReportedBySelect = ({
   const reporters = useSelector(reportedBy);
   const subjects = useSelector(allSubjects);
 
+  const [isMenuOpen, setMenuOpen] = useState(false);
+
   const selections = optionsFromProps ? optionsFromProps : reporters;
 
   const recentRadios = useMemo(
@@ -197,6 +199,20 @@ const ReportedBySelect = ({
     return displayOptions;
   }, [recentRadios, selections]);
 
+  const onMenuClose = useCallback(() => {
+    setMenuOpen(false);
+  }, []);
+
+  const onMenuOpen = useCallback(() => {
+    setMenuOpen(true);
+  }, []);
+
+  const onKeyDown = useCallback((event) => {
+    if (event.key === 'Escape' && isMenuOpen) {
+      event.stopPropagation();
+    }
+  }, [isMenuOpen]);
+
   const selectStyles = {
     option(styles, { isDisabled: _isDisabled }) {
       return styles;
@@ -224,6 +240,9 @@ const ReportedBySelect = ({
     isSearchable={true}
     menuShouldScrollIntoView={false}
     onChange={onChange}
+    onKeyDown={onKeyDown}
+    onMenuClose={onMenuClose}
+    onMenuOpen={onMenuOpen}
     options={options}
     placeholder={placeholder || t('placeholder')}
     recentRadios={recentRadios}

--- a/src/ReportedBySelect/index.test.js
+++ b/src/ReportedBySelect/index.test.js
@@ -67,4 +67,16 @@ describe('ReportedBySelect', () => {
 
     expect(onChange).toHaveBeenCalled();
   });
+
+  it('closes the menu when pressing escape', async () => {
+    const { container } = renderWithWrapper(<ReportedBySelect />);
+
+    userEvent.click(container.querySelector('input'));
+
+    expect(await screen.findByText('Informant2')).toBeVisible();
+
+    userEvent.keyboard('{Escape}');
+
+    expect(await screen.queryByText('Informant2')).toBeNull();
+  });
 });

--- a/src/SchemaFields/index.js
+++ b/src/SchemaFields/index.js
@@ -256,6 +256,8 @@ export const SelectWidget = ({
   const containerRef = useRef(null);
   const selectRef = useRef(null);
 
+  const [isMenuOpen, setMenuOpen] = useState(false);
+
   const SelectContainer = (props) => <div ref={containerRef}>
     <components.SelectContainer {...props} />
   </div>;
@@ -288,15 +290,28 @@ export const SelectWidget = ({
 
   const handleChange = useCallback((update) => onChange(update?.value), [onChange]);
 
-  const onMenuOpen = useCallback(() => setTimeout(() => {
-    if (selectRef.current.select.menuListRef && registry.formContext && registry.formContext.scrollContainer) {
-      scrollSelectIntoViewOnMenuOpenIfNecessary(
-        registry.formContext.scrollContainer,
-        containerRef.current,
-        selectRef.current.select.menuListRef.clientHeight
-      );
+  const onMenuOpen = useCallback(() => {
+    setMenuOpen(true);
+    setTimeout(() => {
+      if (selectRef.current.select.menuListRef && registry.formContext && registry.formContext.scrollContainer) {
+        scrollSelectIntoViewOnMenuOpenIfNecessary(
+          registry.formContext.scrollContainer,
+          containerRef.current,
+          selectRef.current.select.menuListRef.clientHeight
+        );
+      }
+    });
+  }, [registry.formContext]);
+
+  const onMenuClose = useCallback(() => {
+    setMenuOpen(false);
+  }, []);
+
+  const onKeyDown = useCallback((event) => {
+    if (event.key === 'Escape' && isMenuOpen) {
+      event.stopPropagation();
     }
-  }), [registry.formContext]);
+  }, [isMenuOpen]);
 
   return <Select
     autoFocus={autofocus}
@@ -316,6 +331,8 @@ export const SelectWidget = ({
     onBlur={onBlur}
     onChange={handleChange}
     onFocus={onFocus}
+    onKeyDown={onKeyDown}
+    onMenuClose={onMenuClose}
     onMenuOpen={onMenuOpen}
     options={enumOptions}
     ref={selectRef}

--- a/src/SchemaFields/index.test.js
+++ b/src/SchemaFields/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 
-import { DateTimeWidget, ExternalLinkField } from './';
+import { DateTimeWidget, ExternalLinkField, SelectWidget } from './';
 import { render, screen, within } from '../test-utils';
 
 describe('the ExternalLinkField field',  () => {

--- a/src/SideBar/index.test.js
+++ b/src/SideBar/index.test.js
@@ -318,4 +318,30 @@ describe('SideBar', () => {
       expect(navigate).toHaveBeenCalledWith(`/events/${eventID}`, { replace: true });
     });
   });
+
+  test('redirects from details view to new /events URL when user presses Escape', async () => {
+    const locationMock = jest.fn((() => ({ pathname: '/events/123123', key: '2324e2', state: { comesFromLogin: true } })));
+    useLocation.mockImplementation(locationMock);
+    renderSideBar();
+
+    expect(navigate).toHaveBeenCalledTimes(0);
+
+    userEvent.keyboard('{Escape}');
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith('/events');
+  });
+
+  test('redirects from details view to new /patrols URL when user presses Escape', async () => {
+    const locationMock = jest.fn((() => ({ pathname: '/patrols/123123', key: '2324e2', state: { comesFromLogin: true } })));
+    useLocation.mockImplementation(locationMock);
+    renderSideBar();
+
+    expect(navigate).toHaveBeenCalledTimes(0);
+
+    userEvent.keyboard('{Escape}');
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith('/patrols');
+  });
 });

--- a/src/TimePicker/index.js
+++ b/src/TimePicker/index.js
@@ -31,6 +31,10 @@ const TimePicker = ({
       event.target.blur();
     }
 
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+    }
+
     onKeyDown?.(event);
   }, [onKeyDown]);
 


### PR DESCRIPTION
### What does this PR do?
Close details view when pressing esc key.

### Relevant link(s)
* [ERA-9660](https://allenai.atlassian.net/browse/ERA-9660)
* [Env](https://era-9660.dev.pamdas.org)

### Where / how to start reviewing (optional)
- [src/SideBar/index.js](https://github.com/PADAS/das-web-react/compare/ERA-9660?expand=1#diff-788e631783fac0966b699a5548727810acc1d4abab140b5c51f5af1fd07f6946) has the logic to listen to the Escape key and navigate to the feed from the event details pages.
- The rest of the files just stops the propagation of the Escape pressing event so the navigation doesn't happen when using is closing a menu.

### Any background context you want to provide(if applicable)
Since we have lots of visual elements that close when pressing the escape key, like modals, popups and menus, we need to be very specific on how we listen to the event. It only works when the details view or its children are focused.

I couldn't find a way to stop the propagation of the Escape keyboard event when the location and geometry popovers are open, so in those cases the details view will be closed:
![image](https://github.com/PADAS/das-web-react/assets/11725028/0d6ecb24-5d1b-490e-989d-ad77c026c461)


[ERA-9660]: https://allenai.atlassian.net/browse/ERA-9660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ