### PR TITLE
ERA-12138: Fix extra click navigating between two popup-capable items on the map

### DIFF
--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -431,19 +431,11 @@ const Map = ({ children, onMapLoad, socket }) => {
   }, [fetchMapData]);
 
   // Helper function to check if a feature should keep the popup open
-  const isPopupReplacementFeature = useCallback((feature) => {
-    const { layer } = feature;
-
-    if (layer.id.includes(LAYER_IDS.TRACK_TIMEPOINTS)) {
-      return true;
-    }
-
-    if ([SYMBOLS_LAYER_ID, LINES_LAYER_ID, POLYGONS_LAYER_ID, POLYGONS_OUTLINE_LAYER_ID].includes(layer.id)) {
-      return true;
-    }
-
-    return false;
-  }, []);
+  const doesFeatureOpenPopup = useCallback(
+    (feature) => feature.layer.id.includes(LAYER_IDS.TRACK_TIMEPOINTS)
+       || [SYMBOLS_LAYER_ID, LINES_LAYER_ID, POLYGONS_LAYER_ID, POLYGONS_OUTLINE_LAYER_ID].includes(feature.layer.id),
+    []
+  );
 
   const onMapClick = useMemo(() => withLocationPickerState((event) => {
     event.preventDefault();
@@ -470,8 +462,7 @@ const Map = ({ children, onMapLoad, socket }) => {
     }
 
     // Determine if we should hide the existing popup
-    const hasPopupReplacementFeature = featuresAtPoint.some(isPopupReplacementFeature);
-    const shouldHidePopup = !hasClusters && !hasPopupReplacementFeature;
+    const shouldHidePopup = !hasClusters && !featuresAtPoint.some(doesFeatureOpenPopup);
 
     // Handle popup visibility
     if (popup) {
@@ -491,7 +482,7 @@ const Map = ({ children, onMapLoad, socket }) => {
     handleMultiFeaturesAtSameLocationClick,
     hidePopup,
     hideUnpinnedTrackLayers,
-    isPopupReplacementFeature,
+    doesFeatureOpenPopup,
     map,
     popup,
     withLocationPickerState,

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -67,12 +67,11 @@ import MessageBadgeLayer from '../MessageBadgeLayer';
 import MapImagesLayer from '../MapImagesLayer';
 import SleepDetector from '../SleepDetector';
 import ClustersLayer from '../ClustersLayer';
-import {
+import SpatialFeaturesLayer, {
   SYMBOLS_LAYER_ID,
   LINES_LAYER_ID,
   POLYGONS_LAYER_ID,
   POLYGONS_OUTLINE_LAYER_ID,
-  SpatialFeaturesLayer,
 } from '../SpatialFeaturesLayer';
 
 
@@ -457,7 +456,7 @@ const Map = ({ children, onMapLoad, socket }) => {
 
     // Check if clicking on a timepoint (track layer point) - don't hide popup so it can be replaced
     const timepointAtClick = map.queryRenderedFeatures(event.point)
-      .find((item) => item.layer.id.includes(LAYER_IDS.TRACK_TIMEPOINTS_SYMBOLS));
+      .find((item) => item.layer.id.includes(LAYER_IDS.TRACK_TIMEPOINTS));
     if (timepointAtClick) {
       shouldHidePopup = false;
     }

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -67,7 +67,14 @@ import MessageBadgeLayer from '../MessageBadgeLayer';
 import MapImagesLayer from '../MapImagesLayer';
 import SleepDetector from '../SleepDetector';
 import ClustersLayer from '../ClustersLayer';
-import SpatialFeaturesLayer from '../SpatialFeaturesLayer';
+import {
+  SYMBOLS_LAYER_ID,
+  LINES_LAYER_ID,
+  POLYGONS_LAYER_ID,
+  POLYGONS_OUTLINE_LAYER_ID,
+  SpatialFeaturesLayer,
+} from '../SpatialFeaturesLayer';
+
 
 import AddItemButton from '../AddItemButton';
 import MapRulerControl from '../MapRulerControl';
@@ -445,6 +452,25 @@ const Map = ({ children, onMapLoad, socket }) => {
 
     if (clickedLayersOfInterest.length > 1) {
       handleMultiFeaturesAtSameLocationClick(event, clickedLayersOfInterest);
+      shouldHidePopup = false;
+    }
+
+    // Check if clicking on a timepoint (track layer point) - don't hide popup so it can be replaced
+    const timepointAtClick = map.queryRenderedFeatures(event.point)
+      .find((item) => item.layer.id.includes(LAYER_IDS.TRACK_TIMEPOINTS_SYMBOLS));
+    if (timepointAtClick) {
+      shouldHidePopup = false;
+    }
+
+    // Check if clicking on a spatial feature (symbol, line, or polygon) - don't hide popup so it can be replaced
+    const spatialFeatureAtClick = map.queryRenderedFeatures(event.point)
+      .find((item) => [
+        SYMBOLS_LAYER_ID,
+        LINES_LAYER_ID,
+        POLYGONS_LAYER_ID,
+        POLYGONS_OUTLINE_LAYER_ID
+      ].includes(item.layer.id));
+    if (spatialFeatureAtClick) {
       shouldHidePopup = false;
     }
 

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -430,61 +430,72 @@ const Map = ({ children, onMapLoad, socket }) => {
     fetchMapData();
   }, [fetchMapData]);
 
+  // Helper function to check if a feature should keep the popup open
+  const isPopupReplacementFeature = useCallback((feature) => {
+    const { layer } = feature;
+
+    if (layer.id.includes(LAYER_IDS.TRACK_TIMEPOINTS)) {
+      return true;
+    }
+
+    if ([SYMBOLS_LAYER_ID, LINES_LAYER_ID, POLYGONS_LAYER_ID, POLYGONS_OUTLINE_LAYER_ID].includes(layer.id)) {
+      return true;
+    }
+
+    return false;
+  }, []);
+
   const onMapClick = useMemo(() => withLocationPickerState((event) => {
     event.preventDefault();
     event.originalEvent.stopPropagation();
 
+    // Query features once for performance
+    const featuresAtPoint = map.queryRenderedFeatures(event.point);
     const clickedLayersOfInterest = queryMultiLayerClickFeatures(map, event);
 
-    let shouldHidePopup = true;
-
+    // Check for clusters
     const clusterApproxGeometry = [
       [event.point.x - CLUSTER_APPROX_WIDTH, event.point.y + CLUSTER_APPROX_HEIGHT],
       [event.point.x + CLUSTER_APPROX_WIDTH, event.point.y - CLUSTER_APPROX_HEIGHT]
     ];
-    const clustersAtPoint = map.queryRenderedFeatures(
-      clusterApproxGeometry,
-      { layers: [LAYER_IDS.CLUSTERS_LAYER_ID] }
-    );
+    const hasClusters = map.queryRenderedFeatures(clusterApproxGeometry, {
+      layers: [LAYER_IDS.CLUSTERS_LAYER_ID]
+    }).length > 0;
 
-    shouldHidePopup = !clustersAtPoint.length;
-
+    // Handle multiple features at the same location
     if (clickedLayersOfInterest.length > 1) {
       handleMultiFeaturesAtSameLocationClick(event, clickedLayersOfInterest);
-      shouldHidePopup = false;
+      hideUnpinnedTrackLayers(map, event);
+      return;
     }
 
-    // Check if clicking on a timepoint (track layer point) - don't hide popup so it can be replaced
-    const timepointAtClick = map.queryRenderedFeatures(event.point)
-      .find((item) => item.layer.id.includes(LAYER_IDS.TRACK_TIMEPOINTS));
-    if (timepointAtClick) {
-      shouldHidePopup = false;
-    }
+    // Determine if we should hide the existing popup
+    const hasPopupReplacementFeature = featuresAtPoint.some(isPopupReplacementFeature);
+    const shouldHidePopup = !hasClusters && !hasPopupReplacementFeature;
 
-    // Check if clicking on a spatial feature (symbol, line, or polygon) - don't hide popup so it can be replaced
-    const spatialFeatureAtClick = map.queryRenderedFeatures(event.point)
-      .find((item) => [
-        SYMBOLS_LAYER_ID,
-        LINES_LAYER_ID,
-        POLYGONS_LAYER_ID,
-        POLYGONS_OUTLINE_LAYER_ID
-      ].includes(item.layer.id));
-    if (spatialFeatureAtClick) {
-      shouldHidePopup = false;
-    }
-
+    // Handle popup visibility
     if (popup) {
-      // be sure to also deactivate the analyzer features when dismissing an analyzer popup
+      // Deactivate analyzer features when dismissing an analyzer popup
       if (popup.type === 'analyzer-config') {
         setAnalyzerFeatureActiveStateForIDs(map, currentAnalyzerIds, false);
       }
+
       if (shouldHidePopup) {
         hidePopup(popup.id);
       }
     }
 
     hideUnpinnedTrackLayers(map, event);
-  }), [currentAnalyzerIds, map, withLocationPickerState, handleMultiFeaturesAtSameLocationClick, hidePopup, hideUnpinnedTrackLayers, popup]);
+  }), [
+    currentAnalyzerIds,
+    handleMultiFeaturesAtSameLocationClick,
+    hidePopup,
+    hideUnpinnedTrackLayers,
+    isPopupReplacementFeature,
+    map,
+    popup,
+    withLocationPickerState,
+  ]);
 
   useEffect(() => {
     return () => {

--- a/src/Map/index.test.js
+++ b/src/Map/index.test.js
@@ -365,4 +365,268 @@ describe('Map', () => {
       expect(screen.findByTestId('mapLocationSelectionOverview-wrapper')).toBeDefined();
     });
   });
+
+  describe('onMapClick', () => {
+    test('does not hide popup when clicking on a timepoint', async () => {
+      store.view.popup = {
+        id: 'existing-popup-id',
+        type: 'timepoint',
+        data: {
+          geometry: { coordinates: [0, 0] },
+          properties: {},
+        },
+      };
+
+      renderMap();
+
+      // Mock queryRenderedFeatures to return a timepoint layer
+      map.queryRenderedFeatures.mockImplementation((point, options) => {
+        // For the timepoint check (no options or layers not specified)
+        if (!options || !options.layers) {
+          return [
+            {
+              layer: { id: 'track-layer-points-123' },
+              properties: { id: 'timepoint-1' },
+            }
+          ];
+        }
+        // For cluster check and queryMultiLayerClickFeatures
+        return [];
+      });
+
+      await waitFor(() => {
+        // Fire click event on map
+        map.__test__.fireHandlers('click', {
+          point: { x: 100, y: 100 },
+          originalEvent: { stopPropagation: jest.fn() },
+        });
+      });
+
+      // hidePopup should NOT have been called
+      expect(hidePopupMock).not.toHaveBeenCalled();
+    });
+
+    test('hides popup when clicking elsewhere (not on a timepoint)', async () => {
+      store.view.popup = {
+        id: 'existing-popup-id',
+        type: 'timepoint',
+        data: {
+          geometry: { coordinates: [0, 0] },
+          properties: {},
+        },
+      };
+
+      renderMap();
+
+      // Mock queryRenderedFeatures to return no timepoint layers
+      // It's called multiple times: once for queryMultiLayerClickFeatures, once for cluster check, once for timepoint check
+      map.queryRenderedFeatures.mockImplementation((point, options) => {
+        // For the timepoint check (no options or layers not specified)
+        if (!options || !options.layers) {
+          return [
+            {
+              layer: { id: 'some-other-layer' },
+              properties: { id: 'feature-1' },
+            }
+          ];
+        }
+        // For cluster check
+        if (options?.layers?.includes('cluster-layer')) {
+          return [];
+        }
+        // For queryMultiLayerClickFeatures
+        return [];
+      });
+
+      await waitFor(() => {
+        // Fire click event on map
+        map.__test__.fireHandlers('click', {
+          point: { x: 100, y: 100 },
+          originalEvent: { stopPropagation: jest.fn() },
+        });
+      });
+
+      // hidePopup SHOULD have been called
+      expect(hidePopupMock).toHaveBeenCalledWith('existing-popup-id');
+    });
+
+    test('hides popup when clicking on empty map area', async () => {
+      store.view.popup = {
+        id: 'existing-popup-id',
+        type: 'subject',
+        data: {
+          geometry: { coordinates: [0, 0] },
+          properties: {},
+        },
+      };
+
+      renderMap();
+
+      // Mock queryRenderedFeatures to return no features
+      map.queryRenderedFeatures.mockImplementation(() => []);
+
+      await waitFor(() => {
+        // Fire click event on map
+        map.__test__.fireHandlers('click', {
+          point: { x: 100, y: 100 },
+          originalEvent: { stopPropagation: jest.fn() },
+        });
+      });
+
+      // hidePopup SHOULD have been called
+      expect(hidePopupMock).toHaveBeenCalledWith('existing-popup-id');
+    });
+
+    test('does not hide popup when no popup is open and clicking on a timepoint', async () => {
+      store.view.popup = null;
+
+      renderMap();
+
+      // Mock queryRenderedFeatures to return a timepoint layer
+      map.queryRenderedFeatures.mockImplementation((point, options) => {
+        // For the timepoint check (no options or layers not specified)
+        if (!options || !options.layers) {
+          return [
+            {
+              layer: { id: 'track-layer-points-456' },
+              properties: { id: 'timepoint-2' },
+            }
+          ];
+        }
+        // For cluster check and queryMultiLayerClickFeatures
+        return [];
+      });
+
+      await waitFor(() => {
+        // Fire click event on map
+        map.__test__.fireHandlers('click', {
+          point: { x: 100, y: 100 },
+          originalEvent: { stopPropagation: jest.fn() },
+        });
+      });
+
+      // hidePopup should NOT have been called since there was no popup
+      expect(hidePopupMock).not.toHaveBeenCalled();
+    });
+
+    test('does not hide popup when clicking on a spatial feature symbol', async () => {
+      store.view.popup = {
+        id: 'existing-popup-id',
+        type: 'feature-symbol',
+        data: {
+          geometry: { coordinates: [0, 0] },
+          properties: { id: 'feature-1' },
+        },
+      };
+      store.data.mapLayerFilter = { hiddenFeatureIDs: [] };
+
+      renderMap();
+
+      // Mock queryRenderedFeatures to return a spatial feature symbol
+      map.queryRenderedFeatures.mockImplementation((point, options) => {
+        // For the spatial feature check (no options or layers not specified)
+        if (!options || !options.layers) {
+          return [
+            {
+              layer: { id: 'spatial-features-symbols' },
+              properties: { id: 'feature-1' },
+            }
+          ];
+        }
+        // For cluster check and queryMultiLayerClickFeatures
+        return [];
+      });
+
+      await waitFor(() => {
+        // Fire click event on map
+        map.__test__.fireHandlers('click', {
+          point: { x: 100, y: 100 },
+          originalEvent: { stopPropagation: jest.fn() },
+        });
+      });
+
+      // hidePopup should NOT have been called
+      expect(hidePopupMock).not.toHaveBeenCalled();
+    });
+
+    test('does not hide popup when clicking on a spatial feature line', async () => {
+      store.view.popup = {
+        id: 'existing-popup-id',
+        type: 'feature-symbol',
+        data: {
+          geometry: { coordinates: [[0, 0], [1, 1]] },
+          properties: { id: 'feature-2' },
+        },
+      };
+      store.data.mapLayerFilter = { hiddenFeatureIDs: [] };
+
+      renderMap();
+
+      // Mock queryRenderedFeatures to return a spatial feature line
+      map.queryRenderedFeatures.mockImplementation((point, options) => {
+        // For the spatial feature check (no options or layers not specified)
+        if (!options || !options.layers) {
+          return [
+            {
+              layer: { id: 'spatial-features-lines' },
+              properties: { id: 'feature-2' },
+            }
+          ];
+        }
+        // For cluster check and queryMultiLayerClickFeatures
+        return [];
+      });
+
+      await waitFor(() => {
+        // Fire click event on map
+        map.__test__.fireHandlers('click', {
+          point: { x: 100, y: 100 },
+          originalEvent: { stopPropagation: jest.fn() },
+        });
+      });
+
+      // hidePopup should NOT have been called
+      expect(hidePopupMock).not.toHaveBeenCalled();
+    });
+
+    test('does not hide popup when clicking on a spatial feature polygon', async () => {
+      store.view.popup = {
+        id: 'existing-popup-id',
+        type: 'feature-symbol',
+        data: {
+          geometry: { coordinates: [[[0, 0], [1, 1], [1, 0], [0, 0]]] },
+          properties: { id: 'feature-3' },
+        },
+      };
+      store.data.mapLayerFilter = { hiddenFeatureIDs: [] };
+
+      renderMap();
+
+      // Mock queryRenderedFeatures to return a spatial feature polygon
+      map.queryRenderedFeatures.mockImplementation((point, options) => {
+        // For the spatial feature check (no options or layers not specified)
+        if (!options || !options.layers) {
+          return [
+            {
+              layer: { id: 'spatial-features-polygons' },
+              properties: { id: 'feature-3' },
+            }
+          ];
+        }
+        // For cluster check and queryMultiLayerClickFeatures
+        return [];
+      });
+
+      await waitFor(() => {
+        // Fire click event on map
+        map.__test__.fireHandlers('click', {
+          point: { x: 100, y: 100 },
+          originalEvent: { stopPropagation: jest.fn() },
+        });
+      });
+
+      // hidePopup should NOT have been called
+      expect(hidePopupMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/Map/index.test.js
+++ b/src/Map/index.test.js
@@ -22,6 +22,8 @@ import { MapContext } from '../App';
 import MapDrawingToolsContextProvider from '../MapDrawingTools/ContextProvider';
 import { mockedSocket } from '../__test-helpers/MockSocketContext';
 import { mockStore } from '../__test-helpers/MockStore';
+import { LAYER_IDS } from '../constants';
+const { TRACK_TIMEPOINTS } = LAYER_IDS;
 
 jest.mock('mapbox-gl', () => ({
   ...jest.requireActual('mapbox-gl'),
@@ -385,7 +387,7 @@ describe('Map', () => {
         if (!options || !options.layers) {
           return [
             {
-              layer: { id: 'track-layer-points-123' },
+              layer: { id: `${TRACK_TIMEPOINTS}-123` },
               properties: { id: 'timepoint-1' },
             }
           ];
@@ -480,7 +482,7 @@ describe('Map', () => {
         if (!options || !options.layers) {
           return [
             {
-              layer: { id: 'track-layer-points-456' },
+              layer: { id: `${TRACK_TIMEPOINTS}-456` },
               properties: { id: 'timepoint-2' },
             }
           ];

--- a/src/Map/index.test.js
+++ b/src/Map/index.test.js
@@ -402,7 +402,6 @@ describe('Map', () => {
         });
       });
 
-      // hidePopup should NOT have been called
       expect(hidePopupMock).not.toHaveBeenCalled();
     });
 
@@ -421,7 +420,6 @@ describe('Map', () => {
       // Mock queryRenderedFeatures to return no timepoint layers
       // It's called multiple times: once for queryMultiLayerClickFeatures, once for cluster check, once for timepoint check
       map.queryRenderedFeatures.mockImplementation((point, options) => {
-        // For the timepoint check (no options or layers not specified)
         if (!options || !options.layers) {
           return [
             {
@@ -430,7 +428,6 @@ describe('Map', () => {
             }
           ];
         }
-        // For cluster check
         if (options?.layers?.includes('cluster-layer')) {
           return [];
         }
@@ -439,14 +436,12 @@ describe('Map', () => {
       });
 
       await waitFor(() => {
-        // Fire click event on map
         map.__test__.fireHandlers('click', {
           point: { x: 100, y: 100 },
           originalEvent: { stopPropagation: jest.fn() },
         });
       });
 
-      // hidePopup SHOULD have been called
       expect(hidePopupMock).toHaveBeenCalledWith('existing-popup-id');
     });
 
@@ -466,7 +461,6 @@ describe('Map', () => {
       map.queryRenderedFeatures.mockImplementation(() => []);
 
       await waitFor(() => {
-        // Fire click event on map
         map.__test__.fireHandlers('click', {
           point: { x: 100, y: 100 },
           originalEvent: { stopPropagation: jest.fn() },
@@ -482,9 +476,7 @@ describe('Map', () => {
 
       renderMap();
 
-      // Mock queryRenderedFeatures to return a timepoint layer
       map.queryRenderedFeatures.mockImplementation((point, options) => {
-        // For the timepoint check (no options or layers not specified)
         if (!options || !options.layers) {
           return [
             {
@@ -493,19 +485,16 @@ describe('Map', () => {
             }
           ];
         }
-        // For cluster check and queryMultiLayerClickFeatures
         return [];
       });
 
       await waitFor(() => {
-        // Fire click event on map
         map.__test__.fireHandlers('click', {
           point: { x: 100, y: 100 },
           originalEvent: { stopPropagation: jest.fn() },
         });
       });
 
-      // hidePopup should NOT have been called since there was no popup
       expect(hidePopupMock).not.toHaveBeenCalled();
     });
 
@@ -533,19 +522,16 @@ describe('Map', () => {
             }
           ];
         }
-        // For cluster check and queryMultiLayerClickFeatures
         return [];
       });
 
       await waitFor(() => {
-        // Fire click event on map
         map.__test__.fireHandlers('click', {
           point: { x: 100, y: 100 },
           originalEvent: { stopPropagation: jest.fn() },
         });
       });
 
-      // hidePopup should NOT have been called
       expect(hidePopupMock).not.toHaveBeenCalled();
     });
 
@@ -564,7 +550,6 @@ describe('Map', () => {
 
       // Mock queryRenderedFeatures to return a spatial feature line
       map.queryRenderedFeatures.mockImplementation((point, options) => {
-        // For the spatial feature check (no options or layers not specified)
         if (!options || !options.layers) {
           return [
             {
@@ -573,19 +558,16 @@ describe('Map', () => {
             }
           ];
         }
-        // For cluster check and queryMultiLayerClickFeatures
         return [];
       });
 
       await waitFor(() => {
-        // Fire click event on map
         map.__test__.fireHandlers('click', {
           point: { x: 100, y: 100 },
           originalEvent: { stopPropagation: jest.fn() },
         });
       });
 
-      // hidePopup should NOT have been called
       expect(hidePopupMock).not.toHaveBeenCalled();
     });
 
@@ -604,7 +586,6 @@ describe('Map', () => {
 
       // Mock queryRenderedFeatures to return a spatial feature polygon
       map.queryRenderedFeatures.mockImplementation((point, options) => {
-        // For the spatial feature check (no options or layers not specified)
         if (!options || !options.layers) {
           return [
             {
@@ -613,19 +594,16 @@ describe('Map', () => {
             }
           ];
         }
-        // For cluster check and queryMultiLayerClickFeatures
         return [];
       });
 
       await waitFor(() => {
-        // Fire click event on map
         map.__test__.fireHandlers('click', {
           point: { x: 100, y: 100 },
           originalEvent: { stopPropagation: jest.fn() },
         });
       });
 
-      // hidePopup should NOT have been called
       expect(hidePopupMock).not.toHaveBeenCalled();
     });
   });

--- a/src/PatrolTrackLayer/index.js
+++ b/src/PatrolTrackLayer/index.js
@@ -2,6 +2,7 @@ import React, { memo, useContext, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectPatrolData } from '../selectors/patrols';
+import { LAYER_IDS } from '../constants';
 import { MapContext } from '../App';
 import { trimTrackDataToTimeRange } from '../utils/tracks';
 
@@ -14,7 +15,7 @@ const LINE_PAINT = {
 };
 
 const getPointLayer = (event, map) => map.queryRenderedFeatures(event.point)
-  .filter((item) => item.layer.id.includes('track-layer-points-'))[0];
+  .filter((item) => item.layer.id.includes(LAYER_IDS.TRACK_TIMEPOINTS))[0];
 
 const PatrolTrackLayer = ({ onPointClick, patrol: patrolFromProps, trackTimeEnvelope, ...restProps }) => {
   const map = useContext(MapContext);

--- a/src/TracksLayer/index.js
+++ b/src/TracksLayer/index.js
@@ -2,6 +2,7 @@ import React, { memo, useCallback, useContext, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
 import { addMapImage } from '../utils/map';
+import { LAYER_IDS } from '../constants';
 import { MAP_LAYERS_CATEGORY, trackEventFactory } from '../utils/analytics';
 import { MapContext } from '../App';
 import { selectSubjectTracksWithPatrolTrackShownFlag } from '../selectors/patrols';
@@ -20,7 +21,7 @@ const TracksLayer = ({ onPointClick, showTimepoints = true }) => {
 
   const onTimepointClick = useCallback((event) => {
     const layer = map.queryRenderedFeatures(event.point)
-      .filter((item) => item.layer.id.includes('track-layer-points-'))[0];
+      .filter((item) => item.layer.id.includes(LAYER_IDS.TRACK_TIMEPOINTS))[0];
     onPointClick(layer);
 
     mapLayerTracker.track('Clicked Track Timepoint');

--- a/src/TracksLayer/track.js
+++ b/src/TracksLayer/track.js
@@ -11,7 +11,7 @@ import { selectTrackSettings } from '../selectors/tracks';
 import useMapSources from '../hooks/useMapSources';
 import useMapLayers from '../hooks/useMapLayers';
 
-const { TRACKS_LINES, SUBJECT_SYMBOLS } = LAYER_IDS;
+const { SUBJECT_SYMBOLS, TRACKS_LINES, TRACKS_SOURCE, TRACK_TIMEPOINTS,  } = LAYER_IDS;
 
 const STABLE_RANDOM_TRACK_COLOR_BASED_ON_ID = [
   'rgb',
@@ -72,11 +72,11 @@ const TrackLayer = ({
   const onSymbolMouseEnter = () => map.getCanvas().style.cursor = 'pointer';
   const onSymbolMouseLeave = () => map.getCanvas().style.cursor = '';
 
-  const sourceId = `track-source-${trackId}`;
+  const sourceId = `${TRACKS_SOURCE}-${trackId}`;
   const pointSourceId = `${sourceId}-points`;
 
   const layerId = `${TRACKS_LINES}-${trackId}`;
-  const pointLayerId = `${TRACKS_LINES}-points-${trackId}`;
+  const pointLayerId = `${TRACK_TIMEPOINTS}-${trackId}`;
 
   const {
     sourcesConfigs,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -99,8 +99,9 @@ export const LAYER_IDS = {
   STATIC_SENSOR: 'static_sensor',
   SUBJECT_SYMBOLS: 'subject-symbol-layer',
   TOPMOST_STYLE_LAYER: 'feature-separation-layer',
-  TRACK_TIMEPOINTS: 'track-layer-points',
   TRACKS_LINES: 'track-layer',
+  TRACKS_SOURCE: 'track-source',
+  TRACK_TIMEPOINTS: 'track-layer-points',
   UNCLUSTERED_STATIC_SENSORS_LAYER: 'unclustered_static_sensors_layer',
 };
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -99,7 +99,7 @@ export const LAYER_IDS = {
   STATIC_SENSOR: 'static_sensor',
   SUBJECT_SYMBOLS: 'subject-symbol-layer',
   TOPMOST_STYLE_LAYER: 'feature-separation-layer',
-  TRACK_TIMEPOINTS_SYMBOLS: 'track-layer-points',
+  TRACK_TIMEPOINTS: 'track-layer-points',
   TRACKS_LINES: 'track-layer',
   UNCLUSTERED_STATIC_SENSORS_LAYER: 'unclustered_static_sensors_layer',
 };

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -99,7 +99,7 @@ export const LAYER_IDS = {
   STATIC_SENSOR: 'static_sensor',
   SUBJECT_SYMBOLS: 'subject-symbol-layer',
   TOPMOST_STYLE_LAYER: 'feature-separation-layer',
-  TRACK_TIMEPOINTS_SYMBOLS: 'track-layer-timepoints',
+  TRACK_TIMEPOINTS_SYMBOLS: 'track-layer-points',
   TRACKS_LINES: 'track-layer',
   UNCLUSTERED_STATIC_SENSORS_LAYER: 'unclustered_static_sensors_layer',
 };


### PR DESCRIPTION
### What does this PR do?
- Adds checks if the feature under the click is a timepoint or features, if so, always make the shouldHidePopup flag false.

### How does it look
between timepoints

https://github.com/user-attachments/assets/61859226-7e64-45bd-860b-0556adad4c3b

same issue happened on Spatial Features

https://github.com/user-attachments/assets/f999c835-c797-49da-a0a8-973409dd2a7e

### Relevant link(s)
* Tracking tickets: [ERA-12138](https://allenai.atlassian.net/browse/ERA-12138)

[ERA-12138]: https://allenai.atlassian.net/browse/ERA-12138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



