### PR TITLE
ERA-11828: Polygon Edit Drawer crashes the site

### DIFF
--- a/src/FeedListItem/index.test.js
+++ b/src/FeedListItem/index.test.js
@@ -35,7 +35,7 @@ describe('the feed list item component', () => {
 
   test('the icon slot background theme color', async () => {
     const iconContainer = await screen.findByRole('img');
-    expect(iconContainer).toHaveStyle('background-color: rgb(255, 0, 0)');
+    expect(iconContainer).toHaveStyle('background-color: red');
   });
 
   test('rendering a title component slot', async () => {

--- a/src/MapLocationSelectionOverview/styles.module.scss
+++ b/src/MapLocationSelectionOverview/styles.module.scss
@@ -17,7 +17,7 @@
   @media (min-width: $md-layout-width-min) {
     left: 1rem;
     top: 2rem;
-    width: 25rem;
+    width: auto;
   }
 }
 
@@ -62,10 +62,6 @@
   border-bottom: 1px solid #DDD;
   margin: 0.5rem 0 0.5rem -0.5rem;
   width: calc(100% + 1rem);
-
-  @media (min-width: $md-layout-width-min) {
-    width: 25rem;
-  }
 }
 
 .measurements {

--- a/src/ReportGeometryDrawer/index.js
+++ b/src/ReportGeometryDrawer/index.js
@@ -7,7 +7,7 @@ import { LAYER_IDS } from '../MapDrawingTools/MapLayers';
 import { MapContext } from '../App';
 import { MapDrawingToolsContext } from '../MapDrawingTools/ContextProvider';
 import reportGeometryReducer, { reset, setGeometryPoints, undo } from '../ducks/report-geometry';
-import { setIsPickingLocation } from '../ducks/map-ui';
+import { setIsPickingLocation, setMapLocationSelectionEvent } from '../ducks/map-ui';
 import { useMapEventBinding } from '../hooks';
 import { validateEventPolygonPoints } from '../utils/geometry';
 
@@ -81,6 +81,7 @@ const ReportGeometryDrawer = () => {
       } else {
         setMapDrawingData(null);
         dispatch(setIsPickingLocation(false));
+        dispatch(setMapLocationSelectionEvent(null));
       }
     }
   }, [dispatch, event?.geometry, points, setMapDrawingData, showInformationModal]);
@@ -107,6 +108,7 @@ const ReportGeometryDrawer = () => {
 
   const onSaveGeometry = useCallback(() => {
     dispatch(setIsPickingLocation(false));
+    dispatch(setMapLocationSelectionEvent(null));
   }, [dispatch]);
 
   const onHideCancellationConfirmationModal = useCallback(() => setShowCancellationConfirmationModal(false), []);

--- a/src/ReportGeometryDrawer/index.js
+++ b/src/ReportGeometryDrawer/index.js
@@ -152,7 +152,7 @@ const ReportGeometryDrawer = () => {
       setTimeout(() => dispatchReportGeometry(reset()));
       setIsDrawing(false);
     }
-  }, [map]);
+  }, [event?.geometry, map]);
 
   return <>
     <MapLocationSelectionOverview

--- a/src/ReportGeometryDrawer/index.js
+++ b/src/ReportGeometryDrawer/index.js
@@ -141,18 +141,18 @@ const ReportGeometryDrawer = () => {
   }, [isDrawing, isGeometryAValidPolygon, onCancel, onUndo]);
 
   useEffect(() => {
-    if (event?.geometry && isDrawing) {
+    if (event?.geometry) {
       const eventPolygon = event.geometry.type === 'FeatureCollection'
         ? event.geometry.features[0]
         : event.geometry;
 
-      map.fitBounds(bbox(eventPolygon), { padding: VERTICAL_POLYGON_PADDING });
+      map.fitBounds(bbox(eventPolygon), { padding: VERTICAL_POLYGON_PADDING });
 
       dispatchReportGeometry(setGeometryPoints(eventPolygon.geometry.coordinates[0].slice(0, -1)));
       setTimeout(() => dispatchReportGeometry(reset()));
       setIsDrawing(false);
     }
-  }, [event?.geometry, map, isDrawing]);
+  }, [map]);
 
   return <>
     <MapLocationSelectionOverview

--- a/src/ReportManager/DetailsSection/AreaSelectorInput/index.js
+++ b/src/ReportManager/DetailsSection/AreaSelectorInput/index.js
@@ -10,7 +10,7 @@ import { ReactComponent as PolygonIcon } from '../../../common/images/icons/poly
 import { EVENT_REPORT_CATEGORY, trackEventFactory } from '../../../utils/analytics';
 import { hideSideBar, showSideBar } from '../../../ducks/side-bar';
 import { MapDrawingToolsContext } from '../../../MapDrawingTools/ContextProvider';
-import { MAP_LOCATION_SELECTION_MODES, setIsPickingLocation } from '../../../ducks/map-ui';
+import { MAP_LOCATION_SELECTION_MODES, setIsPickingLocation, setMapLocationSelectionEvent } from '../../../ducks/map-ui';
 import { setModalVisibilityState } from '../../../ducks/modals';
 import { useEventGeoMeasurementDisplayStrings } from '../../../hooks/geometry';
 
@@ -48,6 +48,8 @@ const AreaSelectorInput = ({ event, onGeometryChange = null, originalEvent = nul
   const shouldShowCopyButton = !!event?.geometry;
 
   const onAreaSelectStart = useCallback(() => {
+
+    dispatch(setMapLocationSelectionEvent(event));
     dispatch(setIsPickingLocation(true, MAP_LOCATION_SELECTION_MODES.EVENT_GEOMETRY));
 
     if (!event?.geometry) {
@@ -57,7 +59,7 @@ const AreaSelectorInput = ({ event, onGeometryChange = null, originalEvent = nul
     } else {
       eventReportTracker.track('Edit an event geometry');
     }
-  }, [dispatch, event?.geometry]);
+  }, [dispatch, event]);
 
   const onDeleteArea = useCallback(() => {
     setMapDrawingData(null);

--- a/src/ReportManager/DetailsSection/index.js
+++ b/src/ReportManager/DetailsSection/index.js
@@ -1,9 +1,9 @@
-import React, { memo, useCallback, useContext, useEffect, useState } from 'react';
+import React, { memo, useCallback, useContext, useState } from 'react';
 import Dropdown from 'react-bootstrap/Dropdown';
 import Form from '@rjsf/bootstrap-4';
 import { format, isToday, isValid, parseISO } from 'date-fns';
 import MoonLoader from 'react-spinners/MoonLoader';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 import { ReactComponent as PencilWritingIcon } from '../../common/images/icons/pencil-writing.svg';
@@ -16,7 +16,6 @@ import {
 } from '../../utils/event-schemas';
 import { getHoursAndMinutesString } from '../../utils/datetime';
 import { selectEventTypeByValue } from '../../selectors/event-types';
-import { MAP_LOCATION_SELECTION_MODES, setMapLocationSelectionEvent } from '../../ducks/map-ui';
 import { TrackerContext } from '../../utils/analytics';
 
 import {
@@ -40,7 +39,6 @@ import SchemaForm from './SchemaForm';
 import TimePicker, { EMPTY_TIME_VALUE, isValidTime } from '../../TimePicker';
 
 import * as styles from './styles.module.scss';
-import isEqual from 'react-fast-compare';
 
 const LOADER_COLOR = '#006cd9'; // Bright blue
 const LOADER_SIZE = 50;
@@ -68,14 +66,9 @@ const DetailsSection = ({
   reportForm,
   submitFormButtonRef,
 }) => {
-  const dispatch = useDispatch();
   const { t } = useTranslation('reports', { keyPrefix: 'reportManager.detailsSection' });
 
   const eventType = useSelector((state) => reportForm?.event_type ? selectEventTypeByValue(state, reportForm.event_type) : null);
-  const mapLocationSelection = useSelector(state => state.view.mapLocationSelection);
-  const isDrawingEventGeometry = mapLocationSelection.isPickingLocation
-      && mapLocationSelection.mode === MAP_LOCATION_SELECTION_MODES.EVENT_GEOMETRY;
-
 
   const reportTracker = useContext(TrackerContext);
 

--- a/src/ReportManager/DetailsSection/index.js
+++ b/src/ReportManager/DetailsSection/index.js
@@ -16,7 +16,7 @@ import {
 } from '../../utils/event-schemas';
 import { getHoursAndMinutesString } from '../../utils/datetime';
 import { selectEventTypeByValue } from '../../selectors/event-types';
-import { setMapLocationSelectionEvent } from '../../ducks/map-ui';
+import { MAP_LOCATION_SELECTION_MODES, setMapLocationSelectionEvent } from '../../ducks/map-ui';
 import { TrackerContext } from '../../utils/analytics';
 
 import {
@@ -71,6 +71,10 @@ const DetailsSection = ({
   const { t } = useTranslation('reports', { keyPrefix: 'reportManager.detailsSection' });
 
   const eventType = useSelector((state) => reportForm?.event_type ? selectEventTypeByValue(state, reportForm.event_type) : null);
+  const mapLocationSelection = useSelector(state => state.view.mapLocationSelection);
+  const isDrawingEventGeometry = mapLocationSelection.isPickingLocation
+      && mapLocationSelection.mode === MAP_LOCATION_SELECTION_MODES.EVENT_GEOMETRY;
+
 
   const reportTracker = useContext(TrackerContext);
 
@@ -129,8 +133,12 @@ const DetailsSection = ({
   useEffect(() => {
     dispatch(setMapLocationSelectionEvent(reportForm));
 
-    return () => dispatch(setMapLocationSelectionEvent(null));
-  }, [dispatch, reportForm]);
+    return () => {
+      if (!isDrawingEventGeometry){
+        dispatch(setMapLocationSelectionEvent(null));
+      }
+    };
+  }, [dispatch, reportForm, isDrawingEventGeometry]);
 
   return <div ref={ref}>
     <div className={styles.globalDetails}>

--- a/src/ReportManager/DetailsSection/index.js
+++ b/src/ReportManager/DetailsSection/index.js
@@ -40,6 +40,7 @@ import SchemaForm from './SchemaForm';
 import TimePicker, { EMPTY_TIME_VALUE, isValidTime } from '../../TimePicker';
 
 import * as styles from './styles.module.scss';
+import isEqual from 'react-fast-compare';
 
 const LOADER_COLOR = '#006cd9'; // Bright blue
 const LOADER_SIZE = 50;
@@ -129,16 +130,6 @@ const DetailsSection = ({
 
     return filteredErrors.map((error) => ({ ...error, linearProperty: getLinearErrorPropTree(error.property) }));
   }, [eventSchema?.uiSchema]);
-
-  useEffect(() => {
-    dispatch(setMapLocationSelectionEvent(reportForm));
-
-    return () => {
-      if (!isDrawingEventGeometry){
-        dispatch(setMapLocationSelectionEvent(null));
-      }
-    };
-  }, [dispatch, reportForm, isDrawingEventGeometry]);
 
   return <div ref={ref}>
     <div className={styles.globalDetails}>


### PR DESCRIPTION
### What does this PR do?
- Adds security check when `event` object turns to null in a `ReportGeometryDrawer` useEffect.
- Solves [ERA-11289](https://allenai.atlassian.net/browse/ERA-11289)

### Relevant link(s)
* Tracking tickets: [ERA-11828](https://allenai.atlassian.net/browse/ERA-11828)
* [Hosted demo environments](https://era-11828.dev.pamdas.org)


[ERA-11828]: https://allenai.atlassian.net/browse/ERA-11828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ERA-11289]: https://allenai.atlassian.net/browse/ERA-11289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ