### PR TITLE
ERA-10215: Add analytics to event/patrol detail view quicklinks

### DIFF
--- a/src/PatrolDetailView/index.js
+++ b/src/PatrolDetailView/index.js
@@ -94,8 +94,6 @@ const PatrolDetailView = () => {
   const [notesToAdd, setNotesToAdd] = useState([]);
   const [showInvalidDatesModal, setShowInvalidDatesModal] = useState(false);
 
-  const patrolTracker = trackEventFactory(PATROL_DETAIL_VIEW_CATEGORY);
-
   const { patrol, leader } = patrolDataSelector || {};
 
   const isNewPatrol = patrolId === 'new';
@@ -430,8 +428,8 @@ const PatrolDetailView = () => {
       });
     }, parseFloat(activitySectionStyles.cardToggleTransitionTime));
 
-    patrolTracker.track('Added Attachment');
-  }, [attachmentsToAdd, patrolAttachments, patrolTracker]);
+    patrolDetailViewTracker.track('Added Attachment');
+  }, [attachmentsToAdd, patrolAttachments]);
 
   const onAddNote = useCallback(() => {
     const userHasNewNoteEmpty = notesToAdd.some((noteToAdd) => !noteToAdd.originalText);
@@ -539,15 +537,33 @@ const PatrolDetailView = () => {
 
     <Header printableContentRef={printableContentRef} onChangeTitle={onChangeTitle} patrol={patrolForm} setRedirectTo={setRedirectTo} />
 
-    <TrackerContext.Provider value={patrolTracker}>
+    <TrackerContext.Provider value={patrolDetailViewTracker}>
       <div className={styles.body}>
         <QuickLinks scrollTopOffset={QUICK_LINKS_SCROLL_TOP_OFFSET}>
           <QuickLinks.NavigationBar className={styles.navigationBar}>
-            <QuickLinks.Anchor anchorTitle={t('quickLinksTitles.plan')} iconComponent={<CalendarIcon />} />
+            <QuickLinks.Anchor
+              anchorTitle={t('quickLinksTitles.plan')}
+              iconComponent={<CalendarIcon />}
+              onClick={() => patrolDetailViewTracker.track(
+                `Click the "Plan" quicklink in a ${isNewPatrol ? 'new' : 'existing'} patrol`
+              )}
+            />
 
-            <QuickLinks.Anchor anchorTitle={t('quickLinksTitles.activity')} iconComponent={<BulletListIcon />} />
+            <QuickLinks.Anchor
+              anchorTitle={t('quickLinksTitles.activity')}
+              iconComponent={<BulletListIcon />}
+              onClick={() => patrolDetailViewTracker.track(
+                `Click the "Activity" quicklink in a ${isNewPatrol ? 'new' : 'existing'} patrol`
+              )}
+            />
 
-            <QuickLinks.Anchor anchorTitle={t('quickLinksTitles.history')} iconComponent={<HistoryIcon />} />
+            <QuickLinks.Anchor
+              anchorTitle={t('quickLinksTitles.history')}
+              iconComponent={<HistoryIcon />}
+              onClick={() => patrolDetailViewTracker.track(
+                `Click the "History" quicklink in a ${isNewPatrol ? 'new' : 'existing'} patrol`
+              )}
+            />
           </QuickLinks.NavigationBar>
 
           <div className={styles.content}>

--- a/src/QuickLinks/index.js
+++ b/src/QuickLinks/index.js
@@ -64,14 +64,18 @@ NavigationBar.propTypes = {
 QuickLinks.NavigationBar = NavigationBar;
 
 
-const Anchor = ({ anchorTitle, iconComponent }) => {
+const Anchor = ({ anchorTitle, onClick: onClickCallback = null, iconComponent }) => {
   const { getSectionElement, onClickAnchor } = useContext(QuickLinksContext);
 
   const sectionElement = useMemo(() => getSectionElement(anchorTitle), [anchorTitle, getSectionElement]);
 
   const isSectionOnScreen = useOnScreen(sectionElement);
 
-  const onClick = useCallback(() => onClickAnchor(anchorTitle), [onClickAnchor, anchorTitle]);
+  const onClick = useCallback((event) => {
+    onClickAnchor(anchorTitle);
+
+    onClickCallback?.(event);
+  }, [onClickAnchor, onClickCallback, anchorTitle]);
 
   return sectionElement ? <div
     className={`${styles.anchor} ${isSectionOnScreen ? 'active' : ''}`}

--- a/src/QuickLinks/index.test.js
+++ b/src/QuickLinks/index.test.js
@@ -56,21 +56,23 @@ describe('ReportManager - QuickLinks', () => {
   });
 
   describe('QuickLinks.Anchor', () => {
-    test('triggers onClickAnchor', async () => {
-      const getSectionElement = jest.fn(() => true), onClickAnchor= jest.fn();
+    test('triggers onClickAnchor and the onClick callback if it is provided', async () => {
+      const getSectionElement = jest.fn(() => true), onClickAnchor= jest.fn(), onClick= jest.fn();
       render(
         <QuickLinksContext.Provider value={{ getSectionElement, onClickAnchor }}>
-          <QuickLinks.Anchor anchorTitle="anchor1" iconComponent={<BulletListIcon />} />
+          <QuickLinks.Anchor anchorTitle="anchor1" iconComponent={<BulletListIcon />} onClick={onClick} />
         </QuickLinksContext.Provider>
       );
 
       expect(onClickAnchor).toHaveBeenCalledTimes(0);
+      expect(onClick).toHaveBeenCalledTimes(0);
 
       const anchor = await screen.queryByTestId('quickLinks-anchor-anchor1');
       userEvent.click(anchor);
 
       expect(onClickAnchor).toHaveBeenCalledTimes(1);
       expect(onClickAnchor).toHaveBeenCalledWith('anchor1');
+      expect(onClick).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/ReportManager/ReportDetailView/index.js
+++ b/src/ReportManager/ReportDetailView/index.js
@@ -760,21 +760,33 @@ const ReportDetailView = ({
           <QuickLinks.Anchor
             anchorTitle={t('reportDetailView.quickLinks.detailsAnchor')}
             iconComponent={<PencilWritingIcon />}
+            onClick={() => reportTracker.track(
+              `Click the "Details" quicklink in a ${isNewReport ? 'new' : 'existing'} report`
+            )}
           />
 
           <QuickLinks.Anchor
             anchorTitle={t('reportDetailView.quickLinks.activityAnchor')}
             iconComponent={<BulletListIcon />}
+            onClick={() => reportTracker.track(
+              `Click the "Activity" quicklink in a ${isNewReport ? 'new' : 'existing'} report`
+            )}
           />
 
           <QuickLinks.Anchor
             anchorTitle={t('reportDetailView.quickLinks.linksAnchor')}
             iconComponent={<LinkIcon />}
+            onClick={() => reportTracker.track(
+              `Click the "Links" quicklink in a ${isNewReport ? 'new' : 'existing'} report`
+            )}
           />
 
           <QuickLinks.Anchor
             anchorTitle={t('reportDetailView.quickLinks.historyAnchor')}
             iconComponent={<HistoryIcon />}
+            onClick={() => reportTracker.track(
+              `Click the "History" quicklink in a ${isNewReport ? 'new' : 'existing'} report`
+            )}
           />
         </QuickLinks.NavigationBar>
 


### PR DESCRIPTION
### What does this PR do?
Add tracking events to quicklink anchor clicks

### How does it look
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/88d65c7b-5ac1-489b-ade2-bf0c18603a09">

### Relevant link(s)
* [ERA-10215](https://allenai.atlassian.net/browse/ERA-10215)
* [Env]()

### Where / how to start reviewing (optional)
1- Minor change in the `Anchor` element to support the `onClick` prop in [src/QuickLinks/index.js](https://github.com/PADAS/das-web-react/compare/ERA-10215?expand=1#diff-549b72b04185e0adbc9c88a32b7f2d841a1f8f6f170500662cb3db90e044bc12)
2- Addition of the tracking event in the `onClick` callbacks of the anchors in [src/PatrolDetailView/index.js](https://github.com/PADAS/das-web-react/compare/ERA-10215?expand=1#diff-a3d93a12e8ca691c6a766861f21b8cf7b8210bd2b531f92e378109304d7aa183) and [src/ReportManager/ReportDetailView/index.js](https://github.com/PADAS/das-web-react/compare/ERA-10215?expand=1#diff-8d72af8504155f3e1ec4a42de7a7e9656067856cb51ba37f663685b79086eadc)



[ERA-10215]: https://allenai.atlassian.net/browse/ERA-10215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ