### PR TITLE
ERA-10102: Top-level "clear all" filter control

### DIFF
--- a/public/locales/en-US/filters.json
+++ b/public/locales/en-US/filters.json
@@ -62,6 +62,7 @@
       "resetButton": "Reset"
     },
     "filtersTitle": "Filters",
+    "globalResetFilterButton": "Reset",
     "searchbarPlaceHolder": "Search Patrols...",
     "filtersPopover": {
       "checkBoxAllOption": "All",

--- a/public/locales/es/filters.json
+++ b/public/locales/es/filters.json
@@ -62,6 +62,7 @@
       "resetButton": "Restablecer"
     },
     "filtersTitle": "Filtros",
+    "globalResetFilterButton": "Restablecer",
     "searchbarPlaceHolder": "Buscar patrullajes...",
     "filtersPopover": {
       "checkBoxAllOption": "Todos",

--- a/public/locales/fr/filters.json
+++ b/public/locales/fr/filters.json
@@ -62,6 +62,7 @@
       "resetButton": "Réinitialiser"
     },
     "filtersTitle": "Filtres",
+    "globalResetFilterButton": "Réinitialiser",
     "searchbarPlaceHolder": "Recherche...",
     "filtersPopover": {
       "checkBoxAllOption": "Tout Sélectionner",

--- a/public/locales/ne-NP/filters.json
+++ b/public/locales/ne-NP/filters.json
@@ -62,6 +62,7 @@
             "resetButton": "रिसेट गर्नुहोस्"
         },
         "filtersTitle": "फिल्टर",
+        "globalResetFilterButton": "रिसेट गर्नुहोस्",
         "searchbarPlaceHolder": "गस्तीहरु खोज्नुहोस्…",
         "filtersPopover": {
             "checkBoxAllOption": "सबै",

--- a/public/locales/pt/filters.json
+++ b/public/locales/pt/filters.json
@@ -62,6 +62,7 @@
             "resetButton": "Redefinir"
         },
         "filtersTitle": "Filtros",
+        "globalResetFilterButton": "Redefinir",
         "searchbarPlaceHolder": "Buscar patrulhas",
         "filtersPopover": {
             "checkBoxAllOption": "Selecionar tudo",

--- a/public/locales/sw/filters.json
+++ b/public/locales/sw/filters.json
@@ -62,6 +62,7 @@
       "resetButton": "Rudisha"
     },
     "filtersTitle": "Vichujio",
+    "globalResetFilterButton": "Rudisha",
     "searchbarPlaceHolder": "Tafuta Doria...",
     "filtersPopover": {
       "checkBoxAllOption": "Zote",

--- a/src/EventFilter/index.js
+++ b/src/EventFilter/index.js
@@ -224,7 +224,7 @@ const EventFilter = ({
         totalFeedCount={feedEvents.count}
       />
       {
-        (filterModified || isDateRangeModified || isSortModified) &&
+        (filterModified || isDateRangeModified || isSortModified || !!filterText) &&
         <Button type="button" variant='light' size='sm' onClick={resetAllFilters} data-testid='general-reset-btn'>
           <RefreshIcon title={t('resetButton')} />
           {t('resetButton')}

--- a/src/EventFilter/index.test.js
+++ b/src/EventFilter/index.test.js
@@ -220,4 +220,20 @@ describe('After filters being applied', () => {
     jest.useRealTimers();
   });
 
+  test('performing a search shows the reset button', async () => {
+    jest.useFakeTimers();
+    renderEventFilter();
+
+    expect(screen.queryByTestId('general-reset-btn')).toBeNull();
+
+    const searchBar = await screen.getAllByTestId('search-input')[0];
+    const searchValue = 'Chimpanzee';
+    userEvent.type(searchBar, searchValue);
+    jest.advanceTimersByTime(UPDATE_FILTER_DEBOUNCE_TIME);
+
+    expect(screen.queryByTestId('general-reset-btn')).toBeVisible();
+
+    jest.useRealTimers();
+  });
+
 });

--- a/src/PatrolFilter/FiltersPopover/index.js
+++ b/src/PatrolFilter/FiltersPopover/index.js
@@ -127,7 +127,8 @@ const FiltersPopover = React.forwardRef(({
 
   const patrolLeaderFilterOptions = patrolLeaderSchema?.trackedbySchema?.properties?.leader?.enum_ext?.map(({ value }) => value)
     || [];
-  const selectedLeaders = !!selectedLeaderIds?.length ?
+
+  const selectedLeaders = !!selectedLeaderIds?.length && !isEmpty(patrolLeaderSchema) ?
     selectedLeaderIds.map(id => patrolLeaderFilterOptions.find(leader => leader.id === id))
     : [];
 

--- a/src/PatrolFilter/index.js
+++ b/src/PatrolFilter/index.js
@@ -173,8 +173,8 @@ const PatrolFilter = ({ className }) => {
       {
           (filtersModified || dateRangeModified || !!filterText) &&
           <Button type="button" variant='light' size='sm' onClick={resetAllFilters}>
-            <RefreshIcon title={t('resetButton')} />
-            {t('resetButton')}
+            <RefreshIcon title={t('globalResetFilterButton')} />
+            {t('globalResetFilterButton')}
           </Button>
       }
     </div>

--- a/src/PatrolFilter/index.js
+++ b/src/PatrolFilter/index.js
@@ -18,10 +18,13 @@ import FiltersPopover from './FiltersPopover';
 import FriendlyFilterString from '../FriendlyFilterString';
 import { ReactComponent as ClockIcon } from '../common/images/icons/clock-icon.svg';
 import { ReactComponent as FilterIcon } from '../common/images/icons/filter-icon.svg';
+import { ReactComponent as RefreshIcon } from '../common/images/icons/refresh-icon.svg';
+
 import SearchBar from '../SearchBar';
 
 import patrolFilterStyles from './styles.module.scss';
 import styles from '../EventFilter/styles.module.scss';
+import { resetGlobalDateRange } from '../ducks/global-date-range';
 
 export const PATROL_TEXT_FILTER_DEBOUNCE_TIME = 200;
 
@@ -48,12 +51,37 @@ const PatrolFilter = ({ className }) => {
     patrolFilterTracker.track('Change Search Text Filter');
   }, []);
 
-  const resetSearch = useCallback((e) => {
-    e.stopPropagation();
+  const resetSearch = useCallback((event = null) => {
+    event?.stopPropagation();
     setFilterText('');
 
     patrolFilterTracker.track('Clear Search Text Filter');
   }, []);
+
+  const resetDateRange = useCallback(() => {
+    dispatch(resetGlobalDateRange());
+
+    patrolFilterTracker.track('Click Reset Date Range Filter');
+  }, [dispatch]);
+
+  const resetFiltersPopover = useCallback(() => {
+    dispatch(updatePatrolFilter({
+      filter: {
+        tracked_by: INITIAL_FILTER_STATE.filter.tracked_by,
+        patrol_type: INITIAL_FILTER_STATE.filter.patrol_type,
+      },
+      status: INITIAL_FILTER_STATE.status,
+    }));
+
+    patrolFilterTracker.track('Click Reset All Filters');
+  }, [dispatch]);
+
+  const resetAllFilters = useCallback((event) => {
+    event.stopPropagation();
+    resetFiltersPopover();
+    resetDateRange();
+    resetSearch();
+  }, [resetDateRange, resetFiltersPopover, resetSearch]);
 
   useEffect(() => {
     if (!caseInsensitiveCompare(filterText, patrolFilter.filter.text)) {
@@ -141,6 +169,14 @@ const PatrolFilter = ({ className }) => {
         isFiltered={isFilterModified(patrolFilter)}
         totalFeedCount={patrols?.results?.length ?? 0}
       />
+
+      {
+          (filtersModified || dateRangeModified || !!filterText) &&
+          <Button type="button" variant='light' size='sm' onClick={resetAllFilters}>
+            <RefreshIcon title={t('resetButton')} />
+            {t('resetButton')}
+          </Button>
+      }
     </div>
   </>;
 };

--- a/src/PatrolFilter/index.js
+++ b/src/PatrolFilter/index.js
@@ -51,20 +51,16 @@ const PatrolFilter = ({ className }) => {
     patrolFilterTracker.track('Change Search Text Filter');
   }, []);
 
-  const resetSearch = useCallback((event = null) => {
+  const resetSearch = useCallback((event) => {
     event?.stopPropagation();
     setFilterText('');
 
     patrolFilterTracker.track('Clear Search Text Filter');
   }, []);
 
-  const resetDateRange = useCallback(() => {
-    dispatch(resetGlobalDateRange());
+  const resetAllFilters = useCallback((event) => {
+    event.stopPropagation();
 
-    patrolFilterTracker.track('Click Reset Date Range Filter');
-  }, [dispatch]);
-
-  const resetFiltersPopover = useCallback(() => {
     dispatch(updatePatrolFilter({
       filter: {
         tracked_by: INITIAL_FILTER_STATE.filter.tracked_by,
@@ -72,16 +68,13 @@ const PatrolFilter = ({ className }) => {
       },
       status: INITIAL_FILTER_STATE.status,
     }));
-
     patrolFilterTracker.track('Click Reset All Filters');
-  }, [dispatch]);
 
-  const resetAllFilters = useCallback((event) => {
-    event.stopPropagation();
-    resetFiltersPopover();
-    resetDateRange();
-    resetSearch();
-  }, [resetDateRange, resetFiltersPopover, resetSearch]);
+    dispatch(resetGlobalDateRange());
+    patrolFilterTracker.track('Click Reset Date Range Filter');
+
+    resetSearch(null);
+  }, [dispatch, resetSearch]);
 
   useEffect(() => {
     if (!caseInsensitiveCompare(filterText, patrolFilter.filter.text)) {

--- a/src/PatrolFilter/index.js
+++ b/src/PatrolFilter/index.js
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { caseInsensitiveCompare } from '../utils/string';
 import { getPatrolList } from '../selectors/patrols';
 import { INITIAL_FILTER_STATE, updatePatrolFilter } from '../ducks/patrol-filter';
+import { resetGlobalDateRange } from '../ducks/global-date-range';
 import { isFilterModified } from '../utils/patrol-filter';
 import { trackEventFactory, PATROL_FILTER_CATEGORY } from '../utils/analytics';
 
@@ -24,7 +25,6 @@ import SearchBar from '../SearchBar';
 
 import patrolFilterStyles from './styles.module.scss';
 import styles from '../EventFilter/styles.module.scss';
-import { resetGlobalDateRange } from '../ducks/global-date-range';
 
 export const PATROL_TEXT_FILTER_DEBOUNCE_TIME = 200;
 

--- a/src/ReportedBySelect/index.js
+++ b/src/ReportedBySelect/index.js
@@ -168,7 +168,7 @@ const ReportedBySelect = ({
 
     if (isMulti) {
       if (value.length) {
-        return value.map((item) => item.hidden
+        return value.map((item) => item?.hidden
           ? item
           : selections.find((selection) => selection.id === item.id));
       }

--- a/src/ReportedBySelect/index.js
+++ b/src/ReportedBySelect/index.js
@@ -168,7 +168,7 @@ const ReportedBySelect = ({
 
     if (isMulti) {
       if (value.length) {
-        return value.map((item) => item?.hidden
+        return value.map((item) => item.hidden
           ? item
           : selections.find((selection) => selection.id === item.id));
       }


### PR DESCRIPTION
### What does this PR do?
- It adds global reset button for patrol filters
- It adds missing validation for the search text to the global reset button of events

### Relevant link(s)
* Tracking tickets: [ERA-10102](https://allenai.atlassian.net/browse/ERA-10102)
* [Hosted demo environments](https://era-10102.dev.pamdas.org)

### Where / how to start reviewing (optional)
- The new global reset button should reset all filter for patrols including search text, dates, tracked by, patrol type and patrol status
- Now the global reset button for events should react as well with search text


[ERA-10102]: https://allenai.atlassian.net/browse/ERA-10102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ