### PR TITLE
ERA-11132: Hotfix - Remove timeout on fetching events parallelization code

### DIFF
--- a/src/utils/parallelPaginatedRequest.js
+++ b/src/utils/parallelPaginatedRequest.js
@@ -10,6 +10,7 @@ async function fetchPage(apiUrl, requestConfig, page, pageSize, maxRetries) {
     try {
       const response = await axios.get(`${apiUrl}&page=${page}&page_size=${pageSize}`, {
         ...requestConfig,
+        timeout: 120000
       });
 
       if (response.status !== 200) {


### PR DESCRIPTION
### What does this PR do?
- Adding 2min timeout rule to the parallel calls

### Relevant link(s)
* Tracking tickets: [ERA-11132](https://allenai.atlassian.net/browse/ERA-11132)


[ERA-11132]: https://allenai.atlassian.net/browse/ERA-11132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ