### PR TITLE
ERA-11828: Polygon Edit Drawer crashes the site

### DIFF
--- a/src/ReportGeometryDrawer/index.js
+++ b/src/ReportGeometryDrawer/index.js
@@ -141,7 +141,7 @@ const ReportGeometryDrawer = () => {
   }, [isDrawing, isGeometryAValidPolygon, onCancel, onUndo]);
 
   useEffect(() => {
-    if (event?.geometry) {
+    if (event?.geometry && isDrawing) {
       const eventPolygon = event.geometry.type === 'FeatureCollection'
         ? event.geometry.features[0]
         : event.geometry;
@@ -152,7 +152,7 @@ const ReportGeometryDrawer = () => {
       setTimeout(() => dispatchReportGeometry(reset()));
       setIsDrawing(false);
     }
-  }, [event.geometry, map]);
+  }, [event?.geometry, map, isDrawing]);
 
   return <>
     <MapLocationSelectionOverview


### PR DESCRIPTION
### What does this PR do?
- Adds security check when `event` object turns to null in a `ReportGeometryDrawer` useEffect.

### Relevant link(s)
* Tracking tickets: [ERA-11828](https://allenai.atlassian.net/browse/ERA-11828)
* [Hosted demo environments](https://era-11828.dev.pamdas.org)


[ERA-11828]: https://allenai.atlassian.net/browse/ERA-11828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ