### PR TITLE
Fixing 24h formatting for the getTimeInTimezone method

### DIFF
--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -165,5 +165,7 @@ export const getTimeInTimezone = (date, timeZone) => new Intl.DateTimeFormat('en
   timeZone,
   hour: '2-digit',
   minute: '2-digit',
-  hour12: false,
-}).format(date);
+  hourCycle: 'h23',
+}
+).format(date);
+

--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -166,6 +166,5 @@ export const getTimeInTimezone = (date, timeZone) => new Intl.DateTimeFormat('en
   hour: '2-digit',
   minute: '2-digit',
   hourCycle: 'h23',
-}
-).format(date);
+}).format(date);
 


### PR DESCRIPTION
### What does this PR do?
- Fixes 24h formatting for the getTimeInTimezone method