### PR TITLE
Custom Google Analytics for dev

### DIFF
--- a/.github/workflows/develop-workflow.yml
+++ b/.github/workflows/develop-workflow.yml
@@ -64,6 +64,12 @@ jobs:
           if [[ ${SITE} =~ release-*.*.* ]]; then export SITE="stage"; else export SITE=$(echo ${SITE} | tr '[:upper:]' '[:lower:]'); fi
           if $(wget -q --method=HEAD "https://${SITE}.pamdas.org"); then echo "::set-output name=site_exists::true"; else echo "::set-output name=site_exists::false"; fi
 
+      - name: Set GA4 tracking ID for develop
+        if: github.ref_name == 'develop'
+        run: |
+          tracking_id=$(grep REACT_APP_GA4_TRACKING_ID .env.development | cut -d '=' -f2)
+          echo "REACT_APP_GA4_TRACKING_ID=$tracking_id" >> $GITHUB_ENV
+
       - name: Yarn build
         if: steps.validate_env.outputs.site_exists == 'true'
         run: CI=false yarn build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,8 @@ jobs:
 
       - name: Read env file
         id: env-vars
-        if: github.ref_name == 'develop'
+        # if: github.ref_name == 'develop'
+        if: github.ref_name == 'custom-google-analytics-for-dev'
         run: |
           tracking_id=$(grep REACT_APP_GA4_TRACKING_ID .env.development | cut -d '=' -f2)
           echo "build-args=REACT_APP_GA4_TRACKING_ID=$tracking_id" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,13 @@ on:
     branches:
       - develop
       - 'release-**'
+      - custom-google-analytics-for-dev
 
 jobs:
   config:
     runs-on: ubuntu-latest
+    outputs:
+      build-args: ${{ steps.env-vars.outputs.build-args }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node
@@ -17,13 +20,21 @@ jobs:
       - run: |
           npm pkg set "buildbranch"="${{ github.head_ref || github.ref_name }}"
           npm pkg set "buildnum"="${{ github.run_number }}"
+
+      - name: Read env file
+        id: env-vars
+        if: github.ref_name == 'develop'
+        run: |
+          tracking_id=$(grep REACT_APP_GA4_TRACKING_ID .env.development | cut -d '=' -f2)
+          echo "build-args=REACT_APP_GA4_TRACKING_ID=$tracking_id" >> $GITHUB_OUTPUT
+
       - uses: actions/upload-artifact@v4
         with:
           name: npm-config
           path: package.json
   build:
     needs: config
-    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v2
+    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@main
     with:
       environment: padas-app
       repository: europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react
@@ -31,3 +42,4 @@ jobs:
       dockerfile: Dockerfile.mt
       artifact-download: true
       artifact-name: npm-config
+      build-args: ${{ needs.config.outputs.build-args || '' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - develop
       - 'release-**'
-      - custom-google-analytics-for-dev
 
 jobs:
   config:
@@ -23,8 +22,7 @@ jobs:
 
       - name: Read env file
         id: env-vars
-        # if: github.ref_name == 'develop'
-        if: github.ref_name == 'custom-google-analytics-for-dev'
+        if: github.ref_name == 'develop'
         run: |
           tracking_id=$(grep REACT_APP_GA4_TRACKING_ID .env.development | cut -d '=' -f2)
           echo "build-args=REACT_APP_GA4_TRACKING_ID=$tracking_id" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-envs.yml
+++ b/.github/workflows/pr-envs.yml
@@ -10,6 +10,8 @@ jobs:
   config:
     if: contains(github.event.pull_request.labels.*.name, 'deploy')
     runs-on: ubuntu-latest
+    outputs:
+      build-args: ${{ steps.env-vars.outputs.build-args }}
     environment: 
       name: ${{ github.head_ref }}
       url: "https://${{ github.head_ref }}.dev.pamdas.org"
@@ -26,10 +28,17 @@ jobs:
         with:
           name: npm-config
           path: package.json
+      - name: Read env file
+        id: env-vars
+        if: github.ref_name == 'develop'
+        run: |
+          tracking_id=$(grep REACT_APP_GA4_TRACKING_ID .env.development | cut -d '=' -f2)
+          echo "build-args=REACT_APP_GA4_TRACKING_ID=$tracking_id" >> $GITHUB_OUTPUT
+
   build:
     if: contains(github.event.pull_request.labels.*.name, 'deploy')
     needs: config
-    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v2
+    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@main
     with:
       environment: padas-app
       repository: europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react
@@ -37,3 +46,4 @@ jobs:
       dockerfile: Dockerfile.mt
       artifact-download: true
       artifact-name: npm-config
+      build-args: ${{ needs.config.outputs.build-args || '' }}

--- a/Dockerfile.mt
+++ b/Dockerfile.mt
@@ -1,4 +1,8 @@
 FROM node:22-alpine as build
+
+ARG REACT_APP_GA4_TRACKING_ID
+ENV REACT_APP_GA4_TRACKING_ID=$REACT_APP_GA4_TRACKING_ID
+
 WORKDIR /app
 
 RUN apk add --no-cache git alpine-sdk python3


### PR DESCRIPTION
### What does this PR do?
- Adds a new pipeline logic for develop branch to inject the value `REACT_APP_GA4_TRACKING_ID` from `.env.development` as build-arg.

### How does it look
- Dockerfile will receive that value as build-arg before the yarn build command. 

### How was it tested ?
1. I changed temporarily the trigger rules to target the PR's branch.
2. Then, I run locally the image created by the job: https://github.com/PADAS/das-web-react/actions/runs/16449778473/job/46491631607#step:8:19978
```sh
docker run --platform linux/amd64 -it --rm europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react:custom-google-analytics-for-dev-326@sha256:09d00ae7c2a4157e7884802025ed50298c4e069a24d975a126e121eec6af2e77 sh

grep -r "REACT_APP_GA4_TRACKING_ID" /usr/share/nginx/html/ > out.js
docker cp <container_name>:/out.js .
```
3. And was able to verify the code in VSCode Search since it was a bit tricky with sh and grep. It does contain the expected value. 
<img width="1919" height="965" alt="Screenshot 2025-07-22 at 13 26 27" src="https://github.com/user-attachments/assets/8b10e42c-8258-4ac1-92a7-eb04f8c3d2bb" />

4. Same result for legacy build. For that I used a test branch, and this is the workflow there: https://github.com/PADAS/das-web-react/actions/runs/16469553118/job/46555100570#step:14:105. I got the same result repeating the steps 2 and 3 with the legacy image. 


### Relevant link(s)
* Tracking tickets: [DASOPS-1770](https://allenai.atlassian.net/browse/DASOPS-1770)


[DASOPS-1770]: https://allenai.atlassian.net/browse/DASOPS-1770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ