### PR TITLE
[HOTFIX] guard clause for user-linked subjects

### DIFF
--- a/src/ducks/subjects.js
+++ b/src/ducks/subjects.js
@@ -167,6 +167,8 @@ export const subjectStoreReducer = globallyResettableReducer((state = SUBJECT_ST
     const { payload: { data: subjects } } = action;
 
     const newSubjects = subjects.map((subject) => {
+      if (!subject.last_position) return subject;
+
       subject.last_position.properties.name = subject.last_position.properties.title || subject.last_position.properties.name;
       return subject;
     });


### PR DESCRIPTION
### What does this PR do?
- A guard clause to prevent bad web application error handling for when a user-linked subject is returned with map subjects via the API
