### PR TITLE
[ERA-11760] Prevent conflict b/w tenant-level default event filter date range and user-persisted local saved event filters

### DIFF
--- a/src/ducks/system-status.js
+++ b/src/ducks/system-status.js
@@ -4,8 +4,9 @@ import { combineReducers } from 'redux';
 import { API_URL, DAS_HOST, SYSTEM_CONFIG_FLAGS, STATUSES, DEFAULT_SHOW_TRACK_DAYS } from '../constants';
 import { endOfToday, generateDaysAgoDate } from '../utils/datetime';
 import { setServerVersionAnalyticsDimension, setSitenameDimension } from '../utils/analytics';
-import { setDefaultDateRange as setDefaultEventDateRange } from './event-filter';
+import { setDefaultDateRange as setDefaultEventDateRange, EVENT_FILTER_STORAGE_KEY } from './event-filter';
 import { setDefaultDateRange as setDefaultPatrolDateRange } from './patrol-filter';
+import { getKeyIsRestorable } from '../reducers/storage-config';
 
 export const STATUS_API_URL = `${API_URL}status`;
 
@@ -87,10 +88,14 @@ const setSystemConfig = ({ data: { data } }) => (dispatch) => {
   });
 
   if (data[SYSTEM_CONFIG_FLAGS.DEFAULT_EVENT_FILTER_FROM_DAYS]) {
-    dispatch(setDefaultEventDateRange(
-      generateDaysAgoDate(data[SYSTEM_CONFIG_FLAGS.DEFAULT_EVENT_FILTER_FROM_DAYS]).toISOString(),
-      null
-    ));
+    const eventFilterSavedLocally = getKeyIsRestorable(EVENT_FILTER_STORAGE_KEY);
+
+    if (!eventFilterSavedLocally) {
+      dispatch(setDefaultEventDateRange(
+        generateDaysAgoDate(data[SYSTEM_CONFIG_FLAGS.DEFAULT_EVENT_FILTER_FROM_DAYS]).toISOString(),
+        null
+      ));
+    }
   }
 
   if (data[SYSTEM_CONFIG_FLAGS.DEFAULT_PATROL_FILTER_FROM_DAYS]) {

--- a/src/reducers/storage-config.js
+++ b/src/reducers/storage-config.js
@@ -10,7 +10,7 @@ const RESTORABLE_PREFIX = 'er-web-restorable';
 
 const namespaceForKey = key => `${RESTORABLE_PREFIX}:${key}`;
 
-const getKeyIsRestorable = (key) =>
+export const getKeyIsRestorable = (key) =>
   JSON.parse(
     window.localStorage.getItem(namespaceForKey(key))
   )?.restore;


### PR DESCRIPTION
### What does this PR do?
- See title

### How does it look
- N/A

### Relevant link(s)
* https://allenai.atlassian.net/browse/ERA-11760

### Where / how to start reviewing (optional)
- N/A

### Any background context you want to provide(if applicable)
- A few tenants have a system-level setting to change the default date range of their filters. The web client currently applies that value even if a user has chosen to persist their filters in local storage. This resolves the conflict between the two, deferring to locally-persisted ranges if they have been set.
