### PR TITLE
Stable generated track colors for subjects without `stroke` property specified

### DIFF
--- a/src/TracksLayer/track.js
+++ b/src/TracksLayer/track.js
@@ -13,11 +13,21 @@ import useMapLayers from '../hooks/useMapLayers';
 
 const { TRACKS_LINES, SUBJECT_SYMBOLS } = LAYER_IDS;
 
+const STABLE_RANDOM_TRACK_COLOR_BASED_ON_ID = [
+  'rgb',
+  ['random', 64, 224, ['concat', ['get', 'id'], '-r']],
+  ['random', 64, 224, ['concat', ['get', 'id'], '-g']],
+  ['random', 64, 224, ['concat', ['get', 'id'], '-b']]
+];
+
 const TRACK_LAYER_LINE_PAINT = {
   'line-color': [
     'case',
-    ['has', 'stroke'], ['get', 'stroke'],
-    'orange',
+    ['all',
+      ['has', 'stroke'],
+      ['!=', ['get', 'stroke'], '']
+    ], ['to-color', ['get', 'stroke']],
+    STABLE_RANDOM_TRACK_COLOR_BASED_ON_ID,
   ],
   'line-width': ['step', ['zoom'], 1, 8, ['get', 'stroke-width']],
 };


### PR DESCRIPTION
### What does this PR do?
- Uses a Mapbox style expression to assign a random but stable track color for subjects who do not have explicitly assigned subject tracks. 
- The generated color value is seeded based on the UUID of the subject
- The color range is within boundaries that prevent them from being too dark or too light to be seen on low-contrast backgrounds as best possible.

### How does it look

### Relevant link(s)
* 🤷 
* https://joshua-random-track-colors.dev.pamdas.org/
* 

### Where / how to start reviewing (optional)
- It's a one-liner that can benefit a lot of users. Let's test in dev.

### Any background context you want to provide(if applicable)
- This is a long-desired feature which was recently yet again requested. This is a near-no-code-change way to achieve it.
