### PR TITLE
ERA-10108: Include sort order in saved event/patrol filters

### DIFF
--- a/src/ColumnSort/index.js
+++ b/src/ColumnSort/index.js
@@ -11,7 +11,7 @@ import { ReactComponent as ArrowUp } from '../common/images/icons/arrow-up.svg';
 import { ReactComponent as CheckIcon } from '../common/images/icons/check.svg';
 import { ReactComponent as SortLines } from '../common/images/icons/sort-lines.svg';
 
-import { DEFAULT_EVENT_SORT, SORT_DIRECTION } from '../utils/event-filter';
+import { DEFAULT_EVENT_SORT, SORT_DIRECTION } from '../ducks/event-filter';
 
 import styles from './styles.module.scss';
 
@@ -21,7 +21,7 @@ const ColumnSort = ({ className, sortOptions, orderOptions, value, onChange }) =
   const [isSortUp, setSortDirection] = useState(value === SORT_DIRECTION.up);
 
   const [direction, selectedOption] = value;
-  const isSortModified = !DEFAULT_EVENT_SORT.includes(selectedOption);
+  const isSortModified = !DEFAULT_EVENT_SORT.find(({ value, key }) => value === selectedOption.value && key === selectedOption.key );
 
   const onClickSortOption = useCallback((option) => {
     if (option.value !== selectedOption.value){

--- a/src/ColumnSort/index.js
+++ b/src/ColumnSort/index.js
@@ -11,7 +11,7 @@ import { ReactComponent as ArrowUp } from '../common/images/icons/arrow-up.svg';
 import { ReactComponent as CheckIcon } from '../common/images/icons/check.svg';
 import { ReactComponent as SortLines } from '../common/images/icons/sort-lines.svg';
 
-import { DEFAULT_EVENT_SORT, SORT_DIRECTION } from '../ducks/event-filter';
+import { DEFAULT_EVENT_SORT, SORT_DIRECTION } from '../constants';
 
 import styles from './styles.module.scss';
 

--- a/src/ColumnSort/index.test.js
+++ b/src/ColumnSort/index.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { within } from '@testing-library/dom';
 
-import { SORT_DIRECTION } from '../ducks/event-filter';
+import { SORT_DIRECTION } from '../constants';
 import { EVENT_SORT_ORDER_OPTIONS } from '../utils/event-filter';
 import ColumnSort from './';
 import { render, screen } from '../test-utils';

--- a/src/ColumnSort/index.test.js
+++ b/src/ColumnSort/index.test.js
@@ -2,7 +2,8 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { within } from '@testing-library/dom';
 
-import { EVENT_SORT_ORDER_OPTIONS, SORT_DIRECTION } from '../utils/event-filter';
+import { SORT_DIRECTION } from '../ducks/event-filter';
+import { EVENT_SORT_ORDER_OPTIONS } from '../utils/event-filter';
 import ColumnSort from './';
 import { render, screen } from '../test-utils';
 

--- a/src/EventFilter/index.js
+++ b/src/EventFilter/index.js
@@ -9,7 +9,8 @@ import debounce from 'lodash/debounce';
 import noop from 'lodash/noop';
 
 import { BREAKPOINTS } from '../constants';
-import { updateEventFilter, INITIAL_FILTER_STATE, DEFAULT_EVENT_SORT } from '../ducks/event-filter';
+import { updateEventFilter, INITIAL_FILTER_STATE } from '../ducks/event-filter';
+import { DEFAULT_EVENT_SORT } from '../constants';
 import { isFilterModified } from '../utils/event-filter';
 import { resetGlobalDateRange } from '../ducks/global-date-range';
 import { trackEventFactory, EVENT_FILTER_CATEGORY, REPORTS_CATEGORY } from '../utils/analytics';

--- a/src/EventFilter/index.js
+++ b/src/EventFilter/index.js
@@ -9,8 +9,8 @@ import debounce from 'lodash/debounce';
 import noop from 'lodash/noop';
 
 import { BREAKPOINTS } from '../constants';
-import { updateEventFilter, INITIAL_FILTER_STATE } from '../ducks/event-filter';
-import { DEFAULT_EVENT_SORT, isFilterModified } from '../utils/event-filter';
+import { updateEventFilter, INITIAL_FILTER_STATE, DEFAULT_EVENT_SORT } from '../ducks/event-filter';
+import { isFilterModified } from '../utils/event-filter';
 import { resetGlobalDateRange } from '../ducks/global-date-range';
 import { trackEventFactory, EVENT_FILTER_CATEGORY, REPORTS_CATEGORY } from '../utils/analytics';
 import { caseInsensitiveCompare } from '../utils/string';

--- a/src/EventFilter/index.test.js
+++ b/src/EventFilter/index.test.js
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import store from '../store';
 import userEvent from '@testing-library/user-event';
 
-import { DEFAULT_EVENT_SORT } from '../utils/event-filter';
+import { DEFAULT_EVENT_SORT } from '../ducks/event-filter';
 import { INITIAL_FILTER_STATE, UPDATE_EVENT_FILTER } from '../ducks/event-filter';
 
 import EventFilter, { UPDATE_FILTER_DEBOUNCE_TIME } from './';

--- a/src/EventFilter/index.test.js
+++ b/src/EventFilter/index.test.js
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import store from '../store';
 import userEvent from '@testing-library/user-event';
 
-import { DEFAULT_EVENT_SORT } from '../ducks/event-filter';
+import { DEFAULT_EVENT_SORT } from '../constants';
 import { INITIAL_FILTER_STATE, UPDATE_EVENT_FILTER } from '../ducks/event-filter';
 
 import EventFilter, { UPDATE_FILTER_DEBOUNCE_TIME } from './';

--- a/src/FriendlyFilterString/index.js
+++ b/src/FriendlyFilterString/index.js
@@ -5,7 +5,7 @@ import pluralize from 'pluralize';
 import { useTranslation } from 'react-i18next';
 
 import { calcFriendlyDurationString } from '../utils/datetime';
-import { SORT_DIRECTION, DEFAULT_EVENT_SORT, EVENT_SORT_OPTIONS } from '../ducks/event-filter';
+import { SORT_DIRECTION, DEFAULT_EVENT_SORT, EVENT_SORT_OPTIONS } from '../constants';
 
 const FriendlyFilterString = ({ children, className, dateRange, isFiltered, sortConfig, totalFeedCount }) => {
   const { t } = useTranslation('filters', { keyPrefix: 'friendlyFilterString' });

--- a/src/FriendlyFilterString/index.js
+++ b/src/FriendlyFilterString/index.js
@@ -5,7 +5,7 @@ import pluralize from 'pluralize';
 import { useTranslation } from 'react-i18next';
 
 import { calcFriendlyDurationString } from '../utils/datetime';
-import { DEFAULT_EVENT_SORT, EVENT_SORT_OPTIONS, SORT_DIRECTION } from '../utils/event-filter';
+import { SORT_DIRECTION, DEFAULT_EVENT_SORT, EVENT_SORT_OPTIONS } from '../ducks/event-filter';
 
 const FriendlyFilterString = ({ children, className, dateRange, isFiltered, sortConfig, totalFeedCount }) => {
   const { t } = useTranslation('filters', { keyPrefix: 'friendlyFilterString' });

--- a/src/FriendlyFilterString/index.test.js
+++ b/src/FriendlyFilterString/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import FriendlyFilterString from '.';
-import { EVENT_SORT_OPTIONS, SORT_DIRECTION } from '../utils/event-filter';
+import { EVENT_SORT_OPTIONS, SORT_DIRECTION } from '../ducks/event-filter';
 import { render, screen } from '../test-utils';
 
 describe('FriendlyFilterString', () => {

--- a/src/FriendlyFilterString/index.test.js
+++ b/src/FriendlyFilterString/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import FriendlyFilterString from '.';
-import { EVENT_SORT_OPTIONS, SORT_DIRECTION } from '../ducks/event-filter';
+import { EVENT_SORT_OPTIONS, SORT_DIRECTION } from '../constants';
 import { render, screen } from '../test-utils';
 
 describe('FriendlyFilterString', () => {

--- a/src/SideBar/ReportsFeedTab/index.js
+++ b/src/SideBar/ReportsFeedTab/index.js
@@ -12,7 +12,7 @@ import {
 import {
   DEFAULT_EVENT_SORT,
   EVENT_SORT_OPTIONS
-} from '../../ducks/event-filter';
+} from '../../constants';
 import { FEED_CATEGORY, trackEventFactory } from '../../utils/analytics';
 import { fetchNextEventFeedPage } from '../../ducks/events';
 import { MapContext } from '../../App';

--- a/src/SideBar/ReportsFeedTab/index.js
+++ b/src/SideBar/ReportsFeedTab/index.js
@@ -7,10 +7,12 @@ import { useTranslation } from 'react-i18next';
 import { ReactComponent as RefreshIcon } from '../../common/images/icons/refresh-icon.svg';
 
 import {
-  DEFAULT_EVENT_SORT,
-  EVENT_SORT_OPTIONS,
   EVENT_SORT_ORDER_OPTIONS,
 } from '../../utils/event-filter';
+import {
+  DEFAULT_EVENT_SORT,
+  EVENT_SORT_OPTIONS
+} from '../../ducks/event-filter';
 import { FEED_CATEGORY, trackEventFactory } from '../../utils/analytics';
 import { fetchNextEventFeedPage } from '../../ducks/events';
 import { MapContext } from '../../App';

--- a/src/SideBar/useReportsFeed/index.js
+++ b/src/SideBar/useReportsFeed/index.js
@@ -4,7 +4,7 @@ import debounce from 'lodash/debounce';
 import isEqual from 'react-fast-compare';
 import { useDispatch, useSelector } from 'react-redux';
 
-import {calcEventFilterForRequest, DEFAULT_EVENT_SORT} from '../../utils/event-filter';
+import { calcEventFilterForRequest, DEFAULT_EVENT_SORT } from '../../utils/event-filter';
 import { calcLocationParamStringForUserLocationCoords } from '../../utils/location';
 import { fetchEventFeed, fetchEventFeedCancelToken } from '../../ducks/events';
 import { getFeedEvents } from '../../selectors';

--- a/src/SideBar/useReportsFeed/index.js
+++ b/src/SideBar/useReportsFeed/index.js
@@ -4,7 +4,7 @@ import debounce from 'lodash/debounce';
 import isEqual from 'react-fast-compare';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { calcEventFilterForRequest, DEFAULT_EVENT_SORT } from '../../utils/event-filter';
+import { calcEventFilterForRequest } from '../../utils/event-filter';
 import { calcLocationParamStringForUserLocationCoords } from '../../utils/location';
 import { fetchEventFeed, fetchEventFeedCancelToken } from '../../ducks/events';
 import { getFeedEvents } from '../../selectors';
@@ -19,7 +19,7 @@ const useReportsFeed = () => {
   const events = useSelector((state) => getFeedEvents(state));
   const userIsGeoPermRestricted = useSelector((state) => userIsGeoPermissionRestricted(state?.data?.user));
   const userLocationCoords = useSelector((state) => state?.view?.userLocation?.coords);
-  const feedSort = eventFilter.filter.sort ?? DEFAULT_EVENT_SORT;
+  const feedSort = eventFilter.filter.sort;
 
   const [loadingEventFeed, setEventLoadState] = useState(true);
 

--- a/src/SideBar/useReportsFeed/index.js
+++ b/src/SideBar/useReportsFeed/index.js
@@ -1,14 +1,14 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import debounce from 'lodash/debounce';
 import isEqual from 'react-fast-compare';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { calcEventFilterForRequest, DEFAULT_EVENT_SORT } from '../../utils/event-filter';
+import {calcEventFilterForRequest, DEFAULT_EVENT_SORT} from '../../utils/event-filter';
 import { calcLocationParamStringForUserLocationCoords } from '../../utils/location';
 import { fetchEventFeed, fetchEventFeedCancelToken } from '../../ducks/events';
 import { getFeedEvents } from '../../selectors';
-import { INITIAL_FILTER_STATE } from '../../ducks/event-filter';
+import { INITIAL_FILTER_STATE, updateEventFilter } from '../../ducks/event-filter';
 import { objectToParamString } from '../../utils/query';
 import { userIsGeoPermissionRestricted } from '../../utils/geo-perms';
 
@@ -19,8 +19,8 @@ const useReportsFeed = () => {
   const events = useSelector((state) => getFeedEvents(state));
   const userIsGeoPermRestricted = useSelector((state) => userIsGeoPermissionRestricted(state?.data?.user));
   const userLocationCoords = useSelector((state) => state?.view?.userLocation?.coords);
+  const feedSort = eventFilter.filter.sort ?? DEFAULT_EVENT_SORT;
 
-  const [feedSort, setFeedSort] = useState(DEFAULT_EVENT_SORT);
   const [loadingEventFeed, setEventLoadState] = useState(true);
 
   const shouldExcludeContained = useMemo(() => {
@@ -39,6 +39,16 @@ const useReportsFeed = () => {
     },
     format: 'object',
   }, feedSort));
+
+  const setFeedSort = useCallback((sort) => {
+    dispatch(updateEventFilter(
+      {
+        filter: {
+          sort
+        }
+      }
+    ));
+  }, [dispatch]);
 
   const geoResrictedUserLocationCoords = useMemo(
     () => userIsGeoPermRestricted && userLocationCoords,

--- a/src/SideBar/useReportsFeed/index.test.js
+++ b/src/SideBar/useReportsFeed/index.test.js
@@ -5,7 +5,7 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { waitFor } from '@testing-library/react';
 
-import { DEFAULT_EVENT_SORT } from '../../ducks/event-filter';
+import { DEFAULT_EVENT_SORT } from '../../constants';
 import { events, eventWithPoint } from '../../__test-helpers/fixtures/events';
 import { EVENTS_API_URL, EVENT_API_URL } from '../../ducks/events';
 import { INITIAL_FILTER_STATE as INITIAL_EVENT_FILTER_STATE } from '../../ducks/event-filter';

--- a/src/SideBar/useReportsFeed/index.test.js
+++ b/src/SideBar/useReportsFeed/index.test.js
@@ -5,7 +5,7 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { waitFor } from '@testing-library/react';
 
-import { DEFAULT_EVENT_SORT } from '../../utils/event-filter';
+import { DEFAULT_EVENT_SORT } from '../../ducks/event-filter';
 import { events, eventWithPoint } from '../../__test-helpers/fixtures/events';
 import { EVENTS_API_URL, EVENT_API_URL } from '../../ducks/events';
 import { INITIAL_FILTER_STATE as INITIAL_EVENT_FILTER_STATE } from '../../ducks/event-filter';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -340,3 +340,13 @@ export const DEVELOPMENT_FEATURE_FLAGS = {
 };
 
 export const LINK_TYPES = { PATROL: 'patrol', EVENT: 'event' };
+
+export const EVENT_SORT_OPTIONS = [
+  { value: 'updated_at', key: 'updatedAtLabel' },
+  { value: 'created_at', key: 'createdAtLabel' },
+  { value: 'event_time', key: 'eventTimeLabel' },
+];
+
+export const SORT_DIRECTION = { up: 'up', down: 'down' };
+
+export const DEFAULT_EVENT_SORT = [SORT_DIRECTION.down, EVENT_SORT_OPTIONS[0]];

--- a/src/ducks/event-filter/index.js
+++ b/src/ducks/event-filter/index.js
@@ -4,6 +4,16 @@ import { generateDaysAgoDate } from '../../utils/datetime';
 import globalDateRangeReducerWithDefaultConfig, { RESET_DATE_RANGE, UPDATE_DATE_RANGE } from '../global-date-range';
 import globallyResettableReducer from '../../reducers/global-resettable';
 
+export const EVENT_SORT_OPTIONS = [
+  { value: 'updated_at', key: 'updatedAtLabel' },
+  { value: 'created_at', key: 'createdAtLabel' },
+  { value: 'event_time', key: 'eventTimeLabel' },
+];
+
+export const SORT_DIRECTION = { up: 'up', down: 'down' };
+
+export const DEFAULT_EVENT_SORT = [SORT_DIRECTION.down, EVENT_SORT_OPTIONS[0]];
+
 const defaultDateRange = {
   lower: generateDaysAgoDate(REACT_APP_DEFAULT_EVENT_FILTER_FROM_DAYS).toISOString(),
   upper: null,
@@ -23,7 +33,7 @@ export const INITIAL_FILTER_STATE = {
     duration: null,
     priority: [],
     reported_by: [],
-    sort: null,
+    sort: DEFAULT_EVENT_SORT,
   },
 };
 

--- a/src/ducks/event-filter/index.js
+++ b/src/ducks/event-filter/index.js
@@ -1,4 +1,4 @@
-import {DEFAULT_EVENT_SORT, EVENT_STATE_CHOICES, REACT_APP_DEFAULT_EVENT_FILTER_FROM_DAYS} from '../../constants';
+import { DEFAULT_EVENT_SORT, EVENT_STATE_CHOICES, REACT_APP_DEFAULT_EVENT_FILTER_FROM_DAYS } from '../../constants';
 import { generateOptionalStorageConfig } from '../../reducers/storage-config';
 import { generateDaysAgoDate } from '../../utils/datetime';
 import globalDateRangeReducerWithDefaultConfig, { RESET_DATE_RANGE, UPDATE_DATE_RANGE } from '../global-date-range';

--- a/src/ducks/event-filter/index.js
+++ b/src/ducks/event-filter/index.js
@@ -23,6 +23,7 @@ export const INITIAL_FILTER_STATE = {
     duration: null,
     priority: [],
     reported_by: [],
+    sort: null,
   },
 };
 

--- a/src/ducks/event-filter/index.js
+++ b/src/ducks/event-filter/index.js
@@ -1,18 +1,8 @@
-import { EVENT_STATE_CHOICES, REACT_APP_DEFAULT_EVENT_FILTER_FROM_DAYS } from '../../constants';
+import {DEFAULT_EVENT_SORT, EVENT_STATE_CHOICES, REACT_APP_DEFAULT_EVENT_FILTER_FROM_DAYS} from '../../constants';
 import { generateOptionalStorageConfig } from '../../reducers/storage-config';
 import { generateDaysAgoDate } from '../../utils/datetime';
 import globalDateRangeReducerWithDefaultConfig, { RESET_DATE_RANGE, UPDATE_DATE_RANGE } from '../global-date-range';
 import globallyResettableReducer from '../../reducers/global-resettable';
-
-export const EVENT_SORT_OPTIONS = [
-  { value: 'updated_at', key: 'updatedAtLabel' },
-  { value: 'created_at', key: 'createdAtLabel' },
-  { value: 'event_time', key: 'eventTimeLabel' },
-];
-
-export const SORT_DIRECTION = { up: 'up', down: 'down' };
-
-export const DEFAULT_EVENT_SORT = [SORT_DIRECTION.down, EVENT_SORT_OPTIONS[0]];
 
 const defaultDateRange = {
   lower: generateDaysAgoDate(REACT_APP_DEFAULT_EVENT_FILTER_FROM_DAYS).toISOString(),

--- a/src/utils/event-filter.js
+++ b/src/utils/event-filter.js
@@ -4,7 +4,8 @@ import merge from 'lodash/merge';
 
 import { cleanedUpFilterObject, objectToParamString } from './query';
 import { generateMonthsAgoDate } from './datetime';
-import { DEFAULT_EVENT_SORT, INITIAL_FILTER_STATE, SORT_DIRECTION } from '../ducks/event-filter';
+import { INITIAL_FILTER_STATE } from '../ducks/event-filter/';
+import { DEFAULT_EVENT_SORT, SORT_DIRECTION } from '../constants';
 
 import store from '../store';
 

--- a/src/utils/event-filter.js
+++ b/src/utils/event-filter.js
@@ -4,23 +4,14 @@ import merge from 'lodash/merge';
 
 import { cleanedUpFilterObject, objectToParamString } from './query';
 import { generateMonthsAgoDate } from './datetime';
-import { INITIAL_FILTER_STATE } from '../ducks/event-filter';
+import { DEFAULT_EVENT_SORT, INITIAL_FILTER_STATE, SORT_DIRECTION } from '../ducks/event-filter';
+
 import store from '../store';
-
-export const EVENT_SORT_OPTIONS = [
-  { value: 'updated_at', key: 'updatedAtLabel' },
-  { value: 'created_at', key: 'createdAtLabel' },
-  { value: 'event_time', key: 'eventTimeLabel' },
-];
-
-export const SORT_DIRECTION = { up: 'up', down: 'down' };
 
 export const EVENT_SORT_ORDER_OPTIONS = [
   { value: SORT_DIRECTION.down, key: 'newest' },
   { value: SORT_DIRECTION.up, key: 'oldest' },
 ];
-
-export const DEFAULT_EVENT_SORT = [SORT_DIRECTION.down, EVENT_SORT_OPTIONS[0]];
 
 export const isFilterModified = ({ state, filter: { priority, reported_by, text } }) => (
   !isEqual(INITIAL_FILTER_STATE.state, state)

--- a/src/utils/event-filter.test.js
+++ b/src/utils/event-filter.test.js
@@ -1,5 +1,5 @@
 import { calcSortParamForEventFilter, sortEventsBySortConfig } from './event-filter';
-import { SORT_DIRECTION } from '../ducks/event-filter';
+import { SORT_DIRECTION } from '../constants';
 import { events } from '../__test-helpers/fixtures/events';
 
 test('calcSortParamForEventFilter', () => {

--- a/src/utils/event-filter.test.js
+++ b/src/utils/event-filter.test.js
@@ -1,4 +1,5 @@
-import { calcSortParamForEventFilter, sortEventsBySortConfig, SORT_DIRECTION } from './event-filter';
+import { calcSortParamForEventFilter, sortEventsBySortConfig } from './event-filter';
+import { SORT_DIRECTION } from '../ducks/event-filter';
 import { events } from '../__test-helpers/fixtures/events';
 
 test('calcSortParamForEventFilter', () => {


### PR DESCRIPTION
### What does this PR do?
- Adds sort filter to the redux store making it able to be persisted

### Relevant link(s)
* Tracking tickets: [ERA-10108](https://allenai.atlassian.net/browse/ERA-10108)
* [Hosted demo environments](https://era-10108.dev.pamdas.org)


[ERA-10108]: https://allenai.atlassian.net/browse/ERA-10108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ