### PR TITLE
ERA-11799: Event types filtered i18n transpolation text is wrongly defined.

### DIFF
--- a/src/EventFilter/Filters/index.js
+++ b/src/EventFilter/Filters/index.js
@@ -73,7 +73,7 @@ const Filters = ({
   } else if (someReportTypesChecked) {
     appliedFilterLabel = t('reportTypesSelectionLabels.someSelected', {
       eventTypeIDsLength: eventTypeIds.length,
-      selectedEventTypesCount,
+      reportTypesCheckedCount: selectedEventTypesCount,
     });
   }
 


### PR DESCRIPTION
### What does this PR do?
- Fixes wrong i18n key

### How does it look
<img width="533" height="652" alt="image" src="https://github.com/user-attachments/assets/b132013e-8943-4c89-ba03-5d54d437142e" />

### Relevant link(s)
* Tracking tickets: [ERA-11799](https://allenai.atlassian.net/browse/ERA-11799)


[ERA-11799]: https://allenai.atlassian.net/browse/ERA-11799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ