### PR TITLE
Add automated cleanup for stale PR environments

### DIFF
--- a/.github/workflows/cleanup-stale-pr-envs.yml
+++ b/.github/workflows/cleanup-stale-pr-envs.yml
@@ -1,0 +1,9 @@
+name: Cleanup Stale PR Environments
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    uses: PADAS/.github/.github/workflows/pipeline-cleanup-stale-pr-envs.yml@main


### PR DESCRIPTION
### What does this PR do?
- Implements automated cleanup of stale PR environments to reduce infrastructure costs and prevent resource waste.

### How does it look
Automatically manages PR environment lifecycle:
- Marks environments as stale after 14 days of inactivity
- Grace period of 3 days before teardown
- Removes `deploy` label → Flux tears down namespace
- Supports `keep-alive` label for permanent exemption

### Relevant link(s)
[DASOPS-1707](https://allenai.atlassian.net/browse/DASOPS-1707)

### Where / how to start reviewing (optional)
- https://github.com/PADAS/.github/blob/main/.github/workflows/pipeline-cleanup-stale-pr-envs.yml


[DASOPS-1707]: https://allenai.atlassian.net/browse/DASOPS-1707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ