### PR TITLE
ERA-11176: Patrol "to" date filter disabled after selecting "from" date filter

### DIFF
--- a/src/DateRangeSelector/index.js
+++ b/src/DateRangeSelector/index.js
@@ -71,8 +71,6 @@ const DateRangeSelector = ({
     onFilterSettingsToggle && onFilterSettingsToggle(!filterSettingsOpen);
   }, [filterSettingsOpen, onFilterSettingsToggle]);
 
-  const hasEndMaxDate = typeof endMaxDate !== 'undefined';
-
   const onStartDateTimePickerChange = (dateTime) => {
     setStartDateTime(dateTime);
 
@@ -147,7 +145,7 @@ const DateRangeSelector = ({
                 popperPlacement: placement,
               },
             }}
-            max={formatDateToLocalISO(hasEndMaxDate ? endMaxDate : maxDate)}
+            max={endMaxDate === null ? undefined : formatDateToLocalISO(endMaxDate || maxDate)}
             min={formatDateToLocalISO(startDate || new Date('2000-01-01'))}
             onChange={onEndDateTimePickerChange}
             required={requireEnd}


### PR DESCRIPTION
### What does this PR do?
Fixes a bug that was causing Patrol date filter to make impossible to set an end date.

### Relevant link(s)
- [ERA-11176](https://allenai.atlassian.net/browse/ERA-11176)
- [Env]()

### Any background context you want to provide(if applicable)
The previous logic in the `max` prop of the end date `DateTimePicker` component was forcing to set a max date even if the max end date was `null`. The new logic checks if the max end date is `null` and in that case leaves the `max` as `undefined`, which is desired.


[ERA-11176]: https://allenai.atlassian.net/browse/ERA-11176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ