### PR TITLE
ERA-9754: adds data-testids for e2e subject tests

### DIFF
--- a/src/DateTime/index.js
+++ b/src/DateTime/index.js
@@ -11,7 +11,7 @@ const DateTime = ({ date, showElapsed = true, className = '', ...rest }) => {
     return null;
   }
 
-  return <div className={`${styles.container} ${className}`} title={generateCurrentTimeZoneTitle()} {...rest}>
+  return <div className={`${styles.container} ${className}`} data-testid='date-time' title={generateCurrentTimeZoneTitle()} {...rest}>
     <span className={styles.date}>
       {
         format(new Date(date), STANDARD_DATE_FORMAT)

--- a/src/DateTime/index.js
+++ b/src/DateTime/index.js
@@ -11,7 +11,7 @@ const DateTime = ({ date, showElapsed = true, className = '', ...rest }) => {
     return null;
   }
 
-  return <div className={`${styles.container} ${className}`} data-testid='date-time' title={generateCurrentTimeZoneTitle()} {...rest}>
+  return <div className={`${styles.container} ${className}`} data-testid="date-time" title={generateCurrentTimeZoneTitle()} {...rest}>
     <span className={styles.date}>
       {
         format(new Date(date), STANDARD_DATE_FORMAT)

--- a/src/HeatmapToggleButton/index.js
+++ b/src/HeatmapToggleButton/index.js
@@ -21,6 +21,7 @@ const HeatmapToggleButton = ({
     containerClassName={`${styles.container} ${visibilityClassName}`}
     labelText={visibilityClassName ? t('heatmapOnLabel') : t('heatmapOffLabel')}
     onClick={onButtonClick}
+    data-testid="heatmap-toggle-button"
     {...restProps}
   />;
 };

--- a/src/SubjectMessagesPopover/index.js
+++ b/src/SubjectMessagesPopover/index.js
@@ -54,6 +54,7 @@ const SubjectMessagesPopover = ({ className = '', subject = null, ...restProps }
       buttonClassName={`${className} ${styles.button}`}
       containerClassName={styles.container}
       labelText={t('label')}
+      data-testid="subject-messages-popover"
       {...restProps}
     />
   </OverlayTrigger>;

--- a/src/SubjectPopup/index.js
+++ b/src/SubjectPopup/index.js
@@ -54,7 +54,7 @@ const SubjectPopup = ({ data }) => {
   return <>
     <div className={styles.header}>
       <div>
-        <div className={styles.defaultStatusProperty} data-testid='subject-popup-name'>
+        <div className={styles.defaultStatusProperty} data-testid="subject-popup-name">
           {properties.default_status_value && <>
             {properties.image && <img alt={t('subjectIconAlt', { name: properties.name })} src={properties.image} />}
 

--- a/src/SubjectPopup/index.js
+++ b/src/SubjectPopup/index.js
@@ -54,7 +54,7 @@ const SubjectPopup = ({ data }) => {
   return <>
     <div className={styles.header}>
       <div>
-        <div className={styles.defaultStatusProperty}>
+        <div className={styles.defaultStatusProperty} data-testid='subject-popup-name'>
           {properties.default_status_value && <>
             {properties.image && <img alt={t('subjectIconAlt', { name: properties.name })} src={properties.image} />}
 

--- a/src/TrackLegend/index.js
+++ b/src/TrackLegend/index.js
@@ -103,7 +103,7 @@ const TrackLegend = ({
             ? <>
               {items[0].icon}
 
-              <p className={styles.title} title={items[0].title}>{items[0].title}</p>
+              <p className={styles.title} data-testid="points-over-time" title={items[0].title}>{items[0].title}</p>
             </>
             : <>
               <TracksOffIcon className={styles.tracksOffIcon} data-testid="tracks-off-icon" />

--- a/src/TrackToggleButton/index.js
+++ b/src/TrackToggleButton/index.js
@@ -34,6 +34,7 @@ const TrackToggleButton = ({
     containerClassName={containerClasses}
     labelText={t((trackPinned && 'tracksPinned') || (trackVisible && 'tracksOn') || 'tracksOff')}
     ref={ref}
+    data-testid="tracks-toggle-button"
     {...restProps}
   />;
 };


### PR DESCRIPTION
### What does this PR do?
- just adds some data-testid attributes that are used in https://github.com/PADAS/er-web-automation-playwright/pull/201

### Context
It was difficult to interact with the texts and buttons related to subjects since they were dynamic. Adding a data-testid stablize Playwright interactions.

