### PR TITLE
ERA-10960: Profiles - Non-admin users can't switch to their own profiles if they lack proper permissions

### DIFF
--- a/src/ducks/user.js
+++ b/src/ducks/user.js
@@ -26,7 +26,11 @@ export const fetchCurrentUser = () => (dispatch, getState) => axios.get(CURRENT_
     dispatch(fetchUserSuccess(data));
     const { data: { selectedUserProfile } } = getState();
     if (selectedUserProfile?.id && selectedUserProfile.id !== data.id) {
-      return axios.get(`${USER_API_URL}/${selectedUserProfile.id}`)
+      return axios.get(`${USER_API_URL}/${selectedUserProfile.id}`, {
+        headers: {
+          'User-Profile': selectedUserProfile.id,
+        },
+      })
         .then(({ data: { data: profileUser } }) => {
           dispatch(setUserProfile(profileUser));
         });


### PR DESCRIPTION
### What does this PR do?
Fixes issue when switching to a user profile when the master user isn't an admin. We were getting a 404 when requesting the user profile through `/user/{profile_id}` because we weren't setting the `User-Profile` header. Why the issue doesn't happen with admins is beyond my knowledge, maybe related to their permissions.

### Relevant link(s)
* [ERA-10960](https://allenai.atlassian.net/browse/ERA-10960)
* [Env](https://era-10960.dev.pamdas.org/)

### Any background context you want to provide(if applicable)
When the user switches to a profile, we store the profile data in our Redux store. Then, we read that data and add an Axios interceptor that injects the `User-Profile` header on every request that is not `/user/me`. However, probably due to a race condition or simply because of the order in which things happen, we are not setting that header to the `/user/{profile_id}` call we do on `fetchCurrentUser`, which results in the backend returning a 404.

The solution in this PR simply consists in injecting the header during the request of the profile, instead of depending on the Axios interceptor.


[ERA-10960]: https://allenai.atlassian.net/browse/ERA-10960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ