### PR TITLE
[ERA-9940] Exclude empty patrols for the web client

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the web interface for EarthRanger. It is built with React (whose bootstr
 ### Licensing
 This repository is open-sourced under the Apache 2.0 license. However, Mapbox GL, a required dependency, is closed-source. It is provided here in a "bring your own token" capacity; you may use and modify all EarthRanger-authored code herein, but will need to provide your own Mapbox access token, tied to your own Mapbox account.
 
-------------------
+-------------------
 
 ## Setting up for development
 To start developing within this repo, you need to have [Docker](https://www.docker.com/get-started), [Node](https://nodejs.org/), and [Yarn](https://yarnpkg.com/) installed. Once docker is up and running, `cd` into the root of this project repository and run the following command: `docker compose up --build`.

--- a/src/utils/patrol-filter.js
+++ b/src/utils/patrol-filter.js
@@ -12,7 +12,14 @@ export const calcPatrolFilterForRequest = (options = {}) => {
   const { data: { patrolFilter } } = store.getState();
   const { filter: { patrols_overlap_daterange } } = patrolFilter;
   const { params, format = 'string' } = options;
-  const  filterParams = merge({}, patrolFilter, params);
+
+  const filterParams = merge(
+    {
+      exclude_empty_patrols: true,
+    },
+    patrolFilter,
+    params
+  );
   delete filterParams._persist;
   // only apply current filter settings if it is modified, otherwise allow overlap
   filterParams.filter.patrols_overlap_daterange = isDateFilterModified(patrolFilter) ? patrols_overlap_daterange : true;
@@ -23,7 +30,7 @@ export const calcPatrolFilterForRequest = (options = {}) => {
 
 export const isFilterModified = ({ status, filter: { patrol_type, text, tracked_by } }) => (
   !isEqual(INITIAL_FILTER_STATE.status, status)
-    || !isEqual(INITIAL_FILTER_STATE.filter.patrol_type, patrol_type)
-    || !isEqual(INITIAL_FILTER_STATE.filter.text, text)
-    || !isEqual(INITIAL_FILTER_STATE.filter.tracked_by, tracked_by)
+  || !isEqual(INITIAL_FILTER_STATE.filter.patrol_type, patrol_type)
+  || !isEqual(INITIAL_FILTER_STATE.filter.text, text)
+  || !isEqual(INITIAL_FILTER_STATE.filter.tracked_by, tracked_by)
 );

--- a/src/utils/patrol-filter.test.js
+++ b/src/utils/patrol-filter.test.js
@@ -1,7 +1,15 @@
 import { INITIAL_FILTER_STATE } from '../ducks/patrol-filter';
-import { isFilterModified } from './patrol-filter';
+import { isFilterModified, calcPatrolFilterForRequest } from './patrol-filter';
 
 describe('Patrol filter utils', () => {
+  describe('calcPatrolFilterForRequest', () => {
+    test('adds a constant exclude_empty_patrols=true param to all patrols API requests', () => {
+      const value = calcPatrolFilterForRequest({ hello: false });
+
+      expect(value).toContain('exclude_empty_patrols=true');
+    });
+  });
+
   describe('isFilterModified', () => {
     test('returns false if the filter has the default values', () => {
       expect(isFilterModified(INITIAL_FILTER_STATE)).toBe(false);


### PR DESCRIPTION
**What does this do?** Adds a new param to web requests for patrols so the UI doesn't crash on segmentless patrols.