### PR TITLE
ERA-11154: Do not add a collection item when pressing "cancel" upon first creation

### DIFF
--- a/src/ReportManager/DetailsSection/SchemaForm/fields/Collection/SortableList/Item/index.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/fields/Collection/SortableList/Item/index.js
@@ -78,7 +78,7 @@ const Item = ({
   const onFormModalCancel = () => {
     onChange(formDataBeforeEditingRef.current, errorsBeforeEditingRef.current);
     setIsFormModalOpen(false);
-    onCancel?.(id);
+    onCancel?.();
   };
 
   const onFieldChange = (fieldId, value, error) => {

--- a/src/ReportManager/DetailsSection/SchemaForm/fields/Collection/SortableList/Item/index.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/fields/Collection/SortableList/Item/index.js
@@ -32,6 +32,7 @@ const Item = ({
   isFormPreviewOpen,
   onChange = null,
   onDelete = null,
+  onCancel = null,
   renderField = null,
   setIsFormModalOpen = null,
   setIsFormPreviewOpen = null,
@@ -77,6 +78,7 @@ const Item = ({
   const onFormModalCancel = () => {
     onChange(formDataBeforeEditingRef.current, errorsBeforeEditingRef.current);
     setIsFormModalOpen(false);
+    onCancel?.(id);
   };
 
   const onFieldChange = (fieldId, value, error) => {

--- a/src/ReportManager/DetailsSection/SchemaForm/fields/Collection/SortableList/index.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/fields/Collection/SortableList/index.js
@@ -45,6 +45,7 @@ const SortableList = ({
   focusLocationMarker,
   items,
   onItemChange,
+  onItemCancel,
   onItemDelete,
   onItemMove,
   renderField,
@@ -155,6 +156,7 @@ const SortableList = ({
           isFormPreviewOpen={item.isFormPreviewOpen}
           key={item.id}
           onChange={onItemChange(index)}
+          onCancel={onItemCancel(index)}
           onDelete={onItemDelete(index)}
           setIsFormModalOpen={setIsItemFormModalOpen(index)}
           setIsFormPreviewOpen={setIsItemFormPreviewOpen(index)}

--- a/src/ReportManager/DetailsSection/SchemaForm/fields/Collection/index.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/fields/Collection/index.js
@@ -128,9 +128,32 @@ const Collection = ({
       updatedError = undefined;
     }
 
+   /* console.log(items);
+    console.log(value);*/
+
     lastAddedItemIdRef.current += 1;
     onFieldChange(id, [...value, {}], updatedError);
     setItems([...items, { id: lastAddedItemIdRef.current, isFormModalOpen: true, isFormPreviewOpen: false }]);
+  };
+
+  const onItemCancel = (itemIndex) => (itemId) => {
+    /*console.log('Cancelled item id', itemId);
+    console.log('Cancelled item index', itemIndex);*/
+
+    const isNewItem = Object.keys(value[itemIndex]).length === 0;
+    console.log(isNewItem);
+
+    const newItems = items.filter((_, index) => itemIndex !== index);
+    const newValue = value.filter((_, index) => itemIndex !== index);
+
+  /*  console.log(newItems);
+    console.log(newValue);*/
+
+    lastAddedItemIdRef.current -= 1;
+    setItems(newItems);
+    onFieldChange(id, newValue);
+    // se necesita reiniciar el contador de items
+    // se necesita remover el objeto vacio de value
   };
 
   // If a location field from an item requests to focus its location marker, prefix the marker id with the collection
@@ -184,6 +207,7 @@ const Collection = ({
             onItemChange={onItemChange}
             onItemDelete={onItemDelete}
             onItemMove={onItemMove}
+            onItemCancel={onItemCancel}
             setIsItemFormModalOpen={setIsItemFormModalOpen}
             setIsItemFormPreviewOpen={setIsItemFormPreviewOpen}
             renderField={renderField}

--- a/src/ReportManager/DetailsSection/SchemaForm/fields/Collection/index.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/fields/Collection/index.js
@@ -80,7 +80,7 @@ const Collection = ({
         if (erroneousItemIndex > itemIndex) {
           updatedError[parseInt(erroneousItemIndex) - 1] = updatedError[erroneousItemIndex];
           delete updatedError[erroneousItemIndex];
-        };
+        }
       });
     }
 
@@ -128,32 +128,17 @@ const Collection = ({
       updatedError = undefined;
     }
 
-   /* console.log(items);
-    console.log(value);*/
-
     lastAddedItemIdRef.current += 1;
     onFieldChange(id, [...value, {}], updatedError);
     setItems([...items, { id: lastAddedItemIdRef.current, isFormModalOpen: true, isFormPreviewOpen: false }]);
   };
 
-  const onItemCancel = (itemIndex) => (itemId) => {
-    /*console.log('Cancelled item id', itemId);
-    console.log('Cancelled item index', itemIndex);*/
-
-    const isNewItem = Object.keys(value[itemIndex]).length === 0;
-    console.log(isNewItem);
-
-    const newItems = items.filter((_, index) => itemIndex !== index);
-    const newValue = value.filter((_, index) => itemIndex !== index);
-
-  /*  console.log(newItems);
-    console.log(newValue);*/
-
-    lastAddedItemIdRef.current -= 1;
-    setItems(newItems);
-    onFieldChange(id, newValue);
-    // se necesita reiniciar el contador de items
-    // se necesita remover el objeto vacio de value
+  const onItemCancel = (itemIndex) => () => {
+    if (Object.keys(value[itemIndex]).length === 0){ // applying the removal logic only for new items
+      lastAddedItemIdRef.current -= 1;
+      setItems(items.filter((_, index) => itemIndex !== index));
+      onFieldChange(id, value.filter((_, index) => itemIndex !== index));
+    }
   };
 
   // If a location field from an item requests to focus its location marker, prefix the marker id with the collection


### PR DESCRIPTION
### What does this PR do?
- Adds logic to the Collection component to remove new empty collection items when user cancels an addition. 

### Relevant link(s)
* Tracking tickets: [ERA-11154](https://allenai.atlassian.net/browse/ERA-11154)
* [Hosted demo environments](https://era-11154.dev.pamdas.org)

[ERA-11154]: https://allenai.atlassian.net/browse/ERA-11154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ