### PR TITLE
ERA-12053: Handle schema rendering errors (event details)

### DIFF
--- a/public/locales/en-US/reports.json
+++ b/public/locales/en-US/reports.json
@@ -141,6 +141,7 @@
       },
       "dateLabel": "Event Date",
       "detailsHeader": "Details",
+      "errorLoadingSchema": "Error loading schema",
       "locationLabel": "Event Location",
       "priorityLabel": "Priority",
       "reportedByLabel": "Reported By",

--- a/public/locales/es/reports.json
+++ b/public/locales/es/reports.json
@@ -130,6 +130,7 @@
       },
       "dateLabel": "Fecha del Evento",
       "detailsHeader": "Detalles",
+      "errorLoadingSchema": "Error cargando esquema",
       "locationLabel": "Ubicación del evento",
       "priorityLabel": "Prioridad",
       "reportedByLabel": "Reportado por",

--- a/public/locales/fr/reports.json
+++ b/public/locales/fr/reports.json
@@ -130,6 +130,7 @@
       },
       "dateLabel": "Date de l'Événement",
       "detailsHeader": "Détails",
+      "errorLoadingSchema": "Erreur lors du chargement du schéma",
       "locationLabel": "Emplacement",
       "priorityLabel": "Priorité",
       "reportedByLabel": "Complété Par",

--- a/public/locales/ne-NP/reports.json
+++ b/public/locales/ne-NP/reports.json
@@ -138,6 +138,7 @@
             },
             "dateLabel": "घटनाको मिति",
             "detailsHeader": "विवरण",
+            "errorLoadingSchema": "स्किमा लोड गर्दा त्रुटि",
             "locationLabel": "घटनाको लोकेसन",
             "priorityLabel": "प्राथमिकता",
             "reportedByLabel": "द्वारा रिपार्ट गरिएको",

--- a/public/locales/pt/reports.json
+++ b/public/locales/pt/reports.json
@@ -130,6 +130,7 @@
             },
             "dateLabel": "Data do evento",
             "detailsHeader": "Detalhes",
+            "errorLoadingSchema": "Erro ao carregar esquema",
             "locationLabel": "Localização do evento",
             "priorityLabel": "Prioridade",
             "reportedByLabel": "Reportado por",

--- a/public/locales/sw/reports.json
+++ b/public/locales/sw/reports.json
@@ -141,6 +141,7 @@
       },
       "dateLabel": "Tarehe ya Tukio",
       "detailsHeader": "Maelezo",
+      "errorLoadingSchema": "Hitilafu wakati wa kupakia muundo",
       "locationLabel": "Mahali pa Tukio",
       "priorityLabel": "Kipaumbele",
       "reportedByLabel": "Iliripotiwa Na",

--- a/src/ReportManager/DetailsSection/index.js
+++ b/src/ReportManager/DetailsSection/index.js
@@ -302,11 +302,13 @@ const DetailsSection = ({
       role="alert"
       aria-live="polite"
     >
-      <strong>{t('errorLoadingSchema')}</strong>
+      <p>
+        <strong>{t('errorLoadingSchema')}</strong>
 
-      {eventSchema?.response?.data?.status?.detail && <span>
-        {eventSchema.response.data.status.detail}
-      </span>}
+        {eventSchema?.response?.data?.status?.detail && <span className={styles.errorDetail}>
+          {eventSchema.response.data.status.detail}
+        </span>}
+      </p>
     </div>}
   </div>;
 };

--- a/src/ReportManager/DetailsSection/index.js
+++ b/src/ReportManager/DetailsSection/index.js
@@ -299,13 +299,13 @@ const DetailsSection = ({
 
     {eventSchema instanceof Error && <div
       aria-live="polite"
-      className={styles.errorMessage}
+      className={styles.errorMessageWrapper}
       role="alert"
     >
-      <p>
+      <p className={styles.errorMessage}>
         <strong>{t('errorLoadingSchema')}</strong>
 
-        {eventSchema?.response?.data?.status?.detail && <span className={styles.errorDetail}>
+        {eventSchema?.response?.data?.status?.detail && <span>
           {eventSchema.response.data.status.detail}
         </span>}
       </p>

--- a/src/ReportManager/DetailsSection/index.js
+++ b/src/ReportManager/DetailsSection/index.js
@@ -50,7 +50,6 @@ const DetailsSection = ({
   isBehindAddedEvent,
   isCollection,
   isNewEvent,
-  loadingSchema,
   onFormDataChange,
   onFormError,
   onFormSubmit,
@@ -61,7 +60,6 @@ const DetailsSection = ({
   onReportGeometryChange,
   onReportLocationChange,
   onReportStateChange,
-  originalReport,
   ref,
   reportForm,
   submitFormButtonRef,
@@ -69,6 +67,7 @@ const DetailsSection = ({
   const { t } = useTranslation('reports', { keyPrefix: 'reportManager.detailsSection' });
 
   const eventType = useSelector((state) => reportForm?.event_type ? selectEventTypeByValue(state, reportForm.event_type) : null);
+  const loadingEventSchemas = useSelector((state) => state.data.eventSchemas.loading);
 
   const reportTracker = useContext(TrackerContext);
 
@@ -290,12 +289,24 @@ const DetailsSection = ({
       schema={eventSchema}
     />}
 
-    {!eventSchema && !reportForm.is_collection && loadingSchema && <div className={styles.loaderWrapper}>
+    {!eventSchema && !reportForm.is_collection && loadingEventSchemas && <div className={styles.loaderWrapper}>
       <MoonLoader
         color={LOADER_COLOR}
         data-testid="reportManager-detailsSection-loader"
         size={LOADER_SIZE}
       />
+    </div>}
+
+    {eventSchema instanceof Error && <div
+      className={styles.errorMessage}
+      role="alert"
+      aria-live="polite"
+    >
+      <strong>{t('errorLoadingSchema')}</strong>
+
+      {eventSchema?.response?.data?.status?.detail && <span>
+        {eventSchema.response.data.status.detail}
+      </span>}
     </div>}
   </div>;
 };

--- a/src/ReportManager/DetailsSection/index.js
+++ b/src/ReportManager/DetailsSection/index.js
@@ -298,9 +298,9 @@ const DetailsSection = ({
     </div>}
 
     {eventSchema instanceof Error && <div
+      aria-live="polite"
       className={styles.errorMessage}
       role="alert"
-      aria-live="polite"
     >
       <p>
         <strong>{t('errorLoadingSchema')}</strong>

--- a/src/ReportManager/DetailsSection/index.test.js
+++ b/src/ReportManager/DetailsSection/index.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AxiosError } from 'axios';
 import { Provider } from 'react-redux';
 import userEvent from '@testing-library/user-event';
 
@@ -63,7 +64,10 @@ describe('ReportManager - DetailsSection', () => {
         eventStore: {},
         eventTypes,
         patrolTypes,
-        eventSchemas,
+        eventSchemas: {
+          ...eventSchemas,
+          loading: false,
+        },
       },
       view: {
         coordinateReferenceSystems: {
@@ -97,7 +101,6 @@ describe('ReportManager - DetailsSection', () => {
               isBehindAddedEvent={false}
               isCollection={false}
               isNewEvent={false}
-              loadingSchema={false}
               onFormDataChange={onFormDataChange}
               onFormError={onFormError}
               onFormSubmit={onFormSubmit}
@@ -108,7 +111,6 @@ describe('ReportManager - DetailsSection', () => {
               onReportGeometryChange={onReportGeometryChange}
               onReportLocationChange={onReportLocationChange}
               onReportStateChange={onReportStateChange}
-              originalReport={report}
               reportForm={report}
               submitFormButtonRef={submitFormButtonRef}
               {...props}
@@ -502,9 +504,48 @@ describe('ReportManager - DetailsSection', () => {
     expect(onFormSubmit).toHaveBeenCalledTimes(1);
   });
 
+  test('does not show the loader if the schema is loaded', async () => {
+    renderDetailsSection();
+
+    expect(screen.queryByTestId('reportManager-detailsSection-loader')).toBeNull();
+  });
+
   test('shows a loader while the schema loads', async () => {
-    renderDetailsSection({ eventSchema: null, loadingSchema: true });
+    store.data.eventSchemas.loading = true;
+    renderDetailsSection({ eventSchema: null });
 
     expect(screen.getByTestId('reportManager-detailsSection-loader')).toBeVisible();
+  });
+
+  test('does not show an error message if the schema is loaded correctly', async () => {
+    renderDetailsSection();
+
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  test('shows an error message if the schema is erroneous', async () => {
+    renderDetailsSection({ eventSchema: new Error('Error loading schema') });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Error loading schema');
+  });
+
+  test('shows an error message with the detail of the error if the schema is erroneous', async () => {
+    renderDetailsSection({
+      eventSchema: new AxiosError(
+        'Request failed with status code 500',
+        'ERR_BAD_RESPONSE',
+        {},
+        {},
+        {
+          data: {
+            status: {
+              detail: 'Error detail',
+            },
+          },
+        },
+      ),
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Error loading schemaError detail');
   });
 });

--- a/src/ReportManager/DetailsSection/styles.module.scss
+++ b/src/ReportManager/DetailsSection/styles.module.scss
@@ -204,3 +204,11 @@
   margin: 1rem;
   width: 100%;
 }
+
+.errorMessage {
+  color: $bright-red;
+  display: flex;
+  flex-direction: column;
+  font-size: 0.875rem;
+  margin: 1rem 0.5rem;
+}

--- a/src/ReportManager/DetailsSection/styles.module.scss
+++ b/src/ReportManager/DetailsSection/styles.module.scss
@@ -205,10 +205,14 @@
   width: 100%;
 }
 
-.errorMessage {
-  color: $bright-red;
-  display: flex;
-  flex-direction: column;
-  font-size: 0.875rem;
+.errorMessageWrapper {
   margin: 1rem 0.5rem;
+
+  .errorMessage {
+    color: $bright-red;
+    display: flex;
+    flex-direction: column;
+    font-size: 0.875rem;
+    margin: 0;
+  }
 }

--- a/src/ReportManager/ReportDetailView/index.js
+++ b/src/ReportManager/ReportDetailView/index.js
@@ -124,7 +124,6 @@ const ReportDetailView = ({
   const reportTracker = useContext(TrackerContext);
   const { setScrollPosition } = useContext(SidebarScrollContext);
 
-  const loadingEventSchemas = useSelector((state) => state.data.eventSchemas.loading);
   const eventStore = useSelector((state) => state.data.eventStore);
   const patrolStore = useSelector((state) => state.data.patrolStore);
   const eventType = useSelector((state) => {
@@ -171,7 +170,6 @@ const ReportDetailView = ({
   const isActive = isReportActive(originalReport);
   const isCollection = !!reportForm?.is_collection;
   const isCollectionChild = eventBelongsToCollection(reportForm);
-  const isLoadingSchemas = (!!reportForm && !eventSchema) || !!loadingEventSchemas;
   const isPatrolAddedReport = formProps?.hasOwnProperty('isPatrolReport') && formProps.isPatrolReport;
   const belongsToPatrol = eventBelongsToPatrol(reportForm);
 
@@ -792,7 +790,6 @@ const ReportDetailView = ({
                 isBehindAddedEvent={isBehindAddedEvent}
                 isCollection={isCollection}
                 isNewEvent={isNewReport}
-                loadingSchema={isLoadingSchemas}
                 onFormDataChange={onFormDataChange}
                 onFormError={onFormError}
                 onFormSubmit={onFormSubmit}
@@ -803,7 +800,6 @@ const ReportDetailView = ({
                 onReportGeometryChange={onReportGeometryChange}
                 onReportLocationChange={onReportLocationChange}
                 onReportStateChange={onReportStateChange}
-                originalReport={originalReport}
                 reportForm={reportForm}
                 submitFormButtonRef={submitFormButtonRef}
                 formValidator={formValidator}

--- a/src/ducks/event-schemas/index.js
+++ b/src/ducks/event-schemas/index.js
@@ -126,7 +126,7 @@ const eventSchemasReducer = (state, action) => {
       loading: false,
       [action.payload.eventTypeValue]: {
         ...state[action.payload.eventTypeValue],
-        [action.payload.eventId]: action.payload.error,
+        [action.payload.eventId || 'base']: action.payload.error,
       },
     };
 

--- a/src/ducks/event-schemas/index.test.js
+++ b/src/ducks/event-schemas/index.test.js
@@ -136,6 +136,19 @@ describe('Ducks - Event schemas', () => {
       expect(eventSchemasReducer(INITIAL_STATE, action)).toEqual(expectedState);
     });
 
+    test('handles a FETCH_EVENT_TYPE_SCHEMA_FAILURE action with a base schema', async () => {
+      const payload = { error: 'Error', eventTypeValue: 'snare_rep' };
+      const action = { payload, type: FETCH_EVENT_TYPE_SCHEMA_FAILURE };
+      const expectedState = {
+        loading: false,
+        snare_rep: {
+          base: 'Error',
+        },
+      };
+
+      expect(eventSchemasReducer(INITIAL_STATE, action)).toEqual(expectedState);
+    });
+
     test('handles a FETCH_EVENT_TYPE_SCHEMA_V1_SUCCESS action', async () => {
       const payload = {
         definition: {},

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,7 +7,7 @@ import LocalStorageBackend from 'i18next-localstorage-backend';
 
 import { SUPPORTED_LANGUAGES } from './constants';
 
-const I18N_FILES_VERSION = '1.26';
+const I18N_FILES_VERSION = '1.27';
 
 const preloadNamespaces = [
   'components',


### PR DESCRIPTION
### What does this PR do?
Fix the event schema loading spinner logic and add an error message if the schema request fails.

### How does it look
<img width="1920" height="992" alt="image" src="https://github.com/user-attachments/assets/51bfcacc-35ff-4c71-a841-524c3b8b9662" />


### Relevant link(s)
* [ERA-12053](ERA-12053)
* [Env](https://era-12053.dev.pamdas.org)

### Notes
Since there weren't any designs for this task, I added a simple error message. Notice that the second part of the error message is a string that comes from the backend response, so it won't be translated with our i18n files.


[ERA-12053]: https://allenai.atlassian.net/browse/ERA-12053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ