### PR TITLE
ERA-11803: Split message API calls

### DIFF
--- a/src/FeedListItem/index.test.js
+++ b/src/FeedListItem/index.test.js
@@ -35,7 +35,7 @@ describe('the feed list item component', () => {
 
   test('the icon slot background theme color', async () => {
     const iconContainer = await screen.findByRole('img');
-    expect(iconContainer).toHaveStyle('background-color: red');
+    expect(iconContainer).toHaveStyle('background-color: rgb(255, 0, 0)');
   });
 
   test('rendering a title component slot', async () => {

--- a/src/GpsFormatToggle/styles.module.scss
+++ b/src/GpsFormatToggle/styles.module.scss
@@ -35,7 +35,7 @@
       display: block;
       height: 100%;
       overflow: hidden;
-      padding: 0.25rem;
+      padding: 0.25rem 0;
       text-align: center;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/src/SubjectPopup/styles.module.scss
+++ b/src/SubjectPopup/styles.module.scss
@@ -70,14 +70,15 @@ $background_image_url: '../common/images/icons/';
 }
 
 .gpsFormatToggle {
-  background-color: $very-light-gray;
-  margin: 0.5rem 0 0.8rem 0;
   display: flex;
   flex-direction: column-reverse;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0.8rem 0;
 
-  div {
-    justify-content: space-between;
-    padding: .3rem;
+  fieldset {
+    label {
+      font-size: 0.6875rem;
+    }
   }
 
   span {
@@ -86,22 +87,6 @@ $background_image_url: '../common/images/icons/';
 
     button {
       padding: 0;
-    }
-  }
-
-  > ul {
-    background-color: $very-light-gray-alt;
-    margin: 0;
-
-    li {
-      color: $dark-gray;
-      padding: .1rem 2% .2rem 2%;
-      text-decoration: none;
-
-      &[class*=active] {
-        color: $bright-blue;
-        background-color: $very-light-gray;
-      }
     }
   }
 }

--- a/src/ducks/messaging.js
+++ b/src/ducks/messaging.js
@@ -7,8 +7,9 @@ import { API_URL } from '../constants';
 
 import { objectToParamString, recursivePaginatedQuery } from '../utils/query';
 
-
 import { messageIsValidForDisplay } from '../utils/messaging';
+
+const MAXIMUM_SUBJECT_IDS_PER_REQUEST = 25;
 
 const FETCH_MESSAGES_SUCCESS = 'FETCH_MESSAGES_SUCCESS';
 const UPDATE_UNREAD_MESSAGES_COUNT = 'UPDATE_UNREAD_MESSAGES_COUNT';
@@ -50,11 +51,31 @@ export const fetchMessages = (params = {}) => {
   return get(`${MESSAGING_API_URL}?${paramString}`);
 };
 
-export const fetchAllMessages = (params = {}) =>
-  recursivePaginatedQuery(
-    fetchMessages(params)
-  );
+export const fetchAllMessages = async (params = {}) => {
+  if (params.subject_id) {
+    // If the parameters of the request includes a string of subject ids,
+    // divide them in chunks to avoid errors due to enormous requests.
+    const subjectIdsChunks = [];
+    const subjectIds = params.subject_id.split(',');
+    for (let i = 0; i < subjectIds.length; i += MAXIMUM_SUBJECT_IDS_PER_REQUEST) {
+      subjectIdsChunks.push(subjectIds.slice(i, i + MAXIMUM_SUBJECT_IDS_PER_REQUEST).join(','));
+    }
 
+    // Do the recursive paginated query for the messages of each chunk of
+    // subject ids in parallel.
+    const responses = await Promise.all(subjectIdsChunks.map((subjectIdsChunk) => recursivePaginatedQuery(
+      fetchMessages({ ...params, subject_id: subjectIdsChunk })
+    )));
+
+    // Flatten the responses and sort them by message time, as the server would
+    // have responded in a single request.
+    return responses.flat().sort((messageA, messageB) => messageA.message_time < messageB.message_time ? 1 : -1);
+  }
+
+  // If the parameters do not include subject ids, do a single recurisve
+  // paginated query.
+  return recursivePaginatedQuery(fetchMessages(params));
+};
 
 export const fetchMessagesNextPage = url => get(url);
 
@@ -80,7 +101,6 @@ export const messageListReducer = (state = INITIAL_MESSAGE_LIST_STATE, action) =
   const { refresh, type, payload } = action;
 
   if (type === FETCH_MESSAGES_SUCCESS) {
-
     const withOnlyValidMessages = {
       ...payload,
       results: payload.results.filter(msg => messageIsValidForDisplay(msg, store.getState().data.subjectStore)),

--- a/src/ducks/messaging.test.js
+++ b/src/ducks/messaging.test.js
@@ -1,53 +1,111 @@
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
+import { fetchAllMessages, MESSAGING_API_URL } from './messaging';
 import { messages } from '../__test-helpers/fixtures/messages';
 
-import { MESSAGING_API_URL, fetchAllMessages } from './messaging';
+describe('Ducks - Messaging', () => {
+  describe('fetchAllMessages', () => {
+    test('Retrieves all messages page by page', async () => {
+      const firstPageOfMessages = messages.slice(0, 26);
+      const secondPageOfMessages = messages.slice(26, 50);
 
-const firstPageOfMessages = messages.slice(0, 26);
-const secondPageOfMessages = messages.slice(26, 50);
+      const secondPageUrl = 'next-page-url';
+      const requestParams = {
+        whatever: 666,
+        neato: 'hello',
+      };
 
-describe('#fetchAllMessages', () => {
-  test('paginating, with parameters, to retrieve all messages from the messaging API', async () => {
-    const secondPageUrl = 'next-page-url';
-    const requestParams = {
-      whatever: 666,
-      neato: 'hello',
-    };
+      const server = setupServer(
+        http.get(MESSAGING_API_URL, () => HttpResponse.json({
+          data: {
+            next: secondPageUrl,
+            results: firstPageOfMessages,
+          },
+        })),
+        http.get(secondPageUrl, () => HttpResponse.json({
+          data: {
+            next: null,
+            results: secondPageOfMessages,
+          },
+        })),
+      );
 
-    const server = setupServer(
-      http.get(MESSAGING_API_URL, ({ request }) => {
-        const { url: requestUrl } = request;
+      server.listen();
 
-        const url = new URL(requestUrl);
-        Object.entries(requestParams).forEach(([key, val]) => {
-          expect(url.search.includes(`${key}=${val}`)).toBeTruthy();
-        });
+      const results = await fetchAllMessages(requestParams);
 
-        const data = {
-          results: firstPageOfMessages,
-          next: secondPageUrl,
-        };
+      expect(results).toEqual([...firstPageOfMessages, ...secondPageOfMessages]);
 
-        return HttpResponse.json({ data });
-      }),
-      http.get(secondPageUrl, () => {
-        const data = {
-          results: secondPageOfMessages,
-          next: null,
-        };
+      server.resetHandlers();
+      server.close();
+    });
 
-        return HttpResponse.json({ data });
-      })
-    );
+    test('Parallelizes requests to many subject ids and sorts the results', async () => {
+      const sortedMessages = [{
+        id: 'message8',
+        message_time: '2020-01-01T15:30:00.000000-07:00',
+      }, {
+        id: 'message7',
+        message_time: '2020-01-01T15:00:00.000000-07:00',
+      }, {
+        id: 'message6',
+        message_time: '2020-01-01T14:30:00.000000-07:00',
+      }, {
+        id: 'message5',
+        message_time: '2020-01-01T14:00:00.000000-07:00',
+      }, {
+        id: 'message4',
+        message_time: '2020-01-01T13:30:00.000000-07:00',
+      }, {
+        id: 'message3',
+        message_time: '2020-01-01T13:00:00.000000-07:00',
+      }, {
+        id: 'message2',
+        message_time: '2020-01-01T12:30:00.000000-07:00',
+      }, {
+        id: 'message1',
+        message_time: '2020-01-01T12:00:00.000000-07:00',
+      }];
+      // Since we are requesting messages from 75 subject ids, we expect to
+      // have 3 requests with 25 subject ids each. We return the messages in
+      // a random order to test that the function sorts them.
+      const requestResults = [
+        [sortedMessages[2], sortedMessages[6]],
+        [sortedMessages[7], sortedMessages[5], sortedMessages[1]],
+        [sortedMessages[3], sortedMessages[4], sortedMessages[0]],
+      ];
 
-    server.listen();
+      // Send the subject_id parameter with 75 subject ids so the method splits
+      // the request in 3 chunks.
+      const requestParams = {
+        subject_id: 'subject1,subject2,subject3,subject4,subject5,subject6,subject7,subject8,subject9,subject10,subject11,subject12,subject13,subject14,subject15,subject16,subject17,subject18,subject19,subject20,subject21,subject22,subject23,subject24,subject25,subject26,subject27,subject28,subject29,subject30,subject31,subject32,subject33,subject34,subject35,subject36,subject37,subject38,subject39,subject40,subject41,subject42,subject43,subject44,subject45,subject46,subject47,subject48,subject49,subject50,subject51,subject52,subject53,subject54,subject55,subject56,subject57,subject58,subject59,subject60,subject61,subject62,subject63,subject64,subject65,subject66,subject67,subject68,subject69,subject70,subject71,subject72,subject73,subject74,subject75',
+      };
 
-    const results = await fetchAllMessages(requestParams);
-    expect(results).toEqual([...firstPageOfMessages, ...secondPageOfMessages]);
+      let callCount = 0;
+      const server = setupServer(
+        http.get(MESSAGING_API_URL, () => {
+          const results = requestResults[callCount];
+          callCount += 1;
 
-    server.resetHandlers();
-    server.close();
+          return HttpResponse.json({
+            data: {
+              next: null,
+              results,
+            },
+          });
+        })
+      );
+
+      server.listen();
+
+      const results = await fetchAllMessages(requestParams);
+
+      expect(callCount).toBe(3);
+      expect(results).toEqual(sortedMessages);
+
+      server.resetHandlers();
+      server.close();
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Add logic to our `fetchAllMessages` action creator to split message requests in chunks of 25 subject ids at the same time to avoid server errors with enormous requests.

Also, this PR fixes the UI of our `GPSFormatToggle` in the subjects map popup.

### Relevant link(s)
* [ERA-11803](https://allenai.atlassian.net/browse/ERA-11803)
* [Env](https://era-11803.dev.pamdas.org/)

### Where / how to start reviewing (optional)
In order to test this in the environment, I needed to create 25+ subjects so we can see the requests being broken. Since that would take me much time, and I know @AlanCalvillo has scripts to generate subjects in bulk, I didn't do that.

Instead, what I recommend to the dev reviewers (@gaboDev @JoshuaVulcan ) is to checkout to this branch locally (pull the changes) and run your local server against https://era-11803.dev.pamdas.org/ . Then, go to `src/ducks/messaging.js` and modify the constant `MAXIMUM_SUBJECT_IDS_PER_REQUEST` to have a value of 3. That way, you can easily navigate the map to Madagascar and see all the message requests of the subjects I created being broken in several network calls in chunks of 2 subjects:
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/c2a73999-3178-4445-83b3-5884f5e5a6c9" />



[ERA-11803]: https://allenai.atlassian.net/browse/ERA-11803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ