### PR TITLE
ERA-11166: Patrols - Users can't check/uncheck auto-end checkbox when selecting the same date both in Start Date and End Date

### DIFF
--- a/src/PatrolDetailView/PlanSection/index.js
+++ b/src/PatrolDetailView/PlanSection/index.js
@@ -290,7 +290,7 @@ const PlanSection = ({
       <label className={styles.autoFieldCheckbox}>
         <input
           checked={isAutoEnd}
-          disabled={!endDate || !isFuture(endDate)}
+          disabled={endDate === EMPTY_DATE_VALUE}
           onChange={handleAutoEndChange}
           type="checkbox"
           data-testid="patrol-is-auto-end"

--- a/src/PatrolDetailView/PlanSection/index.test.js
+++ b/src/PatrolDetailView/PlanSection/index.test.js
@@ -266,6 +266,53 @@ describe('PatrolDetailView - PlanSection', () => {
     expect(autoEndAction).toStrictEqual({ payload: { autoEndPatrols: true }, type: 'UPDATE_USER_PREFERENCES' });
   });
 
+  test('disables the auto-end checkbox when there is no end date set', async () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+
+    renderPlanSectionWithWrapper({
+      patrolForm: {
+        ...newPatrol,
+        patrol_segments: [{
+          ...newPatrol.patrol_segments[0],
+          time_range: {
+            end_time: null,
+            start_time: tomorrow,
+          },
+        }],
+      }
+    });
+
+    expect(await screen.findByTestId('patrol-is-auto-end')).toBeDisabled();
+  });
+
+  test('allows the user to check auto-end checkbox when the end date is the same as the start date ', async () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+
+    renderPlanSectionWithWrapper({
+      patrolForm: {
+        ...newPatrol,
+        patrol_segments: [{
+          ...newPatrol.patrol_segments[0],
+          time_range: {
+            end_time: tomorrow,
+            start_time: tomorrow,
+          },
+        }],
+      }
+    });
+
+    const autoEndInput = await screen.findByTestId('patrol-is-auto-end');
+
+    expect(autoEndInput).not.toBeDisabled();
+
+    userEvent.click(autoEndInput);
+    const [, autoEndAction] = mockedStore.getActions();
+
+    expect(autoEndAction).toStrictEqual({ payload: { autoEndPatrols: true }, type: 'UPDATE_USER_PREFERENCES' });
+  });
+
   test('prevent updating user preferences when user changes auto end/start value for an existing', async () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);

--- a/src/ReportManager/DetailsSection/SchemaForm/fields/Collection/index.test.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/fields/Collection/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 
-import { render, screen, waitFor, within } from '../../../../../test-utils';
+import { render, screen, within } from '../../../../../test-utils';
 import { FORM_ELEMENT_TYPES } from '../../constants';
 
 import Collection from './';


### PR DESCRIPTION
### What does this PR do?
- Updating validation of disabling for auto-end checkbox in `<PlanSection />`
- Adding test coverage


### Relevant link(s)
* Tracking tickets: [ERA-11166](https://allenai.atlassian.net/browse/ERA-11166)
* [Hosted demo environments](https://era-11166.dev.pamdas.org)

### Where / how to start reviewing (optional)
- Patrol creation should be working as regular
- Start/End dates validation should be working as regular, the only change is that now the auto-end checkbox is usable when the end date is the same as the start date


[ERA-11166]: https://allenai.atlassian.net/browse/ERA-11166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ