### PR TITLE
ERA-11132: Hotfix - Remove timeout on fetching events parallelization code.

### DIFF
--- a/src/utils/parallelPaginatedRequest.js
+++ b/src/utils/parallelPaginatedRequest.js
@@ -10,7 +10,6 @@ async function fetchPage(apiUrl, requestConfig, page, pageSize, maxRetries) {
     try {
       const response = await axios.get(`${apiUrl}&page=${page}&page_size=${pageSize}`, {
         ...requestConfig,
-        timeout: 7500
       });
 
       if (response.status !== 200) {


### PR DESCRIPTION
### What does this PR do?
- Removing timeouts from parallel request

### Relevant link(s)
* Tracking tickets: [ERA-11132](https://allenai.atlassian.net/browse/ERA-11132)
* [Hosted demo environments](https://era-11132.dev.pamdas.org)


[ERA-11132]: https://allenai.atlassian.net/browse/ERA-11132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ