### PR TITLE
ERA-10255: Permission Sets - Permissions in Can Export Data permission set are corrupt

### DIFF
--- a/src/GlobalMenuDrawer/index.js
+++ b/src/GlobalMenuDrawer/index.js
@@ -67,8 +67,8 @@ const GlobalMenuDrawer = () => {
   const { t } = useTranslation('menu-drawer', { keyPrefix: 'globalMenuDrawer' });
 
   const hasPatrolViewPermissions = usePermissions(PERMISSION_KEYS.PATROLS, PERMISSIONS.READ);
-  const hasObservationExportPermissions = usePermissions(PERMISSION_KEYS.OBSERVATIONS_EXPORT, PERMISSIONS.EXPORT);
-  const hasEventExportPermissions = usePermissions(PERMISSION_KEYS.EVENTS_EXPORT, PERMISSIONS.EXPORT);
+  const hasObservationExportPermissions = usePermissions(PERMISSION_KEYS.OBSERVATIONS, PERMISSIONS.EXPORT);
+  const hasEventExportPermissions = usePermissions(PERMISSION_KEYS.EVENTS, PERMISSIONS.EXPORT);
 
   const isMediumLayoutOrLarger = useMatchMedia(BREAKPOINTS.screenIsMediumLayoutOrLarger);
 

--- a/src/GlobalMenuDrawer/index.js
+++ b/src/GlobalMenuDrawer/index.js
@@ -67,8 +67,8 @@ const GlobalMenuDrawer = () => {
   const { t } = useTranslation('menu-drawer', { keyPrefix: 'globalMenuDrawer' });
 
   const hasPatrolViewPermissions = usePermissions(PERMISSION_KEYS.PATROLS, PERMISSIONS.READ);
-  const hasObservationExportPermissions = usePermissions(PERMISSION_KEYS.OBSERVATIONS_EXPORT, PERMISSIONS.READ);
-  const hasEventExportPermissions = usePermissions(PERMISSION_KEYS.EVENTS_EXPORT, PERMISSIONS.READ);
+  const hasObservationExportPermissions = usePermissions(PERMISSION_KEYS.OBSERVATIONS_EXPORT, PERMISSIONS.EXPORT);
+  const hasEventExportPermissions = usePermissions(PERMISSION_KEYS.EVENTS_EXPORT, PERMISSIONS.EXPORT);
 
   const isMediumLayoutOrLarger = useMatchMedia(BREAKPOINTS.screenIsMediumLayoutOrLarger);
 

--- a/src/GlobalMenuDrawer/index.test.js
+++ b/src/GlobalMenuDrawer/index.test.js
@@ -59,8 +59,8 @@ describe('GlobalMenuDrawer', () => {
         user: {
           permissions: {
             [PERMISSION_KEYS.PATROLS]: [PERMISSIONS.READ],
-            [PERMISSION_KEYS.EVENTS_EXPORT]: [PERMISSIONS.EXPORT],
-            [PERMISSION_KEYS.OBSERVATIONS_EXPORT]: [PERMISSIONS.EXPORT],
+            [PERMISSION_KEYS.EVENTS]: [PERMISSIONS.EXPORT],
+            [PERMISSION_KEYS.OBSERVATIONS]: [PERMISSIONS.EXPORT],
           }
         },
       },
@@ -326,7 +326,7 @@ describe('GlobalMenuDrawer', () => {
     const getFieldEventsButton = () => screen.queryByText('Field Events');
 
     test('does not show the Field Reports button if a user doesn\'t have export event data permissions', () => {
-      delete store.data.user.permissions[PERMISSION_KEYS.EVENTS_EXPORT];
+      delete store.data.user.permissions[PERMISSION_KEYS.EVENTS];
 
       render(
         <Provider store={mockStore(store)}>
@@ -378,7 +378,7 @@ describe('GlobalMenuDrawer', () => {
     const getSubjectInfoButton = () => screen.queryByText('Subject Summary');
 
     test('does not show the subject information link if a user doesn\'t have export observation data permissions', () => {
-      delete store.data.user.permissions[PERMISSION_KEYS.OBSERVATIONS_EXPORT];
+      delete store.data.user.permissions[PERMISSION_KEYS.OBSERVATIONS];
 
       render(
         <Provider store={mockStore(store)}>
@@ -411,7 +411,7 @@ describe('GlobalMenuDrawer', () => {
     const getSubjectReportsButton = () => screen.queryByText('Observations');
 
     test('does not show the subject reports link if a user doesn\'t have export observation data permissions', () => {
-      delete store.data.user.permissions[PERMISSION_KEYS.OBSERVATIONS_EXPORT];
+      delete store.data.user.permissions[PERMISSION_KEYS.OBSERVATIONS];
 
       render(
         <Provider store={mockStore(store)}>

--- a/src/GlobalMenuDrawer/index.test.js
+++ b/src/GlobalMenuDrawer/index.test.js
@@ -59,8 +59,8 @@ describe('GlobalMenuDrawer', () => {
         user: {
           permissions: {
             [PERMISSION_KEYS.PATROLS]: [PERMISSIONS.READ],
-            [PERMISSION_KEYS.EVENTS_EXPORT]: [PERMISSIONS.READ],
-            [PERMISSION_KEYS.OBSERVATIONS_EXPORT]: [PERMISSIONS.READ],
+            [PERMISSION_KEYS.EVENTS_EXPORT]: [PERMISSIONS.EXPORT],
+            [PERMISSION_KEYS.OBSERVATIONS_EXPORT]: [PERMISSIONS.EXPORT],
           }
         },
       },

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -297,8 +297,8 @@ export const PERMISSION_KEYS = {
   PATROLS: 'patrol',
   PATROL_TYPES: 'patroltype',
   MESSAGING: 'message',
-  OBSERVATIONS_EXPORT: 'export_observation_data',
-  EVENTS_EXPORT: 'export_event_data',
+  OBSERVATIONS: 'observation',
+  EVENTS: 'event',
 };
 
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -307,6 +307,7 @@ export const PERMISSIONS = {
   READ: 'view',
   UPDATE: 'change',
   DELETE: 'delete',
+  EXPORT: 'export',
 };
 
 export const SUBJECT_FEATURE_CONTENT_TYPE = 'observations.subject';


### PR DESCRIPTION
### What does this PR do?
- It modifies the export permissions logic to match backend update

### Relevant link(s)
* [ERA-10255](https://allenai.atlassian.net/browse/ERA-10255)
* [ERA-10313](https://allenai.atlassian.net/browse/ERA-10313)
* [Hosted demo environments](https://era-10255.dev.pamdas.org)


[ERA-10255]: https://allenai.atlassian.net/browse/ERA-10255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ERA-10313]: https://allenai.atlassian.net/browse/ERA-10313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ