### PR TITLE
ERA-11922: Limit the amount of added Coordinate Reference Systems to 6

### DIFF
--- a/public/locales/en-US/components.json
+++ b/public/locales/en-US/components.json
@@ -239,6 +239,7 @@
           "coordinateReferenceSystemFinder": {
             "addCrsButton": "Add",
             "addCrsButtonLabel": "Add EPSG:{{epsgCode}} {{name}} to the GPS format selector options",
+            "addedMaximumSystemsMessage": "You have added 6 coordinate reference systems. Delete at least 1 of them before adding others.",
             "emptyStateMessage": "Adjust your search to find what you are looking for.",
             "emptyStateMessageTitle": "No results found.",
             "instructions": "Search additional coordinate reference systems",

--- a/public/locales/es/components.json
+++ b/public/locales/es/components.json
@@ -222,6 +222,7 @@
           "coordinateReferenceSystemFinder": {
             "addCrsButton": "Agregar",
             "addCrsButtonLabel": "Agregar EPSG:{{epsgCode}} {{name}} a las opciones del selector de formato GPS",
+            "addedMaximumSystemsMessage": "Has añadido 6 sistemas de referencia de coordenadas. Elimina al menos 1 antes de añadir otros.",
             "emptyStateMessage": "Ajusta tu búsqueda para encontrar lo que estás buscando.",
             "emptyStateMessageTitle": "No se encontraron resultados.",
             "instructions": "Buscar sistemas de referencia de coordenadas adicionales",

--- a/public/locales/fr/components.json
+++ b/public/locales/fr/components.json
@@ -222,6 +222,7 @@
           "coordinateReferenceSystemFinder": {
             "addCrsButton": "Ajouter",
             "addCrsButtonLabel": "Ajouter EPSG:{{epsgCode}} {{name}} aux options du sélecteur de format GPS",
+            "addedMaximumSystemsMessage": "Vous avez ajouté 6 systèmes de référence de coordonnées. Supprimez-en au moins 1 avant d’en ajouter d’autres.",
             "emptyStateMessage": "Ajustez votre recherche pour trouver ce que vous cherchez.",
             "emptyStateMessageTitle": "Aucun résultat trouvé.",
             "instructions": "Rechercher d'autres systèmes de référence de coordonnées",

--- a/public/locales/ne-NP/components.json
+++ b/public/locales/ne-NP/components.json
@@ -223,6 +223,7 @@
                     "coordinateReferenceSystemFinder": {
                         "addCrsButton": "थप्नुहोस्",
                         "addCrsButtonLabel": "EPSG:{{epsgCode}} {{name}} लाई GPS ढाँचा चयन विकल्पहरूमा थप्नुहोस्",
+                        "addedMaximumSystemsMessage": "तपाईंले ६ निर्देशांक सन्दर्भ प्रणाली थप्नुभयो। अरू थप्नुअघि कम्तिमा १ मेटाउनुहोस्।",
                         "emptyStateMessage": "तपाईं खोजिरहनुभएको कुरा फेला पार्नको लागि आफ्नो खोज समायोजन गर्नुहोस्।",
                         "emptyStateMessageTitle": "कुनै परिणाम फेला परेन।",
                         "instructions": "थप समन्वय सन्दर्भ प्रणालीहरू खोज्नुहोस्",

--- a/public/locales/pt/components.json
+++ b/public/locales/pt/components.json
@@ -222,6 +222,7 @@
                     "coordinateReferenceSystemFinder": {
                         "addCrsButton": "Adicionar",
                         "addCrsButtonLabel": "Adicionar EPSG:{{epsgCode}} {{name}} às opções do seletor de formato GPS",
+                        "addedMaximumSystemsMessage": "Você adicionou 6 sistemas de referência de coordenadas. Exclua pelo menos 1 antes de adicionar outros.",
                         "emptyStateMessage": "Ajuste sua busca para encontrar o que está procurando.",
                         "emptyStateMessageTitle": "Nenhum resultado encontrado.",
                         "instructions": "Pesquisar sistemas de referência de coordenadas adicionais",

--- a/public/locales/sw/components.json
+++ b/public/locales/sw/components.json
@@ -239,6 +239,7 @@
           "coordinateReferenceSystemFinder": {
             "addCrsButton": "Ongeza",
             "addCrsButtonLabel": "Ongeza EPSG:{{epsgCode}} {{name}} kwenye chaguzi za kielelezo cha muundo wa GPS",
+            "addedMaximumSystemsMessage": "Umeongeza mifumo 6 ya marejeleo ya kuratibu. Futa angalau 1 kabla ya kuongeza mingine.",
             "emptyStateMessage": "Rekebisha utafutaji wako ili kupata kile unachotafuta.",
             "emptyStateMessageTitle": "Hakuna matokeo yaliyopatikana.",
             "instructions": "Tafuta mifumo mingine ya marejeleo ya uratibu",

--- a/src/SideBar/SettingsPane/MapTab/CoordinateSystemSettingsView/CoordinateReferenceSystemFinder/index.js
+++ b/src/SideBar/SettingsPane/MapTab/CoordinateSystemSettingsView/CoordinateReferenceSystemFinder/index.js
@@ -11,6 +11,7 @@ import SearchBar from '../../../../../SearchBar';
 import * as styles from './styles.module.scss';
 
 const LOADER_SIZE = 30;
+const MAX_COORDINATE_REFERENCE_SYSTEMS_ADDED = 6;
 const MAX_FILTERED_CRS_AREA_LENGTH = 60;
 const MAX_FILTERED_CRS_RESULTS = 10;
 
@@ -108,7 +109,7 @@ const CoordinateReferenceSystemFinder = () => {
     </label>
 
     <SearchBar
-      aria-describedby="crs-finder-message"
+      aria-describedby="crs-finder-showing-maximum-filtered-results-message crs-finder-empty-state-message"
       className={styles.searchBar}
       id="crs-finder-search"
       onChange={(event) => setSearchText(event.target.value)}
@@ -156,8 +157,10 @@ const CoordinateReferenceSystemFinder = () => {
             <AreaTD area={filteredCRS.area} epsgCode={filteredCRS.code} name={filteredCRS.name} />
             <td>
               <button
+                aria-describedby="crs-finder-added-maximum-systems-message"
                 aria-label={t('addCrsButtonLabel', { epsgCode: filteredCRS.code, name: filteredCRS.name })}
                 className={styles.addButton}
+                disabled={storedCRS.length === MAX_COORDINATE_REFERENCE_SYSTEMS_ADDED}
                 onClick={() => dispatch(setStoredCoordinateReferenceSystems([...storedCRS, filteredCRS]))}
                 title={t('addCrsButtonLabel', { epsgCode: filteredCRS.code, name: filteredCRS.name })}
                 type="button"
@@ -172,7 +175,7 @@ const CoordinateReferenceSystemFinder = () => {
         results, show an empty state. */}
         {supportedCRS !== null && filteredCRS.length === 0 && <tr>
           <td colSpan="100%">
-            <div className={styles.emptyState} id="crs-finder-message">
+            <div className={styles.emptyState} id="crs-finder-empty-state-message">
               {t('emptyStateMessageTitle')}
 
               <span className={styles.message}>{t('emptyStateMessage')}</span>
@@ -184,10 +187,18 @@ const CoordinateReferenceSystemFinder = () => {
 
     {filteredCRS.length === MAX_FILTERED_CRS_RESULTS && <p
         className={styles.crsFinderMessage}
-        id="crs-finder-message"
+        id="crs-finder-showing-maximum-filtered-results-message"
         role="status"
       >
       {t('showingMaximumFilteredResultsMessage')}
+    </p>}
+
+    {storedCRS.length === MAX_COORDINATE_REFERENCE_SYSTEMS_ADDED && <p
+        className={styles.crsFinderMessage}
+        id="crs-finder-added-maximum-systems-message"
+        role="status"
+      >
+      {t('addedMaximumSystemsMessage')}
     </p>}
   </div>;
 };

--- a/src/SideBar/SettingsPane/MapTab/CoordinateSystemSettingsView/CoordinateReferenceSystemFinder/index.test.js
+++ b/src/SideBar/SettingsPane/MapTab/CoordinateSystemSettingsView/CoordinateReferenceSystemFinder/index.test.js
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 
 import { render, screen, waitFor, within } from '../../../../../test-utils';
-import { epsg5367 } from '../../../../../__test-helpers/fixtures/location';
+import { epsg2154, epsg2946, epsg32633, epsg32719, epsg3857, epsg5367 } from '../../../../../__test-helpers/fixtures/location';
 import { mockStore } from '../../../../../__test-helpers/MockStore';
 import { setStoredCoordinateReferenceSystems } from '../../../../../ducks/coordinate-reference-systems';
 
@@ -140,7 +140,7 @@ describe('SideBar - SettingsPane - MapTab - CoordinateSystemSettingsView - Coord
     ).toBeVisible();
   });
 
-  test('Expands and collapses a lon CRS area description when the user clicks the Read more and Read less buttons', async () => {
+  test('Expands and collapses a long CRS area description when the user clicks the Read more and Read less buttons', async () => {
     renderCoordinateReferenceSystemFinder();
 
     const resultsTable = screen.getByRole('table', { name: 'List of coordinate reference system search results' });
@@ -207,13 +207,13 @@ describe('SideBar - SettingsPane - MapTab - CoordinateSystemSettingsView - Coord
         .toHaveTextContent('2001Antigua 1943 / British West Indies GridAntigua island - onshore.Add');
     });
 
-    await userEvent.type(screen.getByRole('searchbox', {
-      name: 'Search additional coordinate reference systems',
-    }), 'xxx');
+    const searchBar = screen.getByRole('searchbox', { name: 'Search additional coordinate reference systems' });
+    await userEvent.type(searchBar, 'xxx');
 
     const firstResultsRow = within(resultsTable).getAllByRole('row')[1];
 
     expect(firstResultsRow).toHaveTextContent('No results found.Adjust your search to find what you are looking for.');
+    expect(searchBar).toHaveAccessibleDescription('No results found. Adjust your search to find what you are looking for.');
   });
 
   test('shows a message when the filter criteria matches more than the maximum results shown', async () => {
@@ -228,6 +228,8 @@ describe('SideBar - SettingsPane - MapTab - CoordinateSystemSettingsView - Coord
 
     expect(screen.getByText('Showing the top 10 results. Try refining your search to narrow down the list.'))
       .toBeVisible();
+    expect(screen.getByRole('searchbox', { name: 'Search additional coordinate reference systems' }))
+      .toHaveAccessibleDescription('Showing the top 10 results. Try refining your search to narrow down the list.');
   });
 
   test('does not show a message when the filter criteria matches less than the maximum results shown', async () => {
@@ -240,11 +242,62 @@ describe('SideBar - SettingsPane - MapTab - CoordinateSystemSettingsView - Coord
         .toHaveTextContent('2001Antigua 1943 / British West Indies GridAntigua island - onshore.Add');
     });
 
-    await userEvent.type(screen.getByRole('searchbox', {
-      name: 'Search additional coordinate reference systems',
-    }), 'CRTM05');
+    const searchBar = screen.getByRole('searchbox', { name: 'Search additional coordinate reference systems' });
+    await userEvent.type(searchBar, 'CRTM05');
 
     expect(screen.queryByText('Showing the top 10 results. Try refining your search to narrow down the list.'))
       .toBeNull();
+    expect(searchBar).not.toHaveAccessibleDescription();
+  });
+
+  test('shows a message when the user already added 6 CRS and disables the Add buttons', async () => {
+    store.view.coordinateReferenceSystems.storedSystems = [
+      epsg2154,
+      epsg2946,
+      epsg3857,
+      epsg5367,
+      epsg32633,
+      epsg32719,
+    ];
+    renderCoordinateReferenceSystemFinder();
+
+    const resultsTable = screen.getByRole('table', { name: 'List of coordinate reference system search results' });
+
+    await waitFor(() => {
+      expect(within(resultsTable).getAllByRole('row')[1])
+        .toHaveTextContent('2001Antigua 1943 / British West Indies GridAntigua island - onshore.Add');
+    });
+
+    const addEpsg2001Button = screen.getByRole('button', {
+      name: 'Add EPSG:2001 Antigua 1943 / British West Indies Grid to the GPS format selector options',
+    });
+
+    expect(screen.getByText('You have added 6 coordinate reference systems. Delete at least 1 of them before adding others.'))
+      .toBeVisible();
+    expect(addEpsg2001Button).toBeDisabled();
+    expect(addEpsg2001Button)
+      .toHaveAccessibleDescription('You have added 6 coordinate reference systems. Delete at least 1 of them before adding others.');
+  });
+
+  test('does not show a message if the user has not added 6 CRS yet', async () => {
+    store.view.coordinateReferenceSystems.storedSystems = [epsg2154, epsg2946, epsg3857, epsg5367, epsg32633];
+    renderCoordinateReferenceSystemFinder();
+
+    const resultsTable = screen.getByRole('table', { name: 'List of coordinate reference system search results' });
+
+    await waitFor(() => {
+      expect(within(resultsTable).getAllByRole('row')[1])
+        .toHaveTextContent('2001Antigua 1943 / British West Indies GridAntigua island - onshore.Add');
+    });
+
+    const addEpsg2001Button = screen.getByRole('button', {
+      name: 'Add EPSG:2001 Antigua 1943 / British West Indies Grid to the GPS format selector options',
+    });
+
+    expect(screen.queryByText('You have added 6 coordinate reference systems. Delete at least 1 of them before adding others.'))
+      .toBeNull();
+    expect(addEpsg2001Button).toBeEnabled();
+    expect(addEpsg2001Button)
+      .toHaveAccessibleDescription('Add EPSG:2001 Antigua 1943 / British West Indies Grid to the GPS format selector options');
   });
 });

--- a/src/SideBar/SettingsPane/MapTab/CoordinateSystemSettingsView/CoordinateReferenceSystemFinder/styles.module.scss
+++ b/src/SideBar/SettingsPane/MapTab/CoordinateSystemSettingsView/CoordinateReferenceSystemFinder/styles.module.scss
@@ -106,12 +106,19 @@
       outline: none;
       padding: 0 0.75rem;
 
-      &:hover {
-        background-color: color.adjust(colors.$very-light-blue, $lightness: -5%);
+      &:disabled {
+        background-color: colors.$disabled-field-gray;
+        color: colors.$secondary-medium-gray;
+        cursor: not-allowed;
+        opacity: 0.66;
       }
 
-      &:focus-visible {
+      &:focus-visible:not(:disabled) {
         outline: 2px solid colors.$bright-blue;
+      }
+
+      &:hover:not(:disabled) {
+        background-color: color.adjust(colors.$very-light-blue, $lightness: -5%);
       }
     }
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,7 +7,7 @@ import LocalStorageBackend from 'i18next-localstorage-backend';
 
 import { SUPPORTED_LANGUAGES } from './constants';
 
-const I18N_FILES_VERSION = '1.21';
+const I18N_FILES_VERSION = '1.22';
 
 const preloadNamespaces = [
   'components',


### PR DESCRIPTION
### What does this PR do?
Add a status text when the user adds 6 coordinate reference systems in the `CoordinateReferenceSystemFinder` widget and disable the `Add` buttons in the table of results.

### How does it look
<img width="1920" height="989" alt="image" src="https://github.com/user-attachments/assets/4716545c-cf58-449d-b6ac-ce911122bdc8" />


### Relevant link(s)
* [ERA-11922](https://allenai.atlassian.net/browse/ERA-11922)
* [Env](https://era-11922.dev.pamdas.org)


[ERA-11922]: https://allenai.atlassian.net/browse/ERA-11922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ