### PR TITLE
ERA-11795: Search for location by name

### DIFF
--- a/public/locales/en-US/components.json
+++ b/public/locales/en-US/components.json
@@ -70,22 +70,28 @@
     "fieldsetLegend": "GPS format",
     "coordinatesOutsideBboxTooltipButtonLabel": "More information about location format",
     "coordinatesOutsideBboxTooltipTitle": "Location is displayed in DEG format. EPSG:{{epsgCode}} {{crsName}} is not supported at this location.",
-    "textCopyButtonLabel": "Copy GPS value to clipboard"
+    "textCopyButtonLabel": "Copy GPS value to clipboard",
+    "textSearchOptionLabel": "Search by name"
   },
   "gpsInput": {
-    "defaultPlaceholder": "Location",
-    "inputDescription": "Example: {{gpsFormat}}",
-    "inputLabel": "GPS location",
-    "invalidLocationErrorMessage": "Invalid location",
-    "outsideBboxErrorMessage": "EPSG:{{epsgCode}} {{crsName}} is not supported at this location.",
-    "outsideBboxInputValue": "N/A",
-    "placeholders": {
+    "coordinatesRepresentationDescription": "Example: {{example}}",
+    "coordinatesRepresentationLabel": "Search location in {{representation}} format",
+    "coordinatesRepresentationPlaceholder": {
       "DDM": "Degrees, Decimals, Minutes",
       "DEG": "Latitude, Longitude",
       "DMS": "Degrees, Minutes, Seconds",
       "UTM": "Universal Transverse Mercator",
       "MGRS": "Military Grid Reference System"
-    }
+    },
+    "defaultLabel": "Search location",
+    "defaultPlaceholder": "Location",
+    "invalidLocationErrorMessage": "Invalid location",
+    "outsideBboxErrorMessage": "EPSG:{{epsgCode}} {{crsName}} is not supported at this location.",
+    "outsideBboxInputValue": "N/A",
+    "placesFromSearchTextListLabel": "Location search results",
+    "textSearchDescription": "Search for a location on the map by name",
+    "textSearchLabel": "Search location by name",
+    "textSearchPlaceholder": "Search Location"
   },
   "locationJumpButton": {
     "title": "Jump to this location"

--- a/public/locales/es/components.json
+++ b/public/locales/es/components.json
@@ -64,22 +64,28 @@
     "fieldsetLegend": "Formato de GPS",
     "coordinatesOutsideBboxTooltipButtonLabel": "Más información sobre el formato de ubicación",
     "coordinatesOutsideBboxTooltipTitle": "La ubicación se muestra en formato DEG. EPSG:{{epsgCode}} {{crsName}} no es compatible en esta ubicación.",
-    "textCopyButtonLabel": "Copiar valor GPS al portapapeles"
+    "textCopyButtonLabel": "Copiar valor GPS al portapapeles",
+    "textSearchOptionLabel": "Buscar por nombre"
   },
   "gpsInput": {
-    "defaultPlaceholder": "Ubicación",
-    "inputDescription": "Ejemplo: {{gpsFormat}}",
-    "inputLabel": "Ubicación GPS",
-    "invalidLocationErrorMessage": "Ubicación inválida",
-    "outsideBboxErrorMessage": "EPSG:{{epsgCode}} {{crsName}} no es compatible en esta ubicación.",
-    "outsideBboxInputValue": "N/D",
-    "placeholders": {
+    "coordinatesRepresentationDescription": "Ejemplo: {{example}}",
+    "coordinatesRepresentationLabel": "Buscar ubicación en formato {{representation}}",
+    "coordinatesRepresentationPlaceholder": {
       "DDM": "Grados, Decimales, Minutos",
       "DEG": "Latitud, Longitud",
       "DMS": "Grados, Minutos, Segundos",
       "UTM": "Universal Transversal de Mercator",
       "MGRS": "Sistema de Referencia de Cuadrícula Militar"
-    }
+    },
+    "defaultLabel": "Buscar ubicación",
+    "defaultPlaceholder": "Ubicación",
+    "invalidLocationErrorMessage": "Ubicación inválida",
+    "outsideBboxErrorMessage": "EPSG:{{epsgCode}} {{crsName}} no es compatible en esta ubicación.",
+    "outsideBboxInputValue": "N/D",
+    "placesFromSearchTextListLabel": "Resultados de búsqueda de ubicaciones",
+    "textSearchDescription": "Busca una ubicación en el mapa por nombre",
+    "textSearchLabel": "Buscar ubicación por nombre",
+    "textSearchPlaceholder": "Buscar ubicación"
   },
   "locationJumpButton": {
     "title": "Ir a está ubicación"

--- a/public/locales/fr/components.json
+++ b/public/locales/fr/components.json
@@ -64,22 +64,28 @@
     "fieldsetLegend": "Format GPS",
     "coordinatesOutsideBboxTooltipButtonLabel": "Plus d’informations sur le format de l’emplacement",
     "coordinatesOutsideBboxTooltipTitle": "L’emplacement est affiché au format DEG. EPSG:{{epsgCode}} {{crsName}} n’est pas pris en charge à cet emplacement.",
-    "textCopyButtonLabel": "Copier la valeur GPS dans le presse-papiers"
+    "textCopyButtonLabel": "Copier la valeur GPS dans le presse-papiers",
+    "textSearchOptionLabel": "Recherche par nom"
   },
   "gpsInput": {
-    "defaultPlaceholder": "Position",
-    "inputDescription": "Exemple: {{gpsFormat}}",
-    "inputLabel": "Position GPS",
-    "invalidLocationErrorMessage": "Coordonnées GPS invalides",
-    "outsideBboxErrorMessage": "EPSG:{{epsgCode}} {{crsName}} n’est pas pris en charge à cet emplacement.",
-    "outsideBboxInputValue": "N/D",
-    "placeholders": {
+    "coordinatesRepresentationDescription": "Exemple: {{example}}",
+    "coordinatesRepresentationLabel": "Rechercher un lieu au format {{representation}}",
+    "coordinatesRepresentationPlaceholder": {
       "DDM": "Degrés Decimaux Minutes (DDM)",
       "DEG": "Lattitude, Longitude",
       "DMS": "Degrés Minutes Secondes (DMS)",
       "UTM": "Transversale Universelle de Mercator (UTM)",
       "MGRS": "Système de Coordonnées Militaire (MGRS)"
-    }
+    },
+    "defaultLabel": "Rechercher un lieu",
+    "defaultPlaceholder": "Position",
+    "invalidLocationErrorMessage": "Coordonnées GPS invalides",
+    "outsideBboxErrorMessage": "EPSG:{{epsgCode}} {{crsName}} n’est pas pris en charge à cet emplacement.",
+    "outsideBboxInputValue": "N/D",
+    "placesFromSearchTextListLabel": "Résultats de recherche de lieux",
+    "textSearchDescription": "Recherchez un lieu sur la carte par nom",
+    "textSearchLabel": "Rechercher un lieu par nom",
+    "textSearchPlaceholder": "Rechercher un lieu"
   },
   "locationJumpButton": {
     "title": "Naviguer à la position suivante"

--- a/public/locales/ne-NP/components.json
+++ b/public/locales/ne-NP/components.json
@@ -65,22 +65,28 @@
         "fieldsetLegend": "GPS ढाँचा",
         "coordinatesOutsideBboxTooltipButtonLabel": "स्थान ढाँचाबारे थप जानकारी",
         "coordinatesOutsideBboxTooltipTitle": "स्थान DEG ढाँचामा देखाइएको छ। EPSG:{{epsgCode}} {{crsName}} यो स्थानमा समर्थित छैन।",
-        "textCopyButtonLabel": "GPS मान क्लिपबोर्डमा प्रतिलिपि गर्नुहोस्"
+        "textCopyButtonLabel": "GPS मान क्लिपबोर्डमा प्रतिलिपि गर्नुहोस्",
+        "textSearchOptionLabel": "नामद्वारा खोज्नुहोस्"
     },
     "gpsInput": {
-        "defaultPlaceholder": "लोकेसन",
-        "inputDescription": "उदाहरण: {{gpsFormat}}",
-        "inputLabel": "GPS स्थान",
-        "invalidLocationErrorMessage": "अमान्य लोकेसन",
-        "outsideBboxErrorMessage": "EPSG:{{epsgCode}} {{crsName}} यो स्थानमा समर्थित छैन।",
-        "outsideBboxInputValue": "उ/ल",
-        "placeholders": {
+        "coordinatesRepresentationDescription": "उदाहरण: {{example}}",
+        "coordinatesRepresentationLabel": "{{representation}} ढाँचामा स्थान खोज्नुहोस्",
+        "coordinatesRepresentationPlaceholder": {
             "DDM": "डिग्री, दशमलव, मिनेट",
             "DEG": "आक्षांश, देशान्तर",
             "DMS": "डिग्री, मिनेट, सेकेन्ड",
             "UTM": "विश्वव्यापी अनुप्रस्थ मर्केटर",
             "MGRS": "सैन्य ग्रिड सन्दर्भ सिस्टम"
-        }
+        },
+        "defaultLabel": "स्थान खोज्नुहोस्",
+        "defaultPlaceholder": "लोकेसन",
+        "invalidLocationErrorMessage": "अमान्य लोकेसन",
+        "outsideBboxErrorMessage": "EPSG:{{epsgCode}} {{crsName}} यो स्थानमा समर्थित छैन।",
+        "outsideBboxInputValue": "उ/ल",
+        "placesFromSearchTextListLabel": "स्थान खोज परिणामहरू",
+        "textSearchDescription": "नाम प्रयोग गरेर नक्सामा स्थान खोज्नुहोस्",
+        "textSearchLabel": "नामद्वारा स्थान खोज्नुहोस्",
+        "textSearchPlaceholder": "स्थान खोज्नुहोस्"
     },
     "locationJumpButton": {
         "title": "यो स्थानमा जानुहोस्"

--- a/public/locales/pt/components.json
+++ b/public/locales/pt/components.json
@@ -64,22 +64,28 @@
         "fieldsetLegend": "Formato de GPS",
         "coordinatesOutsideBboxTooltipButtonLabel": "Mais informações sobre o formato da localização",
         "coordinatesOutsideBboxTooltipTitle": "A localização é exibida no formato DEG. EPSG:{{epsgCode}} {{crsName}} não é compatível nesta localização.",
-        "textCopyButtonLabel": "Copiar valor do GPS para a área de transferência"
+        "textCopyButtonLabel": "Copiar valor do GPS para a área de transferência",
+        "textSearchOptionLabel": "Pesquisar por nome"
     },
     "gpsInput": {
-        "defaultPlaceholder": "Localização",
-        "inputDescription": "Exemplo: {{gpsFormat}}",
-        "inputLabel": "Localização GPS",
-        "invalidLocationErrorMessage": "Localização inválida",
-        "outsideBboxErrorMessage": "EPSG:{{epsgCode}} {{crsName}} não é compatível nesta localização.",
-        "outsideBboxInputValue": "N/D",
-        "placeholders": {
+        "coordinatesRepresentationDescription": "Exemplo: {{example}}",
+        "coordinatesRepresentationLabel": "Pesquisar localização no formato {{representation}}",
+        "coordinatesRepresentationPlaceholder": {
             "DDM": "Graus, decimais, minutos (DDM)",
             "DEG": "Latitude, longitude",
             "DMS": "Graus, minutos e segundos (DMS)",
             "UTM": "Universal Transverso de Mercator (UTM)",
             "MGRS": "Sistema de referência de Grade Militar (MGRS)"
-        }
+        },
+        "defaultLabel": "Pesquisar localização",
+        "defaultPlaceholder": "Localização",
+        "invalidLocationErrorMessage": "Localização inválida",
+        "outsideBboxErrorMessage": "EPSG:{{epsgCode}} {{crsName}} não é compatível nesta localização.",
+        "outsideBboxInputValue": "N/D",
+        "placesFromSearchTextListLabel": "Resultados da pesquisa de localização",
+        "textSearchDescription": "Pesquise uma localização no mapa pelo nome",
+        "textSearchLabel": "Pesquisar localização por nome",
+        "textSearchPlaceholder": "Pesquisar localização"
     },
     "locationJumpButton": {
         "title": "Ir para esta localização"

--- a/public/locales/sw/components.json
+++ b/public/locales/sw/components.json
@@ -70,22 +70,28 @@
     "fieldsetLegend": "Muundo wa GPS",
     "coordinatesOutsideBboxTooltipButtonLabel": "Maelezo zaidi kuhusu umbizo la eneo",
     "coordinatesOutsideBboxTooltipTitle": "Eneo linaonyeshwa kwa umbizo la DEG. EPSG:{{epsgCode}} {{crsName}} haipatikani katika eneo hili.",
-    "textCopyButtonLabel": "Nakili thamani ya GPS kwenye ubao wa kunakili"
+    "textCopyButtonLabel": "Nakili thamani ya GPS kwenye ubao wa kunakili",
+    "textSearchOptionLabel": "Tafuta kwa jina"
   },
   "gpsInput": {
-    "defaultPlaceholder": "Eneo",
-    "inputDescription": "Mfano: {{gpsFormat}}",
-    "inputLabel": "Mahali pa GPS",
-    "invalidLocationErrorMessage": "Eneo halali",
-    "outsideBboxErrorMessage": "EPSG:{{epsgCode}} {{crsName}} haipatikani katika eneo hili.",
-    "outsideBboxInputValue": "H/P",
-    "placeholders": {
+    "coordinatesRepresentationDescription": "Mfano: {{example}}",
+    "coordinatesRepresentationLabel": "Tafuta eneo kwa umbizo la {{representation}}",
+    "coordinatesRepresentationPlaceholder": {
       "DDM": "Digrii, Desimali, Dakika",
       "DEG": "Latitudo, Longitudo",
       "DMS": "Digrii, Dakika, Sekunde",
       "UTM": "Ukurasa wa Jumla wa Transverse",
       "MGRS": "Mfumo wa Kijeshi wa Kumbukumbu ya Gridi"
-    }
+    },
+    "defaultLabel": "Tafuta eneo",
+    "defaultPlaceholder": "Eneo",
+    "invalidLocationErrorMessage": "Eneo halali",
+    "outsideBboxErrorMessage": "EPSG:{{epsgCode}} {{crsName}} haipatikani katika eneo hili.",
+    "outsideBboxInputValue": "H/P",
+    "placesFromSearchTextListLabel": "Matokeo ya utafutaji wa eneo",
+    "textSearchDescription": "Tafuta eneo kwenye ramani kwa jina",
+    "textSearchLabel": "Tafuta eneo kwa jina",
+    "textSearchPlaceholder": "Tafuta eneo"
   },
   "locationJumpButton": {
     "title": "Ruka hadi eneo hili"

--- a/src/CursorGpsDisplay/MenuPopover/index.js
+++ b/src/CursorGpsDisplay/MenuPopover/index.js
@@ -24,21 +24,30 @@ const MenuPopover = ({ buttonRef, className, onClose, ref, ...otherProps }) => {
 
   const [gpsInputValue, setGpsInputValue] = useState(null);
 
-  const onJumpToCoordinates = useCallback(() => {
+  const onJumpToCoordinates = useCallback((coordinates = gpsInputValue) => {
     // If the GPS input value is defined, jump to the coordinates, show a dropped marker popup in the map and close the
     // menu.
-    if (gpsInputValue) {
-      jumpToLocation([gpsInputValue.longitude, gpsInputValue.latitude]);
+    if (coordinates) {
+      jumpToLocation([coordinates.longitude, coordinates.latitude]);
 
       setTimeout(() => dispatch(showPopup('dropped-marker', {
-        coordinates: [gpsInputValue.longitude, gpsInputValue.latitude],
-        location: { lat: gpsInputValue.latitude, lng: gpsInputValue.longitude },
+        coordinates: [coordinates.longitude, coordinates.latitude],
+        location: { lat: coordinates.latitude, lng: coordinates.longitude },
         popupAttrsOverride: { offset: [0, 0] },
       })), 50);
 
       onClose();
     }
   }, [dispatch, gpsInputValue, jumpToLocation, onClose]);
+
+  const onGpsInputPlaceSelected = (event, place) => {
+    // Either if the place was selected by clicking or pressing enter, we stop
+    // the propagation of the event so the GPS input keyboard events and map
+    // clicking events don't get triggered.
+    event.stopPropagation();
+
+    onJumpToCoordinates(place.coordinates);
+  };
 
   const onGpsInputKeyDown = (event) => {
     switch (event.key) {
@@ -116,6 +125,7 @@ const MenuPopover = ({ buttonRef, className, onClose, ref, ...otherProps }) => {
       inputRef={gpsInputRef}
       onChange={setGpsInputValue}
       onKeyDown={onGpsInputKeyDown}
+      onPlaceSelected={onGpsInputPlaceSelected}
       ref={gpsInputWrapperRef}
       renderButton={() => <button
         aria-label={t('gpsInputButtonLabel')}

--- a/src/CursorGpsDisplay/MenuPopover/index.js
+++ b/src/CursorGpsDisplay/MenuPopover/index.js
@@ -128,6 +128,7 @@ const MenuPopover = ({ buttonRef, className, onClose, ref, ...otherProps }) => {
       >
         <SearchIcon className={styles.searchIcon} />
       </button>}
+      showTextSearchOption
       title={t('gpsDisplayTooltip')}
       value={gpsInputValue}
     />

--- a/src/CursorGpsDisplay/MenuPopover/index.js
+++ b/src/CursorGpsDisplay/MenuPopover/index.js
@@ -93,13 +93,13 @@ const MenuPopover = ({ buttonRef, className, onClose, ref, ...otherProps }) => {
   }, [gpsInputValue]);
 
   useEffect(() => {
-    const onMouseDown = (event) => !buttonRef.current.contains(event.target)
-    && !gpsInputWrapperRef.current.contains(event.target)
-    && onClose();
+    const onPointerDown = (event) => !buttonRef.current.contains(event.target)
+      && !gpsInputWrapperRef.current.contains(event.target)
+      && onClose();
 
-    document.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('pointerdown', onPointerDown);
 
-    return () => document.removeEventListener('mousedown', onMouseDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
   }, [buttonRef, onClose]);
 
   return <Popover

--- a/src/CursorGpsDisplay/MenuPopover/index.test.js
+++ b/src/CursorGpsDisplay/MenuPopover/index.test.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import userEvent from '@testing-library/user-event';
 
-import { render, screen } from '../../test-utils';
+import { render, screen, waitFor } from '../../test-utils';
+import { fetchForwardGeocoding } from '../../utils/location';
 import { GPS_FORMATS } from '../../utils/location';
 import { mockStore } from '../../__test-helpers/MockStore';
 import { showPopup } from '../../ducks/popup';
@@ -17,11 +18,34 @@ jest.mock('../../ducks/popup', () => ({
 
 jest.mock('../../hooks/useJumpToLocation', () => jest.fn());
 
+jest.mock('../../utils/location', () => ({
+  ...jest.requireActual('../../utils/location'),
+  fetchForwardGeocoding: jest.fn(() => []),
+}));
+
 describe('CursorGpsDisplay - MenuPopover', () => {
   const onClose = jest.fn();
 
   let jumpToLocationMock, showPopupMock, store, user;
   beforeEach(async () => {
+    fetchForwardGeocoding.mockImplementation(() => [
+      {
+        coordinates: {
+          latitude: 19.432630,
+          longitude: -99.133178,
+        },
+        name_preferred: 'Mexico City',
+        place_formatted: 'Mexico',
+      },
+      {
+        coordinates: {
+          latitude: 20.674793,
+          longitude: -103.359410,
+        },
+        name_preferred: 'Guadalajara',
+        place_formatted: 'Jalisco, Mexico',
+      },
+    ]);
     showPopupMock = jest.fn(() => () => {});
     showPopup.mockImplementation(showPopupMock);
     jumpToLocationMock = jest.fn();
@@ -143,6 +167,39 @@ describe('CursorGpsDisplay - MenuPopover', () => {
       location: {
         lat: 10,
         lng: 10,
+      },
+      popupAttrsOverride: {
+        offset: [0, 0],
+      },
+    });
+  });
+
+  test('jumps to the coordinates of a place selected through text search', async () => {
+    renderMenuPopover();
+
+    await user.click(screen.getByRole('radio', { name: 'Search by name' }));
+    await user.type(screen.getByRole('combobox', { name: 'Search location by name' }), 'mexico');
+
+    expect(jumpToLocationMock).not.toHaveBeenCalled();
+    expect(showPopup).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    await waitFor(async () => {
+      await user.click(screen.getByRole('option', { name: 'Guadalajara - Jalisco, Mexico' }));
+    });
+
+    expect(jumpToLocationMock).toHaveBeenCalledTimes(1);
+    expect(jumpToLocationMock).toHaveBeenCalledWith([-103.35941, 20.674793]);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    jest.runOnlyPendingTimers();
+
+    expect(showPopup).toHaveBeenCalledTimes(1);
+    expect(showPopup).toHaveBeenCalledWith('dropped-marker', {
+      coordinates: [-103.35941, 20.674793],
+      location: {
+        lat: 20.674793,
+        lng: -103.35941,
       },
       popupAttrsOverride: {
         offset: [0, 0],

--- a/src/CursorGpsDisplay/MenuPopover/index.test.js
+++ b/src/CursorGpsDisplay/MenuPopover/index.test.js
@@ -68,7 +68,7 @@ describe('CursorGpsDisplay - MenuPopover', () => {
   test('jumps to the typed coordinates by pressing enter', async () => {
     renderMenuPopover();
 
-    await user.type(screen.getByLabelText('GPS location'), '10,10');
+    await user.type(screen.getByRole('searchbox', { name: 'Search location in DEG format' }), '10,10');
 
     expect(jumpToLocationMock).not.toHaveBeenCalled();
     expect(showPopup).not.toHaveBeenCalled();
@@ -100,7 +100,7 @@ describe('CursorGpsDisplay - MenuPopover', () => {
 
     expect(onClose).not.toHaveBeenCalled();
 
-    await user.type(screen.getByLabelText('GPS location'), '10,10');
+    await user.type(screen.getByRole('searchbox', { name: 'Search location in DEG format' }), '10,10');
     await user.keyboard('{Escape}');
 
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -115,7 +115,7 @@ describe('CursorGpsDisplay - MenuPopover', () => {
   test('enables the GPS input button if there is a value', async () => {
     renderMenuPopover();
 
-    await user.type(screen.getByLabelText('GPS location'), '10,10');
+    await user.type(screen.getByRole('searchbox', { name: 'Search location in DEG format' }), '10,10');
 
     expect(screen.getByLabelText('Jump to coordinates')).toBeEnabled();
   });
@@ -123,7 +123,7 @@ describe('CursorGpsDisplay - MenuPopover', () => {
   test('jumps to the typed coordinates by clicking the GPS input button', async () => {
     renderMenuPopover();
 
-    await user.type(screen.getByLabelText('GPS location'), '10,10');
+    await user.type(screen.getByRole('searchbox', { name: 'Search location in DEG format' }), '10,10');
 
     expect(jumpToLocationMock).not.toHaveBeenCalled();
     expect(showPopup).not.toHaveBeenCalled();
@@ -148,6 +148,33 @@ describe('CursorGpsDisplay - MenuPopover', () => {
         offset: [0, 0],
       },
     });
+  });
+
+  test('adds a focus trap within the menu', async () => {
+    jest.useRealTimers();
+
+    renderMenuPopover();
+
+    const gpsInput = screen.getByRole('searchbox', { name: 'Search location in DEG format' });
+    const degRadioInput = screen.getByRole('radio', { name: 'DEG' });
+
+    await userEvent.keyboard('[Tab]');
+
+    expect(degRadioInput).toBe(document.activeElement);
+
+    await userEvent.keyboard('[Tab]');
+
+    expect(gpsInput).toBe(document.activeElement);
+
+    await userEvent.keyboard('{Shift>}[Tab]{/Shift}');
+
+    expect(degRadioInput).toBe(document.activeElement);
+
+    await userEvent.keyboard('{Shift>}[Tab]{/Shift}');
+
+    expect(gpsInput).toBe(document.activeElement);
+
+    jest.useFakeTimers();
   });
 
   test('closes the menu if the user clicks outside', async () => {

--- a/src/CursorGpsDisplay/MenuPopover/styles.module.scss
+++ b/src/CursorGpsDisplay/MenuPopover/styles.module.scss
@@ -15,7 +15,7 @@
   }
 
   .gpsInput {
-    input[type=text] {
+    input[type=search] {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
     }
@@ -23,9 +23,10 @@
 
   .gpsInputButton {
     background-color: colors.$light-gray-background;
-    border: 1px solid #d8d9d9;
+    border: 1px solid colors.$secondary-light-gray;
     border-left: none;
     border-radius: 0 .2rem .2rem 0;
+    color: colors.$secondary-medium-gray;
     height: 2.5rem;
     min-width: 2.5rem;
     outline: none;
@@ -33,10 +34,15 @@
 
     &:disabled {
       background-color: colors.$disabled-field-gray;
+      cursor: not-allowed;
+      opacity: 0.66;
     }
 
     &:focus-visible:not(:disabled) {
-      border: 2px solid colors.$bright-blue;
+      background-color: white;
+      border: 1px solid colors.$bright-blue;
+      color: colors.$bright-blue;
+      outline: 1px solid colors.$bright-blue;
     }
 
     &:hover:not(:disabled) {
@@ -49,12 +55,7 @@
 
       circle {
         fill: none;
-        stroke: colors.$secondary-medium-gray;
         stroke-width: 1rem;
-      }
-
-      path {
-        fill: colors.$secondary-medium-gray;
       }
     }
   }

--- a/src/GpsFormatToggle/index.js
+++ b/src/GpsFormatToggle/index.js
@@ -2,6 +2,8 @@ import React, { memo, useEffect, useId, useImperativeHandle, useRef } from 'reac
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
+import { ReactComponent as SearchIcon } from '../common/images/icons/search-icon.svg';
+
 import { FEATURE_FLAG_LABELS } from '../constants';
 import { GPS_FORMAT_CATEGORY, trackEventFactory } from '../utils/analytics';
 import { GPS_FORMATS, OUTSIDE_BBOX, stringifyCoordinates } from '../utils/location';
@@ -22,10 +24,13 @@ const gpsFormatTracker = trackEventFactory(GPS_FORMAT_CATEGORY);
 
 const GpsFormatToggle = ({
   className = '',
+  isTextSearchOptionChecked = false,
   lngLat = null,
   name = null,
   ref,
+  setIsTextSearchOptionChecked = null,
   showCoordinates = true,
+  showTextSearchOption = false,
   ...otherProps
 }) => {
   const customCoordinateSystemsEnabled = useFeatureFlag(FEATURE_FLAG_LABELS.CUSTOM_COORDINATE_SYSTEMS_ENABLED);
@@ -46,9 +51,10 @@ const GpsFormatToggle = ({
   useImperativeHandle(ref, () => innerRef.current);
 
   const coordinatesOutsideBboxTooltipId = useId();
-  // We need to provide a name for the radio group to behave correctly, so we
-  // add a fallback in case the implementator didn't provide one.
-  const nameFallback = useId();
+  // The component may be rendered several times so we need a way to make the
+  // HTML ids unique. This id is also used as a name fallback if the
+  // implementator didn't provide one.
+  const id = useId();
 
   const { coordinatesString, outsideRepresentationBbox } = useStringifyCoordinates(lngLat);
 
@@ -64,14 +70,16 @@ const GpsFormatToggle = ({
     : Object.values(GPS_FORMATS);
 
   const onGpsFormatChange = (gpsFormat) => {
+    setIsTextSearchOptionChecked?.(false);
+
     dispatch(updateUserPreferences({ gpsFormat }));
 
     gpsFormatTracker.track('Change GPS Format', `GPS Format:${gpsFormat}`);
   };
 
   useEffect(() => {
-    // Fixes a bug in when mounting map popups where the browser automatically focuses the first input and not the
-    // one that is checked.
+    // Fixes a bug in when mounting map popups where the browser automatically
+    // focuses the first input and not the one that is checked.
     setTimeout(() => {
       if (fieldsetRef.current?.contains(document.activeElement) && document.activeElement !== innerRef.current) {
         innerRef.current.focus();
@@ -83,6 +91,36 @@ const GpsFormatToggle = ({
     <fieldset className={styles.fieldset} ref={fieldsetRef} role="radiogroup">
       <legend className={styles.legend}>{t('fieldsetLegend')}</legend>
 
+      {/* If the flag showTextSearchOption is true, the first option is the
+      text search, which is handled through a controlled prop and not through
+      the gpsFormat store variable. */}
+      {showTextSearchOption && <div className={styles.radio}>
+        <input
+          checked={isTextSearchOptionChecked}
+          className={styles.input}
+          id={`${id}-text-search-radio`}
+          name={name || id}
+          onChange={() => setIsTextSearchOptionChecked?.(true)}
+          ref={(element) => {
+            if (isTextSearchOptionChecked) {
+              innerRef.current = element;
+            }
+          }}
+          type="radio"
+          value={t('textSearchOptionLabel')}
+        />
+
+        <label
+          className={`${styles.label} ${isTextSearchOptionChecked ? styles.active : ''}`}
+          htmlFor={`${id}-text-search-radio`}
+          title={t('textSearchOptionLabel')}
+        >
+          <SearchIcon aria-hidden />
+
+          <span className="sr-only">{t('textSearchOptionLabel')}</span>
+        </label>
+      </div>}
+
       {gpsFormatOptions.map((gpsFormatOption) => {
         // If the option is a CRS and there is a lngLat, calculate if the
         // lngLat point is outside the BBOX.
@@ -91,15 +129,19 @@ const GpsFormatToggle = ({
           ? stringifyCoordinates(lngLat, gpsFormatCoordinateReferenceSystem) === OUTSIDE_BBOX
           : false;
 
+        // If this option is the store gpsFormat and the text search is not
+        // checked, this option is checked.
+        const isChecked = !isTextSearchOptionChecked && gpsFormat === gpsFormatOption;
+
         return <div className={styles.radio} key={gpsFormatOption}>
           <input
-            checked={gpsFormat === gpsFormatOption}
+            checked={isChecked}
             className={styles.input}
-            id={`${gpsFormatOption}-radio`}
-            name={name || nameFallback}
+            id={`${id}-${gpsFormatOption}-radio`}
+            name={name || id}
             onChange={() => onGpsFormatChange(gpsFormatOption)}
             ref={(element) => {
-              if (gpsFormat === gpsFormatOption) {
+              if (isChecked) {
                 innerRef.current = element;
               }
             }}
@@ -108,8 +150,8 @@ const GpsFormatToggle = ({
           />
 
           <label
-            className={`${styles.label} ${gpsFormat === gpsFormatOption ? styles.active : ''} ${isLngLatOutsideCrsBbox ? styles.invalid : ''}`}
-            htmlFor={`${gpsFormatOption}-radio`}
+            className={`${styles.label} ${isChecked ? styles.active : ''} ${isLngLatOutsideCrsBbox ? styles.invalid : ''}`}
+            htmlFor={`${id}-${gpsFormatOption}-radio`}
             title={gpsFormatCoordinateReferenceSystem?.name || gpsFormatOption}
           >
             {gpsFormatCoordinateReferenceSystem?.name || gpsFormatOption}

--- a/src/GpsFormatToggle/index.js
+++ b/src/GpsFormatToggle/index.js
@@ -112,6 +112,7 @@ const GpsFormatToggle = ({
 
         <label
           className={`${styles.label} ${isTextSearchOptionChecked ? styles.active : ''}`}
+          data-testid="gpsFormatToggle-textSearchOptionLabel"
           htmlFor={`${id}-text-search-radio`}
           title={t('textSearchOptionLabel')}
         >

--- a/src/GpsFormatToggle/index.test.js
+++ b/src/GpsFormatToggle/index.test.js
@@ -16,6 +16,8 @@ jest.mock('../ducks/user-preferences', () => ({
 }));
 
 describe('GpsFormatToggle', () => {
+  const setIsTextSearchOptionChecked = jest.fn();
+
   let store, updateUserPreferencesMock;
   beforeEach(() => {
     updateUserPreferencesMock = jest.fn(() => () => {});
@@ -55,17 +57,32 @@ describe('GpsFormatToggle', () => {
   });
 
   test('assigns the name to the radio inputs', async () => {
-    renderGpsFormatToggle({ name: 'name' });
+    renderGpsFormatToggle({ name: 'name', showTextSearchOption: true });
 
     const radiogroup = screen.getByRole('radiogroup', { name: 'GPS format' });
     const radioInputs = within(radiogroup).getAllByRole('radio');
 
-    expect(radioInputs).toHaveLength(5);
+    expect(radioInputs).toHaveLength(6);
     expect(radioInputs[0]).toHaveAttribute('name', 'name');
     expect(radioInputs[1]).toHaveAttribute('name', 'name');
     expect(radioInputs[2]).toHaveAttribute('name', 'name');
     expect(radioInputs[3]).toHaveAttribute('name', 'name');
     expect(radioInputs[4]).toHaveAttribute('name', 'name');
+    expect(radioInputs[5]).toHaveAttribute('name', 'name');
+  });
+
+  test('does not show an option for the text search', async () => {
+    renderGpsFormatToggle();
+
+    expect(screen.queryByRole('radio', { name: 'Search by name' })).toBeNull();
+    expect(screen.getAllByRole('radio')).toHaveLength(5);
+  });
+
+  test('shows an option for the text search', async () => {
+    renderGpsFormatToggle({ showTextSearchOption: true });
+
+    expect(screen.getByRole('radio', { name: 'Search by name' })).toBeVisible();
+    expect(screen.getAllByRole('radio')).toHaveLength(6);
   });
 
   test('checks the GPS format option that is currently selected', async () => {
@@ -73,6 +90,23 @@ describe('GpsFormatToggle', () => {
 
     expect(screen.getByLabelText(GPS_FORMATS.DEG)).toBeChecked();
     expect(screen.getByText(GPS_FORMATS.DEG)).toHaveClass('active');
+    expect(screen.getByLabelText(GPS_FORMATS.DDM)).not.toBeChecked();
+    expect(screen.getByText(GPS_FORMATS.DDM)).not.toHaveClass('active');
+    expect(screen.getByLabelText(GPS_FORMATS.DMS)).not.toBeChecked();
+    expect(screen.getByText(GPS_FORMATS.DMS)).not.toHaveClass('active');
+    expect(screen.getByLabelText(GPS_FORMATS.MGRS)).not.toBeChecked();
+    expect(screen.getByText(GPS_FORMATS.MGRS)).not.toHaveClass('active');
+    expect(screen.getByLabelText(GPS_FORMATS.UTM)).not.toBeChecked();
+    expect(screen.getByText(GPS_FORMATS.UTM)).not.toHaveClass('active');
+  });
+
+  test('checks the text search option', async () => {
+    renderGpsFormatToggle({ isTextSearchOptionChecked: true, showTextSearchOption: true });
+
+    expect(screen.getByLabelText('Search by name')).toBeChecked();
+    expect(screen.getByTestId('gpsFormatToggle-textSearchOptionLabel')).toHaveClass('active');
+    expect(screen.getByLabelText(GPS_FORMATS.DEG)).not.toBeChecked();
+    expect(screen.getByText(GPS_FORMATS.DEG)).not.toHaveClass('active');
     expect(screen.getByLabelText(GPS_FORMATS.DDM)).not.toBeChecked();
     expect(screen.getByText(GPS_FORMATS.DDM)).not.toHaveClass('active');
     expect(screen.getByLabelText(GPS_FORMATS.DMS)).not.toBeChecked();
@@ -97,6 +131,23 @@ describe('GpsFormatToggle', () => {
 
     expect(updateUserPreferences).toHaveBeenCalledTimes(2);
     expect(updateUserPreferences).toHaveBeenCalledWith({ gpsFormat: GPS_FORMATS.UTM });
+  });
+
+  test('updates the search text option through parent props', async () => {
+    renderGpsFormatToggle({
+      isTextSearchOptionChecked: false,
+      setIsTextSearchOptionChecked,
+      showTextSearchOption: true,
+    });
+
+    expect(updateUserPreferences).not.toHaveBeenCalled();
+    expect(setIsTextSearchOptionChecked).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Search by name' }));
+
+    expect(updateUserPreferences).not.toHaveBeenCalled();
+    expect(setIsTextSearchOptionChecked).toHaveBeenCalledTimes(1);
+    expect(setIsTextSearchOptionChecked).toHaveBeenCalledWith(true);
   });
 
   test('sets the label text and title for a coordinate reference system', async () => {

--- a/src/GpsFormatToggle/styles.module.scss
+++ b/src/GpsFormatToggle/styles.module.scss
@@ -57,6 +57,16 @@
         border-bottom-color: colors.$bright-blue;
         color: colors.$bright-blue;
       }
+
+      svg {
+        height: 0.875rem;
+        width: 0.875rem;
+
+        circle {
+          fill: none;
+          stroke-width: 1rem;
+        }
+      }
     }
   }
 }

--- a/src/GpsInput/index.js
+++ b/src/GpsInput/index.js
@@ -281,7 +281,11 @@ const GpsInput = ({
         role="option"
         title={`${place.namePreferred} - ${place.placeFormatted}`}
       >
-        {selectedPlaceIndex === index && <CheckLightIcon className={styles.checkLightIcon} />}
+        {selectedPlaceIndex === index && <CheckLightIcon
+          aria-hidden
+          className={styles.checkLightIcon}
+          data-testid="gpsInput-placeFromSearchTextOption-checkLightIcon"
+        />}
 
         <div className={styles.labelWrapper}>
           {place.namePreferred}

--- a/src/GpsInput/index.js
+++ b/src/GpsInput/index.js
@@ -26,6 +26,7 @@ const GpsInput = ({
   id = null,
   inputRef = null,
   onChange,
+  onPlaceSelected = null,
   ref,
   renderButton = null,
   showTextSearchOption = false,
@@ -137,16 +138,20 @@ const GpsInput = ({
     }
   };
 
-  const onPlaceOptionSelected = (index) => {
+  const onPlaceOptionSelected = (event, index) => {
     // Make the place option active and selected, fill the input value with its
     // content, call onChange with the place coordinates and focus the input.
     const selectedPlace = placesFromSearchText[index];
+    const fullPlaceName = selectedPlace.placeFormatted
+      ? `${selectedPlace.namePreferred} - ${selectedPlace.placeFormatted}`
+      : selectedPlace.namePreferred;
 
     setActivePlaceIndex(index);
     setSelectedPlaceIndex(index);
-    setInputValue(`${selectedPlace.namePreferred} - ${selectedPlace.placeFormatted}`);
+    setInputValue(fullPlaceName);
 
     onChange(selectedPlace.coordinates);
+    onPlaceSelected?.(event, selectedPlace);
 
     innerInputRef.current.focus();
   };
@@ -177,9 +182,8 @@ const GpsInput = ({
       case 'Enter':
         if (activePlaceIndex >= 0) {
           event.preventDefault();
-          event.stopPropagation();
 
-          onPlaceOptionSelected(activePlaceIndex);
+          onPlaceOptionSelected(event, activePlaceIndex);
         }
 
         break;
@@ -271,28 +275,34 @@ const GpsInput = ({
       id={placesFromSearchTextListId}
       role="listbox"
     >
-      {placesFromSearchText.map((place, index) => <li
-        aria-label={`${place.namePreferred} - ${place.placeFormatted}`}
-        aria-selected={selectedPlaceIndex === index}
-        className={`${styles.placeFromSearchTextOption} ${activePlaceIndex === index ? styles.active : ''}`}
-        id={`place-from-search-text-option-${index}`}
-        key={`${place.namePreferred} - ${place.placeFormatted}`}
-        onClick={() => onPlaceOptionSelected(index)}
-        role="option"
-        title={`${place.namePreferred} - ${place.placeFormatted}`}
-      >
-        {selectedPlaceIndex === index && <CheckLightIcon
-          aria-hidden
-          className={styles.checkLightIcon}
-          data-testid="gpsInput-placeFromSearchTextOption-checkLightIcon"
-        />}
+      {placesFromSearchText.map((place, index) => {
+        const fullPlaceName = place.placeFormatted
+          ? `${place.namePreferred} - ${place.placeFormatted}`
+          : place.namePreferred;
 
-        <div className={styles.labelWrapper}>
-          {place.namePreferred}
+        return <li
+          aria-label={fullPlaceName}
+          aria-selected={selectedPlaceIndex === index}
+          className={`${styles.placeFromSearchTextOption} ${activePlaceIndex === index ? styles.active : ''}`}
+          id={`place-from-search-text-option-${index}`}
+          key={fullPlaceName}
+          onClick={(event) => onPlaceOptionSelected(event, index)}
+          role="option"
+          title={fullPlaceName}
+        >
+          {selectedPlaceIndex === index && <CheckLightIcon
+            aria-hidden
+            className={styles.checkLightIcon}
+            data-testid="gpsInput-placeFromSearchTextOption-checkLightIcon"
+          />}
 
-          <span className={styles.placeFormatted}>{place.placeFormatted}</span>
-        </div>
-      </li>)}
+          <div className={styles.labelWrapper}>
+            {place.namePreferred}
+
+            {place.placeFormatted && <span className={styles.placeFormatted}>{place.placeFormatted}</span>}
+          </div>
+        </li>;
+      })}
     </ul>}
   </div>;
 };

--- a/src/GpsInput/index.js
+++ b/src/GpsInput/index.js
@@ -1,8 +1,12 @@
 import React, { memo, useEffect, useId, useRef, useState } from 'react';
+import debounce from 'lodash/debounce';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
+import { ReactComponent as CheckLightIcon } from '../common/images/icons/check-light.svg';
+
 import {
+  fetchForwardGeocoding,
   GPS_FORMAT_EXAMPLES,
   OUTSIDE_BBOX,
   parseCoordinates,
@@ -15,6 +19,8 @@ import GpsFormatToggle from '../GpsFormatToggle';
 
 import * as styles from './styles.module.scss';
 
+const FETCH_PLACES_FROM_SEARCH_TEXT_DEBOUNCE_TIME = 200;
+
 const GpsInput = ({
   gpsFormatToggleRef = null,
   id = null,
@@ -22,6 +28,7 @@ const GpsInput = ({
   onChange,
   ref,
   renderButton = null,
+  showTextSearchOption = false,
   value = null,
   ...otherProps
 }) => {
@@ -33,99 +40,220 @@ const GpsInput = ({
 
   const descriptionId = useId();
   const errorMessageId = useId();
+  const placesFromSearchTextListId = useId();
 
-  // The input value is handled locally to accept any input, but we just
-  // trigger onChange when the value is valid.
+  const [activePlaceIndex, setActivePlaceIndex] = useState(-1);
+  // The input value is handled locally and allows free text. When the input is
+  // a valid set of coordinates, we update the parent through onChange.
   const [inputValue, setInputValue] = useState(() => value
     ? stringifyCoordinates(value, coordinatesRepresentation)
     : '');
   const [isInputValueValid, setIsInputValueValid] = useState(true);
+  const [isTextSearchOptionChecked, setIsTextSearchOptionChecked] = useState(false);
+  const [placesFromSearchText, setPlacesFromSearchText] = useState(null);
+  const [selectedPlaceIndex, setSelectedPlaceIndex] = useState(null);
 
-  // When blurring the input, we set the value as the input value again since
-  // it should have the last valid value.
+  // Debounced method to fetch forward geocoding from the search text.
+  const fetchPlacesFromSearchText = useRef(debounce(async (searchText) => {
+    const places = await fetchForwardGeocoding(searchText);
+
+    // Reset the active and selected indexes when the places are updated.
+    setActivePlaceIndex(-1);
+    setSelectedPlaceIndex(null);
+    setPlacesFromSearchText(places.map((place) => ({
+      coordinates: place.coordinates,
+      namePreferred: place.name_preferred,
+      placeFormatted: place.place_formatted,
+    })));
+  }, FETCH_PLACES_FROM_SEARCH_TEXT_DEBOUNCE_TIME)).current;
+
+  // The input is set in an error state if the text search option is not
+  // checked and the input value not a valid set of coordinates or they are
+  // outside of the coordinates representation BBOX.
+  const isInputValid = isTextSearchOptionChecked || (isInputValueValid && inputValue !== OUTSIDE_BBOX);
+
+  let description;
+  let inputLabel = t('defaultLabel');
+  let inputPlaceholder = t('defaultPlaceholder');
+  if (isTextSearchOptionChecked) {
+    inputLabel = t('textSearchLabel');
+    inputPlaceholder = t('textSearchPlaceholder');
+
+    if (!(placesFromSearchText?.length > 0)) {
+      description = t('textSearchDescription');
+    }
+  } else if (coordinatesRepresentation) {
+    inputLabel = t('coordinatesRepresentationLabel', {
+      representation: coordinatesRepresentation?.name || coordinatesRepresentation,
+    });
+
+    if (coordinatesRepresentation?.name) {
+      inputPlaceholder = coordinatesRepresentation.name;
+    } else {
+      description = t('coordinatesRepresentationDescription', {
+        example: GPS_FORMAT_EXAMPLES[coordinatesRepresentation],
+      });
+      inputPlaceholder = t(`coordinatesRepresentationPlaceholder.${coordinatesRepresentation}`);
+    }
+  }
+
   const onInputBlur = () => {
-    setInputValue(value ? stringifyCoordinates(value, coordinatesRepresentation) : '');
-    setIsInputValueValid(true);
+    if (!isTextSearchOptionChecked) {
+      // If the input is blurred and the text search option is not checked, set
+      // its value to the value prop again since it should contain the last
+      // valid value.
+      setInputValue(value ? stringifyCoordinates(value, coordinatesRepresentation) : '');
+      setIsInputValueValid(true);
+    }
   };
 
-  const onInputChange = (event) => {
+  const onInputChange = async (event) => {
     setInputValue(event.target.value);
 
-    if (!event.target.value) {
-      // If the input was emptied, it is valid.
-      setIsInputValueValid(true);
-      onChange(null);
+    if (isTextSearchOptionChecked) {
+      // If the text search option is checked, use forward geocoding to fetch
+      // the places from the search text.
+      fetchPlacesFromSearchText(event.target.value);
     } else {
-      try {
-        // Frist we try to parse the input value from the current location
-        // type to a lngLat object.
-        const lngLat = parseCoordinates(event.target.value, coordinatesRepresentation);
+      // If the text search option is not checked, validate the input and
+      // notify the parent about the change if it is valid.
+      if (!event.target.value) {
+        // Empty values are valid..
+        setIsInputValueValid(true);
+        onChange(null);
+      } else {
+        try {
+          const lngLat = parseCoordinates(event.target.value, coordinatesRepresentation);
 
-        const isNewInputValueValid = validateLngLat(lngLat.longitude, lngLat.latitude);
-        setIsInputValueValid(isNewInputValueValid);
-
-        if (isNewInputValueValid) {
-          // If the input value is valid, trigger onChange.
-          onChange(lngLat);
+          const isNewInputValueValid = validateLngLat(lngLat.longitude, lngLat.latitude);
+          setIsInputValueValid(isNewInputValueValid);
+          if (isNewInputValueValid) {
+            onChange(lngLat);
+          }
+        } catch (error) {
+          setIsInputValueValid(false);
         }
-      } catch (error) {
-        setIsInputValueValid(false);
+      }
+    }
+  };
+
+  const onPlaceOptionSelected = (index) => {
+    // Make the place option active and selected, fill the input value with its
+    // content, call onChange with the place coordinates and focus the input.
+    const selectedPlace = placesFromSearchText[index];
+
+    setActivePlaceIndex(index);
+    setSelectedPlaceIndex(index);
+    setInputValue(`${selectedPlace.namePreferred} - ${selectedPlace.placeFormatted}`);
+
+    onChange(selectedPlace.coordinates);
+
+    innerInputRef.current.focus();
+  };
+
+  const onInputKeyDown = (event) => {
+    if (isTextSearchOptionChecked && placesFromSearchText?.length > 0) {
+      // If the text search option is checked and there are places from the
+      // search text, add keyboard navigation to the input.
+      switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+
+        setActivePlaceIndex((activePlaceIndex) =>
+          activePlaceIndex < placesFromSearchText.length - 1 ? activePlaceIndex + 1 : 0
+        );
+
+        break;
+
+      case 'ArrowUp':
+        event.preventDefault();
+
+        setActivePlaceIndex((activePlaceIndex) =>
+          activePlaceIndex > 0 ? activePlaceIndex - 1 : placesFromSearchText.length - 1
+        );
+
+        break;
+
+      case 'Enter':
+        if (activePlaceIndex >= 0) {
+          event.preventDefault();
+          event.stopPropagation();
+
+          onPlaceOptionSelected(activePlaceIndex);
+        }
+
+        break;
+
+      default:
       }
     }
   };
 
   useEffect(() => {
     if (value) {
-      // If the user changes the coordinates representation, we transform the input value to the new format.
-      setInputValue(stringifyCoordinates(value, coordinatesRepresentation));
+      if (isTextSearchOptionChecked) {
+        // If the text search option is checked, set the input to the content
+        // of the selected place or empty it if there isn't one.
+        const selectedPlace = placesFromSearchText?.[selectedPlaceIndex];
+        setInputValue(selectedPlace ? `${selectedPlace.namePreferred} - ${selectedPlace.placeFormatted}` : '');
+      } else {
+        // If the text search option is unchecked or the coordinates
+        // representation changes, transform the input value to the new format.
+        setInputValue(stringifyCoordinates(value, coordinatesRepresentation));
+      }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [coordinatesRepresentation]);
-
-  // We set the input in an error state if the current value is invalid or if
-  // it is outside of the BBOX of the CRS.
-  const isInputValid = isInputValueValid && inputValue !== OUTSIDE_BBOX;
+  }, [coordinatesRepresentation, isTextSearchOptionChecked]);
 
   return <div ref={ref} role="group" {...otherProps}>
     <GpsFormatToggle
+      isTextSearchOptionChecked={isTextSearchOptionChecked}
       lngLat={value}
       onKeyDown={(event) => event.key === 'Enter' && innerInputRef.current.focus()}
       ref={gpsFormatToggleRef}
+      setIsTextSearchOptionChecked={setIsTextSearchOptionChecked}
       showCoordinates={false}
+      showTextSearchOption={showTextSearchOption}
     />
 
     <div className={styles.inputWrapper}>
       <input
-        aria-describedby={isInputValid && typeof coordinatesRepresentation === 'string' ? descriptionId : undefined}
+        aria-activedescendant={isTextSearchOptionChecked && activePlaceIndex >= 0
+          ? `place-from-search-text-option-${activePlaceIndex}`
+          : undefined}
+        aria-autocomplete={isTextSearchOptionChecked ? 'list' : undefined}
+        aria-controls={isTextSearchOptionChecked ? placesFromSearchTextListId : undefined}
+        aria-describedby={isInputValid && description ? descriptionId : undefined}
         aria-errormessage={!isInputValid ? errorMessageId : undefined}
+        aria-expanded={isTextSearchOptionChecked ? placesFromSearchText?.length > 0 : undefined}
         aria-invalid={!isInputValid}
-        aria-label={t('inputLabel')}
+        aria-label={inputLabel}
+        autoComplete="off"
         className={styles.input}
         id={id}
         onBlur={onInputBlur}
         onChange={onInputChange}
-        placeholder={coordinatesRepresentation
-          ? coordinatesRepresentation?.name || t(`placeholders.${coordinatesRepresentation}`)
-          : t('defaultPlaceholder')}
+        onKeyDown={onInputKeyDown}
+        placeholder={inputPlaceholder}
         ref={(element) => {
           if (inputRef) {
             inputRef.current = element;
           }
           innerInputRef.current = element;
         }}
-        type="text"
-        // If the value is outside of the BBOX of the CRS, show N/A.
+        role={isTextSearchOptionChecked ? 'combobox' : undefined}
+        title={inputLabel}
+        type="search"
+        // If the value is outside of the BBOX of the coordinates
+        // representation, show N/A.
         value={inputValue === OUTSIDE_BBOX ? t('outsideBboxInputValue') : inputValue}
       />
 
       {renderButton?.()}
     </div>
 
-    {isInputValid && typeof coordinatesRepresentation === 'string' && <p
-      className={styles.description}
-      id={descriptionId}
-    >
-      {t('inputDescription', { gpsFormat: GPS_FORMAT_EXAMPLES[coordinatesRepresentation] })}
+    {isInputValid && description && <p className={styles.description} id={descriptionId}>
+      {description}
     </p>}
 
     {!isInputValid && <p aria-live="assertive" className={`${styles.description} ${styles.error}`} id={errorMessageId}>
@@ -136,6 +264,32 @@ const GpsInput = ({
         })
         : t('invalidLocationErrorMessage')}
     </p>}
+
+    {isTextSearchOptionChecked && placesFromSearchText?.length > 0 && <ul
+      aria-label={t('placesFromSearchTextListLabel')}
+      className={styles.placesFromSearchTextList}
+      id={placesFromSearchTextListId}
+      role="listbox"
+    >
+      {placesFromSearchText.map((place, index) => <li
+        aria-label={`${place.namePreferred} - ${place.placeFormatted}`}
+        aria-selected={selectedPlaceIndex === index}
+        className={`${styles.placeFromSearchTextOption} ${activePlaceIndex === index ? styles.active : ''}`}
+        id={`place-from-search-text-option-${index}`}
+        key={`${place.namePreferred} - ${place.placeFormatted}`}
+        onClick={() => onPlaceOptionSelected(index)}
+        role="option"
+        title={`${place.namePreferred} - ${place.placeFormatted}`}
+      >
+        {selectedPlaceIndex === index && <CheckLightIcon className={styles.checkLightIcon} />}
+
+        <div className={styles.labelWrapper}>
+          {place.namePreferred}
+
+          <span className={styles.placeFormatted}>{place.placeFormatted}</span>
+        </div>
+      </li>)}
+    </ul>}
   </div>;
 };
 

--- a/src/GpsInput/index.test.js
+++ b/src/GpsInput/index.test.js
@@ -2,13 +2,19 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import userEvent from '@testing-library/user-event';
 
-import { fireEvent, render, screen } from '../test-utils';
+import { fetchForwardGeocoding } from '../utils/location';
+import { fireEvent, render, screen, waitFor, within } from '../test-utils';
 import { epsg5367 } from '../__test-helpers/fixtures/location';
 import { GPS_FORMATS } from '../utils/location';
 import { mockStore } from '../__test-helpers/MockStore';
 import { updateUserPreferences } from '../ducks/user-preferences';
 
 import GpsInput from './';
+
+jest.mock('../utils/location', () => ({
+  ...jest.requireActual('../utils/location'),
+  fetchForwardGeocoding: jest.fn(() => []),
+}));
 
 jest.mock('../ducks/user-preferences', () => ({
   ...jest.requireActual('../ducks/user-preferences'),
@@ -20,6 +26,24 @@ describe('GpsInput', () => {
 
   let store, updateUserPreferencesMock;
   beforeEach(() => {
+    fetchForwardGeocoding.mockImplementation(() => [
+      {
+        coordinates: {
+          latitude: 19.432630,
+          longitude: -99.133178,
+        },
+        name_preferred: 'Mexico City',
+        place_formatted: 'Mexico',
+      },
+      {
+        coordinates: {
+          latitude: 20.674793,
+          longitude: -103.359410,
+        },
+        name_preferred: 'Guadalajara',
+        place_formatted: 'Jalisco, Mexico',
+      },
+    ]);
     updateUserPreferencesMock = jest.fn(() => () => {});
     updateUserPreferences.mockImplementation(updateUserPreferencesMock);
 
@@ -54,7 +78,8 @@ describe('GpsInput', () => {
       },
     });
 
-    expect(screen.getByLabelText('GPS location')).toHaveValue('10.000000°, 10.000000°');
+    expect(screen.getByRole('searchbox', { name: 'Search location in DEG format' }))
+      .toHaveValue('10.000000°, 10.000000°');
   });
 
   test('sets the input value as N/A and shows an error if the current coordinates are outside of the BBOX of the current CRS', async () => {
@@ -74,9 +99,42 @@ describe('GpsInput', () => {
 
     const errorMessage = screen.getByText('EPSG:5367 CR05 / CRTM05 is not supported at this location.');
 
-    expect(screen.getByLabelText('GPS location')).toHaveValue('N/A');
+    expect(screen.getByRole('searchbox', { name: 'Search location in CR05 / CRTM05 format' })).toHaveValue('N/A');
     expect(errorMessage).toHaveAttribute('aria-live', 'assertive');
     expect(errorMessage).toHaveClass('error');
+  });
+
+  test('does not enable the text search', async () => {
+    renderGpsInput();
+
+    expect(screen.queryByRole('radio', { name: 'Search by name' })).toBeNull();
+  });
+
+  test('enables the text search', async () => {
+    renderGpsInput({ showTextSearchOption: true });
+
+    expect(screen.getByRole('radio', { name: 'Search by name' })).toBeVisible();
+  });
+
+  test('checks the text search option', async () => {
+    renderGpsInput({ showTextSearchOption: true });
+
+    const textSearchOption = screen.getByRole('radio', { name: 'Search by name' });
+    const gpsInput = screen.getByRole('searchbox', { name: 'Search location in DEG format' });
+
+    expect(textSearchOption).not.toBeChecked();
+    expect(gpsInput).not.toHaveAttribute('aria-autocomplete');
+    expect(gpsInput).not.toHaveAttribute('aria-controls');
+    expect(gpsInput).not.toHaveAttribute('aria-expanded');
+    expect(gpsInput).not.toHaveAttribute('role');
+
+    await userEvent.click(textSearchOption);
+
+    expect(textSearchOption).toBeChecked();
+    expect(gpsInput).toHaveAttribute('aria-autocomplete', 'list');
+    expect(gpsInput).toHaveAttribute('aria-controls');
+    expect(gpsInput).toHaveAttribute('aria-expanded', 'false');
+    expect(gpsInput).toHaveAttribute('role', 'combobox');
   });
 
   test('updates the displayed value to the new GPS format when the user changes the toggle', async () => {
@@ -87,7 +145,7 @@ describe('GpsInput', () => {
       },
     });
 
-    const gpsInput = screen.getByLabelText('GPS location');
+    const gpsInput = screen.getByRole('searchbox', { name: 'Search location in DEG format' });
 
     expect(gpsInput).toHaveValue('10.000000°, 10.000000°');
 
@@ -101,11 +159,29 @@ describe('GpsInput', () => {
     expect(gpsInput).toHaveValue('10° 00.000000′ N, 010° 00.000000′ E');
   });
 
+  test('clears the displayed value when the user checks the text search option if there was not a selected place yet', async () => {
+    renderGpsInput({
+      showTextSearchOption: true,
+      value: {
+        latitude: 10,
+        longitude: 10,
+      },
+    });
+
+    const gpsInput = screen.getByRole('searchbox', { name: 'Search location in DEG format' });
+
+    expect(gpsInput).toHaveValue('10.000000°, 10.000000°');
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Search by name' }));
+
+    expect(gpsInput).toHaveValue('');
+  });
+
   test('focuses the text input if the user presses enter from the GPS format toggle', async () => {
     renderGpsInput();
 
     await userEvent.click(screen.getByLabelText(GPS_FORMATS.DMS));
-    const gpsInput = screen.getByLabelText('GPS location');
+    const gpsInput = screen.getByRole('searchbox', { name: 'Search location in DEG format' });
 
     expect(gpsInput).not.toHaveFocus();
 
@@ -117,7 +193,7 @@ describe('GpsInput', () => {
   test('updates the input', async () => {
     renderGpsInput();
 
-    const gpsInput = screen.getByLabelText('GPS location');
+    const gpsInput = screen.getByRole('searchbox', { name: 'Search location in DEG format' });
 
     expect(gpsInput).toHaveValue('');
 
@@ -134,7 +210,7 @@ describe('GpsInput', () => {
       },
     });
 
-    const gpsInput = screen.getByLabelText('GPS location');
+    const gpsInput = screen.getByRole('searchbox', { name: 'Search location in DEG format' });
 
     expect(gpsInput).toHaveValue('10.000000°, 10.000000°');
     expect(onChange).not.toHaveBeenCalled();
@@ -150,7 +226,7 @@ describe('GpsInput', () => {
   test('does not notify a change and shows an error if the user types an invalid value', async () => {
     renderGpsInput();
 
-    const gpsInput = screen.getByLabelText('GPS location');
+    const gpsInput = screen.getByRole('searchbox', { name: 'Search location in DEG format' });
 
     expect(gpsInput).toHaveValue('');
     expect(onChange).not.toHaveBeenCalled();
@@ -170,7 +246,7 @@ describe('GpsInput', () => {
   test('notifies a change when the user types a valid GPS value', async () => {
     renderGpsInput();
 
-    const gpsInput = screen.getByLabelText('GPS location');
+    const gpsInput = screen.getByRole('searchbox', { name: 'Search location in DEG format' });
 
     expect(gpsInput).toHaveValue('');
     expect(onChange).not.toHaveBeenCalled();
@@ -183,7 +259,26 @@ describe('GpsInput', () => {
     expect(onChange).toHaveBeenCalledWith({ latitude: 10, longitude: 10 });
   });
 
-  test('sets the value in the input on blur', async () => {
+  test('fetches the places from the search text when the user types in the input and the text search option is checked', async () => {
+    renderGpsInput({ showTextSearchOption: true });
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Search by name' }));
+    const gpsInput = screen.getByRole('combobox', { name: 'Search location by name' });
+
+    expect(screen.queryByRole('listbox', { name: 'Location search results' })).toBeNull();
+    expect(gpsInput).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.type(gpsInput, 'mexico');
+    const placesFromSearchTextList = await screen.findByRole('listbox', { name: 'Location search results' });
+
+    expect(placesFromSearchTextList).toBeVisible();
+    expect(within(placesFromSearchTextList).getByRole('option', { name: 'Mexico City - Mexico' })).toBeVisible();
+    expect(within(placesFromSearchTextList).getByRole('option', { name: 'Guadalajara - Jalisco, Mexico' }))
+      .toBeVisible();
+    expect(gpsInput).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('sets the value in the input on blur if the text search option is not checked', async () => {
     renderGpsInput({
       value: {
         latitude: 10,
@@ -191,7 +286,7 @@ describe('GpsInput', () => {
       },
     });
 
-    const gpsInput = screen.getByLabelText('GPS location');
+    const gpsInput = screen.getByRole('searchbox', { name: 'Search location in DEG format' });
 
     expect(gpsInput).toHaveValue('10.000000°, 10.000000°');
 
@@ -207,20 +302,52 @@ describe('GpsInput', () => {
     expect(gpsInput).not.toHaveAccessibleErrorMessage();
   });
 
-  test('sets a default placeholder to the input', async () => {
+  test('leaves the input values as is on blur if the text search option is checked', async () => {
+    renderGpsInput({ showTextSearchOption: true });
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Search by name' }));
+    const gpsInput = screen.getByRole('combobox', { name: 'Search location by name' });
+    await userEvent.type(gpsInput, 'mexico');
+
+    expect(gpsInput).toHaveValue('mexico');
+
+    fireEvent.blur(gpsInput);
+
+    expect(gpsInput).toHaveValue('mexico');
+  });
+
+  test('sets a default placeholder and label to the input', async () => {
     store.view.userPreferences.gpsFormat = null;
     renderGpsInput();
 
-    expect(screen.getByLabelText('GPS location')).toHaveAttribute('placeholder', 'Location');
+    expect(screen.getByRole('searchbox', { name: 'Search location' })).toHaveAttribute('placeholder', 'Location');
   });
 
-  test('sets a placeholder if the coordinates representation is a GPS format', async () => {
-    renderGpsInput();
+  test('sets a placeholder, description and label if the text search option is checked', async () => {
+    renderGpsInput({ showTextSearchOption: true });
 
-    expect(screen.getByLabelText('GPS location')).toHaveAttribute('placeholder', 'Latitude, Longitude');
+    await userEvent.click(screen.getByRole('radio', { name: 'Search by name' }));
+    const gpsInput = screen.getByRole('combobox', { name: 'Search location by name' });
+
+    expect(gpsInput).toHaveAttribute('placeholder', 'Search Location');
+    expect(gpsInput).toHaveAccessibleDescription('Search for a location on the map by name');
+    expect(screen.getByText('Search for a location on the map by name')).toBeVisible();
   });
 
-  test('sets a placeholder if the coordinates representation is a CRS', async () => {
+  test('hides the description of the combobox when the text search option is checked and there are places fetched', async () => {
+    renderGpsInput({ showTextSearchOption: true });
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Search by name' }));
+    const gpsInput = screen.getByRole('combobox', { name: 'Search location by name' });
+    await userEvent.type(gpsInput, 'mexico');
+
+    await waitFor(() => {
+      expect(gpsInput).toHaveAccessibleDescription('Search location by name');
+      expect(screen.queryByText('Search for a location on the map by name')).toBeNull();
+    });
+  });
+
+  test('sets a label and placeholder if the coordinates representation is a CRS and the text search option is not checked', async () => {
     store.view.coordinateReferenceSystems.selectedCoordinateRepresentations = [
       GPS_FORMATS.DEG,
       GPS_FORMATS.UTM,
@@ -230,7 +357,18 @@ describe('GpsInput', () => {
     store.view.userPreferences.gpsFormat = '5367';
     renderGpsInput();
 
-    expect(screen.getByLabelText('GPS location')).toHaveAttribute('placeholder', 'CR05 / CRTM05');
+    expect(screen.getByRole('searchbox', { name: 'Search location in CR05 / CRTM05 format' }))
+      .toHaveAttribute('placeholder', 'CR05 / CRTM05');
+  });
+
+  test('sets a label, description and placeholder if the coordinates representation is a GPS format and the text search option is not checked', async () => {
+    renderGpsInput();
+
+    const gpsInput = screen.getByRole('searchbox', { name: 'Search location in DEG format' });
+
+    expect(gpsInput).toHaveAttribute('placeholder', 'Latitude, Longitude');
+    expect(gpsInput).toHaveAccessibleDescription('Example: -0.15293, 37.30906');
+    expect(screen.getByText('Example: -0.15293, 37.30906')).toBeVisible();
   });
 
   test('renders a button', async () => {
@@ -239,30 +377,167 @@ describe('GpsInput', () => {
     expect(screen.getByTestId('button')).toBeVisible();
   });
 
-  test('shows an input description if the coordinates representation is a GPS format', async () => {
-    renderGpsInput();
-
-    expect(screen.getByLabelText('GPS location')).toHaveAccessibleDescription('Example: -0.15293, 37.30906');
-  });
-
   test('does not show an input description if the coordinates representation is a GPS format but the value is invalid', async () => {
     renderGpsInput();
 
-    await userEvent.type(screen.getByLabelText('GPS location'), 'a');
+    await userEvent.type(screen.getByRole('searchbox', { name: 'Search location in DEG format' }), 'a');
 
-    expect(screen.getByLabelText('GPS location')).not.toHaveAccessibleDescription();
+    expect(screen.getByRole('searchbox', { name: 'Search location in DEG format' }))
+      .toHaveAccessibleDescription('Search location in DEG format');
+    expect(screen.queryByText('Example: -0.15293, 37.30906')).toBeNull();
   });
 
-  test('does not show an input description if the coordinates representation is a CRS', async () => {
-    store.view.coordinateReferenceSystems.selectedCoordinateRepresentations = [
-      GPS_FORMATS.DEG,
-      GPS_FORMATS.UTM,
-      '5367',
-    ];
-    store.view.coordinateReferenceSystems.storedSystems = [epsg5367];
-    store.view.userPreferences.gpsFormat = '5367';
-    renderGpsInput();
+  test('navigates the list of places with the keyboard', async () => {
+    renderGpsInput({ showTextSearchOption: true });
 
-    expect(screen.getByLabelText('GPS location')).not.toHaveAccessibleDescription();
+    await userEvent.click(screen.getByRole('radio', { name: 'Search by name' }));
+    const gpsInput = screen.getByRole('combobox', { name: 'Search location by name' });
+    await userEvent.type(gpsInput, 'mexico');
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Mexico City - Mexico' })).toBeVisible();
+      expect(screen.getByRole('option', { name: 'Guadalajara - Jalisco, Mexico' })).toBeVisible();
+    });
+
+    const mexicoCityOption = screen.getByRole('option', { name: 'Mexico City - Mexico' });
+    const guadalajaraOption = screen.getByRole('option', { name: 'Guadalajara - Jalisco, Mexico' });
+
+    expect(gpsInput).not.toHaveAttribute('aria-activedescendant');
+    expect(mexicoCityOption).not.toHaveClass('active');
+    expect(guadalajaraOption).not.toHaveClass('active');
+
+    await userEvent.keyboard('[ArrowDown]');
+
+    expect(gpsInput).toHaveAttribute('aria-activedescendant', 'place-from-search-text-option-0');
+    expect(mexicoCityOption).toHaveClass('active');
+    expect(guadalajaraOption).not.toHaveClass('active');
+
+    await userEvent.keyboard('[ArrowDown]');
+
+    expect(gpsInput).toHaveAttribute('aria-activedescendant', 'place-from-search-text-option-1');
+    expect(mexicoCityOption).not.toHaveClass('active');
+    expect(guadalajaraOption).toHaveClass('active');
+
+    await userEvent.keyboard('[ArrowDown]');
+
+    expect(gpsInput).toHaveAttribute('aria-activedescendant', 'place-from-search-text-option-0');
+    expect(mexicoCityOption).toHaveClass('active');
+    expect(guadalajaraOption).not.toHaveClass('active');
+
+    await userEvent.keyboard('[ArrowUp]');
+
+    expect(gpsInput).toHaveAttribute('aria-activedescendant', 'place-from-search-text-option-1');
+    expect(mexicoCityOption).not.toHaveClass('active');
+    expect(guadalajaraOption).toHaveClass('active');
+
+    await userEvent.keyboard('[ArrowUp]');
+
+    expect(gpsInput).toHaveAttribute('aria-activedescendant', 'place-from-search-text-option-0');
+    expect(mexicoCityOption).toHaveClass('active');
+    expect(guadalajaraOption).not.toHaveClass('active');
+  });
+
+  test('selects an option from the list of places by focusing it and pressing enter', async () => {
+    renderGpsInput({ showTextSearchOption: true });
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Search by name' }));
+    const gpsInput = screen.getByRole('combobox', { name: 'Search location by name' });
+    await userEvent.type(gpsInput, 'mexico');
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Mexico City - Mexico' })).toBeVisible();
+      expect(screen.getByRole('option', { name: 'Guadalajara - Jalisco, Mexico' })).toBeVisible();
+    });
+
+    const mexicoCityOption = screen.getByRole('option', { name: 'Mexico City - Mexico' });
+    const guadalajaraOption = screen.getByRole('option', { name: 'Guadalajara - Jalisco, Mexico' });
+
+    expect(mexicoCityOption).toHaveAttribute('aria-selected', 'false');
+    expect(within(mexicoCityOption).queryByTestId('gpsInput-placeFromSearchTextOption-checkLightIcon')).toBeNull();
+    expect(guadalajaraOption).toHaveAttribute('aria-selected', 'false');
+    expect(within(guadalajaraOption).queryByTestId('gpsInput-placeFromSearchTextOption-checkLightIcon')).toBeNull();
+    expect(gpsInput).toHaveValue('mexico');
+    expect(onChange).not.toHaveBeenCalled();
+
+    await userEvent.keyboard('[ArrowDown]');  // Focuses the first option
+    await userEvent.keyboard('[ArrowDown]');  // Focuses the second option
+    await userEvent.keyboard('[Enter]');  // Selects the second option
+
+    expect(mexicoCityOption).toHaveAttribute('aria-selected', 'false');
+    expect(within(mexicoCityOption).queryByTestId('gpsInput-placeFromSearchTextOption-checkLightIcon')).toBeNull();
+    expect(guadalajaraOption).toHaveAttribute('aria-selected', 'true');
+    expect(within(guadalajaraOption).getByTestId('gpsInput-placeFromSearchTextOption-checkLightIcon')).toBeVisible();
+    expect(gpsInput).toHaveValue('Guadalajara - Jalisco, Mexico');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({ latitude: 20.674793, longitude: -103.35941 });
+  });
+
+  test('selects an option from the list of places by clicking it', async () => {
+    renderGpsInput({ showTextSearchOption: true });
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Search by name' }));
+    const gpsInput = screen.getByRole('combobox', { name: 'Search location by name' });
+    await userEvent.type(gpsInput, 'mexico');
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Mexico City - Mexico' })).toBeVisible();
+      expect(screen.getByRole('option', { name: 'Guadalajara - Jalisco, Mexico' })).toBeVisible();
+    });
+
+    const mexicoCityOption = screen.getByRole('option', { name: 'Mexico City - Mexico' });
+    const guadalajaraOption = screen.getByRole('option', { name: 'Guadalajara - Jalisco, Mexico' });
+
+    expect(mexicoCityOption).toHaveAttribute('aria-selected', 'false');
+    expect(within(mexicoCityOption).queryByTestId('gpsInput-placeFromSearchTextOption-checkLightIcon')).toBeNull();
+    expect(guadalajaraOption).toHaveAttribute('aria-selected', 'false');
+    expect(within(guadalajaraOption).queryByTestId('gpsInput-placeFromSearchTextOption-checkLightIcon')).toBeNull();
+    expect(gpsInput).toHaveValue('mexico');
+    expect(onChange).not.toHaveBeenCalled();
+
+    await userEvent.click(guadalajaraOption);
+
+    expect(mexicoCityOption).toHaveAttribute('aria-selected', 'false');
+    expect(within(mexicoCityOption).queryByTestId('gpsInput-placeFromSearchTextOption-checkLightIcon')).toBeNull();
+    expect(guadalajaraOption).toHaveAttribute('aria-selected', 'true');
+    expect(within(guadalajaraOption).getByTestId('gpsInput-placeFromSearchTextOption-checkLightIcon')).toBeVisible();
+    expect(gpsInput).toHaveValue('Guadalajara - Jalisco, Mexico');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({ latitude: 20.674793, longitude: -103.35941 });
+  });
+
+  test('fills the displayed value with the selecte place when the user checks the text search option if there was a selected one', async () => {
+    const { rerender } = renderGpsInput({ showTextSearchOption: true });
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Search by name' }));
+    const gpsInput = screen.getByRole('combobox', { name: 'Search location by name' });
+    await userEvent.type(gpsInput, 'mexico');
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Mexico City - Mexico' })).toBeVisible();
+      expect(screen.getByRole('option', { name: 'Guadalajara - Jalisco, Mexico' })).toBeVisible();
+    });
+
+    await userEvent.click(screen.getByRole('option', { name: 'Guadalajara - Jalisco, Mexico' }));
+
+    expect(gpsInput).toHaveValue('Guadalajara - Jalisco, Mexico');
+
+    rerender(<Provider store={mockStore(store)}>
+      <GpsInput
+        id="gpsInput"
+        onChange={onChange}
+        showTextSearchOption
+        value={{
+          latitude: 20.674793,
+          longitude: -103.359410,
+        }}
+      />
+    </Provider>);
+    await userEvent.click(screen.getByRole('radio', { name: 'DEG' }));
+
+    expect(gpsInput).toHaveValue('20.674793°, -103.359410°');
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Search by name' }));
+
+    expect(gpsInput).toHaveValue('Guadalajara - Jalisco, Mexico');
   });
 });

--- a/src/GpsInput/index.test.js
+++ b/src/GpsInput/index.test.js
@@ -505,6 +505,23 @@ describe('GpsInput', () => {
     expect(onChange).toHaveBeenCalledWith({ latitude: 20.674793, longitude: -103.35941 });
   });
 
+  test('notifies when there is a place selection', async () => {
+    const onPlaceSelected = jest.fn();
+    renderGpsInput({ onPlaceSelected, showTextSearchOption: true });
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Search by name' }));
+    const gpsInput = screen.getByRole('combobox', { name: 'Search location by name' });
+    await userEvent.type(gpsInput, 'mexico');
+
+    expect(onPlaceSelected).not.toHaveBeenCalled();
+
+    await waitFor(async () => {
+      await userEvent.click(screen.getByRole('option', { name: 'Guadalajara - Jalisco, Mexico' }));
+    });
+
+    expect(onPlaceSelected).toHaveBeenCalledTimes(1);
+  });
+
   test('fills the displayed value with the selecte place when the user checks the text search option if there was a selected one', async () => {
     const { rerender } = renderGpsInput({ showTextSearchOption: true });
 

--- a/src/GpsInput/styles.module.scss
+++ b/src/GpsInput/styles.module.scss
@@ -7,20 +7,35 @@
   margin-top: 0.5rem;
 
   .input {
-    height: 2.5rem;
+    border: 1px solid colors.$secondary-light-gray;
+    border-radius: 0.25rem;
+    outline: none;
     padding: 0.25rem 0.5rem;
     width: 100%;
 
-    &:focus {
-      border: 2px solid colors.$bright-blue;
+    &:hover {
+      border: 1px solid colors.$off-black;
+    }
+
+    &:focus-visible {
+      border-color: colors.$bright-blue;
+      outline: 1px solid colors.$bright-blue;
     }
 
     &[aria-invalid="true"] {
-      border: 1px solid colors.$bright-red;
+      border-color: colors.$bright-red;
+      outline: 1px solid colors.$bright-red;
 
       &::placeholder {
         color: color.adjust(colors.$bright-red, $lightness: 33%);
       }
+    }
+
+    &::-webkit-search-decoration,
+    &::-webkit-search-cancel-button,
+    &::-webkit-search-results-button,
+    &::-webkit-search-results-decoration {
+      -webkit-appearance: none;
     }
   }
 }
@@ -29,9 +44,57 @@
   color: colors.$alt-light-gray;
   font-size: 0.75rem;
   font-weight: 400;
-  margin: 0.125rem 0;
+  margin: 0.125rem 0 0;
 
   &.error {
     color: colors.$bright-red;
+  }
+}
+
+.placesFromSearchTextList {
+  margin: 0.25rem 0;
+
+  .placeFromSearchTextOption {
+    align-items: center;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    display: flex;
+    padding: 0.25rem 0.5rem;
+    padding-left: 1.75rem;
+
+    &:hover, &.active {
+      background-color: colors.$semi-light-gray;
+    }
+  
+    &[aria-selected=true] {
+      background-color: colors.$very-light-blue;
+      padding-left: 0.5rem;
+
+      &:hover, &.active {
+        background-color: color.adjust(colors.$very-light-blue, $lightness: -5%);
+      }
+    }
+
+    .checkLightIcon {
+      color: colors.$bright-blue;
+      margin-right: 0.5rem;
+      width: 0.75rem;
+    }
+
+    .labelWrapper {
+      font-size: 0.75rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      .placeFormatted {
+        color: colors.$secondary-medium-gray;
+        display: block;
+        font-size: 0.75rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
   }
 }

--- a/src/ImageModal/index.js
+++ b/src/ImageModal/index.js
@@ -51,9 +51,9 @@ const ImageModal = ({ id, src, title, url, tracker }) => {
       }
     };
 
-    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('pointerdown', handleClickOutside);
 
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('pointerdown', handleClickOutside);
   }, [dispatch, id, tracker]);
 
   return <>

--- a/src/LocationPicker/MenuPopover/index.js
+++ b/src/LocationPicker/MenuPopover/index.js
@@ -115,10 +115,10 @@ const MenuPopover = ({
   }, [isPickingLocation]);
 
   useEffect(() => {
-    // Add a mouse down event to close the menu if the user clicks outside only if the user is not picking a location
+    // Add a pointer down event to close the menu if the user clicks outside only if the user is not picking a location
     // from the map.
     if (!isPickingLocation) {
-      const onMouseDown = (event) => {
+      const onPointerDown = (event) => {
         if (!wrapperRef.current.contains(event.target) && !setLocationButtonRef.current.contains(event.target)) {
           onClose(event);
 
@@ -142,9 +142,9 @@ const MenuPopover = ({
         }
       };
 
-      document.addEventListener('mousedown', onMouseDown);
+      document.addEventListener('pointerdown', onPointerDown);
 
-      return () => document.removeEventListener('mousedown', onMouseDown);
+      return () => document.removeEventListener('pointerdown', onPointerDown);
     }
   }, [isPickingLocation, onBlur, onClose, setLocationButtonRef, target]);
 

--- a/src/LocationPicker/MenuPopover/index.test.js
+++ b/src/LocationPicker/MenuPopover/index.test.js
@@ -124,35 +124,35 @@ describe('LocationPicker - MenuPopover', () => {
     expect(menuPopover).toHaveStyle('width: 380px;');
   });
 
-  test('changes the location when the user types in the GPS input', async () => {
+  test('changes the location when the user types in the search input', async () => {
     renderMenuPopover();
 
     expect(onChange).not.toHaveBeenCalled();
 
-    await userEvent.type(screen.getByLabelText('GPS location'), '10,10');
+    await userEvent.type(screen.getByRole('searchbox', { name: 'Search location in DEG format' }), '10,10');
 
     expect(onChange).toHaveBeenCalledTimes(2);
     expect(onChange).toHaveBeenCalledWith({ latitude: 10, longitude: 10 });
   });
 
-  test('closes the menu and focuses the set location button if the user presses enter while focusing the GPS input', async () => {
+  test('closes the menu and focuses the set location button if the user presses enter while focusing the search input', async () => {
     renderMenuPopover();
 
     expect(onClose).not.toHaveBeenCalled();
     expect(setLocationButtonRefFocus).not.toHaveBeenCalled();
 
-    await userEvent.type(screen.getByLabelText('GPS location'), '10,10');
+    await userEvent.type(screen.getByRole('searchbox', { name: 'Search location in DEG format' }), '10,10');
     await userEvent.keyboard('{Enter}');
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(setLocationButtonRefFocus).toHaveBeenCalledTimes(1);
   });
 
-  test('does neither close the menu nor focuse the set location button if the user presses enter while picking a location', async () => {
+  test('does neither close the menu nor focuses the set location button if the user presses enter while picking a location', async () => {
     store.view.mapLocationSelection.isPickingLocation = true;
     renderMenuPopover();
 
-    await userEvent.type(screen.getByLabelText('GPS location'), '10,10');
+    await userEvent.type(screen.getByRole('searchbox', { name: 'Search location in DEG format' }), '10,10');
     await userEvent.keyboard('{Enter}');
 
     expect(onClose).not.toHaveBeenCalled();
@@ -165,7 +165,7 @@ describe('LocationPicker - MenuPopover', () => {
     expect(onClose).not.toHaveBeenCalled();
     expect(setLocationButtonRefFocus).not.toHaveBeenCalled();
 
-    await userEvent.type(screen.getByLabelText('GPS location'), '10,10');
+    await userEvent.type(screen.getByRole('searchbox', { name: 'Search location in DEG format' }), '10,10');
     await userEvent.keyboard('{Escape}');
 
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -176,7 +176,7 @@ describe('LocationPicker - MenuPopover', () => {
     store.view.mapLocationSelection.isPickingLocation = true;
     renderMenuPopover();
 
-    await userEvent.type(screen.getByLabelText('GPS location'), '10,10');
+    await userEvent.type(screen.getByRole('searchbox', { name: 'Search location in DEG format' }), '10,10');
     await userEvent.keyboard('{Escape}');
 
     expect(onClose).not.toHaveBeenCalled();

--- a/src/ReportManager/DetailsSection/AreaSelectorInput/index.js
+++ b/src/ReportManager/DetailsSection/AreaSelectorInput/index.js
@@ -136,9 +136,9 @@ const AreaSelectorInput = ({ event, onGeometryChange = null, originalEvent = nul
       }
     };
 
-    document.addEventListener('mousedown', handleOutsideClick);
+    document.addEventListener('pointerdown', handleOutsideClick);
 
-    return () => document.removeEventListener('mousedown', handleOutsideClick);
+    return () => document.removeEventListener('pointerdown', handleOutsideClick);
   }, []);
 
   return <label

--- a/src/ReportManager/DetailsSection/SchemaForm/fields/Location/index.test.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/fields/Location/index.test.js
@@ -146,7 +146,7 @@ describe('ReportManager - DetailsSection - SchemaForm - fields - Location', () =
     renderLocationField();
 
     await userEvent.click(screen.getByLabelText('Open the location picker menu to set a value'));
-    await userEvent.type(screen.getByLabelText('GPS location'), '10,10');
+    await userEvent.type(screen.getByRole('searchbox', { name: 'Search location in DEG format' }), '10,10');
 
     expect(onFieldChange).toHaveBeenCalledTimes(2);
     expect(onFieldChange).toHaveBeenCalledWith('location-1', { latitude: 10, longitude: 10 });

--- a/src/TimePicker/OptionsPopover/index.js
+++ b/src/TimePicker/OptionsPopover/index.js
@@ -208,13 +208,13 @@ const OptionsPopover = ({
   }, [options, selectedOptionIndex]);
 
   useEffect(() => {
-    const onMouseDown = (event) => !listRef.current.contains(event.target)
+    const onPointerDown = (event) => !listRef.current.contains(event.target)
       && !optionsPopoverButtonRef.current.contains(event.target)
       && onClose();
 
-    document.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('pointerdown', onPointerDown);
 
-    return () => document.removeEventListener('mousedown', onMouseDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
   }, [onClose, optionsPopoverButtonRef]);
 
   return <Popover

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,7 +7,7 @@ import LocalStorageBackend from 'i18next-localstorage-backend';
 
 import { SUPPORTED_LANGUAGES } from './constants';
 
-const I18N_FILES_VERSION = '1.23';
+const I18N_FILES_VERSION = '1.24';
 
 const preloadNamespaces = [
   'components',

--- a/src/utils/location/index.js
+++ b/src/utils/location/index.js
@@ -1,9 +1,12 @@
+import axios from 'axios';
 import { bearing } from '@turf/turf';
 import Dms from 'geodesy/dms';
 import Utm, { LatLon as LatLonUtm } from 'geodesy/utm';
 import Mgrs, { LatLon as LatLonMgrs } from 'geodesy/mgrs';
 import LatLon from 'geodesy/latlon-ellipsoidal-vincenty';
 import proj4 from 'proj4';
+
+import { REACT_APP_MAPBOX_TOKEN } from '../../constants';
 
 const MAX_WRAPPED_LONGITUDE_ABSOLUTE_VALUE = 180;
 const LOCATION_AXIS_DECIMAL_PRECISION = 6;
@@ -288,4 +291,17 @@ export const getProj4CompatibleCRS = async () => {
   }
 
   return proj4CompatibleCRSSingleton;
+};
+
+export const fetchForwardGeocoding = async (searchText) => {
+  const response = await axios.get('https://api.mapbox.com/search/geocode/v6/forward', {
+    params: {
+      q: searchText,
+      access_token: REACT_APP_MAPBOX_TOKEN,
+    },
+  });
+
+  // Mapbox returns a FeatureCollection with a feature for each place that
+  // matched the search text. We just want their properties.
+  return response.data.features.map((feature) => feature.properties);
 };

--- a/src/utils/location/index.js
+++ b/src/utils/location/index.js
@@ -8,6 +8,8 @@ import proj4 from 'proj4';
 
 import { REACT_APP_MAPBOX_TOKEN } from '../../constants';
 
+const MAPBOX_FORWARD_GEOCODING_ENDPOINT = 'https://api.mapbox.com/search/geocode/v6/forward';
+
 const MAX_WRAPPED_LONGITUDE_ABSOLUTE_VALUE = 180;
 const LOCATION_AXIS_DECIMAL_PRECISION = 6;
 const PROJ4_REQUIRES_GRID_SHIFT_FILES_REGEX = /\+nadgrids=(?!@null)[^\s]+/;
@@ -294,10 +296,10 @@ export const getProj4CompatibleCRS = async () => {
 };
 
 export const fetchForwardGeocoding = async (searchText) => {
-  const response = await axios.get('https://api.mapbox.com/search/geocode/v6/forward', {
+  const response = await axios.get(MAPBOX_FORWARD_GEOCODING_ENDPOINT, {
     params: {
-      q: searchText,
       access_token: REACT_APP_MAPBOX_TOKEN,
+      q: searchText,
     },
   });
 

--- a/src/utils/location/index.test.js
+++ b/src/utils/location/index.test.js
@@ -1,4 +1,7 @@
+import axios from 'axios';
+
 import {
+  fetchForwardGeocoding,
   getProj4CompatibleCRS,
   GPS_FORMATS,
   OUTSIDE_BBOX,
@@ -6,6 +9,8 @@ import {
   stringifyCoordinates,
   validateLocation,
 } from './';
+
+jest.mock('axios');
 
 describe('Utils - location', () => {
   let proj4CompatibleCRSByCode;
@@ -320,6 +325,26 @@ describe('Utils - location', () => {
       expect(validateLocation({ lng: -112.3835 })).toBe(false);
       expect(validateLocation({ lat: 91, lng: 0 })).toBe(false);
       expect(validateLocation({ lat: -91, lng: 0 })).toBe(false);
+    });
+  });
+
+  describe('fetchForwardGeocoding', () => {
+    it('returns an array of places that match the forward geocoding search text', async () => {
+      axios.get.mockResolvedValue({
+        data: {
+          features: [
+            { properties: { name: 'Mexico City', country: 'MX' } },
+            { properties: { name: 'Guadalajara', country: 'MX' } },
+          ],
+        },
+      });
+
+      const places = await fetchForwardGeocoding('mexico');
+
+      expect(places).toEqual([
+        { name: 'Mexico City', country: 'MX' },
+        { name: 'Guadalajara', country: 'MX' },
+      ]);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Adds support to search a location by text in the GpsInput component.

### How does it look
<img width="1920" height="991" alt="image" src="https://github.com/user-attachments/assets/55e22bd4-aad1-47e3-884e-7ced1a256b8c" />


### Relevant link(s)
* [ERA-11795](https://allenai.atlassian.net/browse/ERA-11795)
* [Env](https://era-11795.dev.pamdas.org)

### Where / how to start reviewing (optional)
I'd suggest to review this files in order:
1- `src/utils/location/index.js`
2- `src/GpsInput/index.js` and its styles.
3-`src/GpsFormatToggle/index.js` and its styles.

The rest of the files will be way easier to understand once you fully got the changes done in those two.

### Any background context you want to provide(if applicable)
As suggested in the ticket, I'm using [Mapbox Forward Geocoding endpoint](https://docs.mapbox.com/api/search/geocoding/#forward-geocoding-with-search-text-input) to fetch the locations results, and I created a utility to fetch the locations asynchronously and sanitize the response.

From there, I just added the logic to run the search in our existing `GpsInput` component, making sure the input remains totally accessible as a [combobox](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role).

The changes in `GpsFormatToggle` are a bit tricky since previously, all the `radiogroup` of that component was controlled through our `gpsFormat` store variable, but now the text search option isn't. That one will be controlled by the parent (which is `GpsInput`) and the code conciliates these two sources (store and parent props) to control the `radiogroup` as a whole, keeping it accessible and semantically correct.


[ERA-11795]: https://allenai.atlassian.net/browse/ERA-11795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ