### PR TITLE
ERA-10594: Leverage `read` filter param in messages API calls from das-web-react

### DIFF
--- a/src/Nav/MessageMenu.js
+++ b/src/Nav/MessageMenu.js
@@ -10,7 +10,8 @@ import {
   fetchAllMessages,
   fetchMessagesSuccess,
   fetchUnreadMessagesCount,
-  updateMessageFromRealtime, updateUnreadMessagesCount
+  updateMessageFromRealtime,
+  updateUnreadMessagesCount
 } from '../ducks/messaging';
 import MessageContext from '../InReach/context';
 
@@ -45,7 +46,7 @@ const MessageMenu = () => {
 
   const checkForUnreadMessages = useCallback(() => {
     fetchUnreadMessagesCount()
-      .then(({ data: { data: { count } } }) => dispatch(updateUnreadMessagesCount(count)))
+      .then(({ data: { data: { results } } }) => dispatch(updateUnreadMessagesCount({ results }) ))
       .catch((error) => console.warn('error checking for unread messages', { error }));
   }, [dispatch]);
 
@@ -58,8 +59,10 @@ const MessageMenu = () => {
   }, [dispatch]);
 
   useEffect(() => {
-    checkForUnreadMessages();
-  }, [checkForUnreadMessages, state.results]);
+    if (subjects.length > 0){
+      checkForUnreadMessages();
+    }
+  }, [checkForUnreadMessages, state.results, subjects]);
 
   return canShowMessageMenu ? <Dropdown
       align="end"

--- a/src/ducks/messaging.js
+++ b/src/ducks/messaging.js
@@ -40,7 +40,7 @@ export const updateUnreadMessagesCount = (payload) => ({
 
 const { get, post } = axios;
 
-export const fetchUnreadMessagesCount = () => axios.get(`${MESSAGING_API_URL}?include_additional_data=false&page_size=0&read=false`);
+export const fetchUnreadMessagesCount = () => axios.get(`${MESSAGING_API_URL}?include_additional_data=false&page_size=10&read=false`);
 
 export const fetchMessages = (params = {}) => {
   const paramString = objectToParamString(
@@ -106,7 +106,7 @@ export const messageListReducer = (state = INITIAL_MESSAGE_LIST_STATE, action) =
   if (type === UPDATE_UNREAD_MESSAGES_COUNT) {
     return {
       ...state,
-      unreadMessagesCount: payload,
+      unreadMessagesCount: payload.results.filter(msg => messageIsValidForDisplay(msg, store.getState().data.subjectStore)).length,
     };
   }
 


### PR DESCRIPTION
### What does this PR do?
- It filters unread messages against `messageIsValidForDisplay` to take in count active/inactive subjects.
- Adds the subject store as dependency for checking unread messages 

### Relevant link(s)
* Tracking tickets: [ERA-10594](https://allenai.atlassian.net/browse/ERA-10594)
* [Hosted demo environments](https://era-10594.dev.pamdas.org)


[ERA-10594]: https://allenai.atlassian.net/browse/ERA-10594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ