### PR TITLE
ERA-11774: event creation dialog' "jump to" dropdown doesnt show the list of event categories

### DIFF
--- a/src/EventFilter/Filters/index.js
+++ b/src/EventFilter/Filters/index.js
@@ -305,6 +305,7 @@ const Filters = ({
           isMulti={true}
           onChange={onReportedByChange}
           value={selectedReporters}
+          menuRef={document.body}
         />
 
         <Button

--- a/src/ReportedBySelect/index.js
+++ b/src/ReportedBySelect/index.js
@@ -225,7 +225,7 @@ const ReportedBySelect = ({
   const optionalProps = {};
   if (menuRef) {
     optionalProps.menuPortalTarget = menuRef;
-    selectStyles.menuPortal = base => ({ ...base, fontSize: '0.9rem', left: '1rem', top: '10rem', zIndex: 9999 });
+    selectStyles.menuPortal = base => ({ ...base, fontSize: '0.9rem', zIndex: 9999 });
   }
 
   return <Select


### PR DESCRIPTION
### What does this PR do?
- It adds a menuRef to `<ReportedBySelect />`
- Removes unnecessary styles of the menu

### How does it look
- <img width="517" height="693" alt="Screenshot 2025-07-16 at 1 32 48 p m" src="https://github.com/user-attachments/assets/1e1d9639-2132-476b-bbea-5b6378ceccb9" />

### Relevant link(s)
* Tracking tickets: [ERA-11774](https://allenai.atlassian.net/browse/ERA-11774)


[ERA-11774]: https://allenai.atlassian.net/browse/ERA-11774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ