### PR TITLE
ERA-12122: Export filters not staying in sync

### DIFF
--- a/src/GlobalMenuDrawer/index.js
+++ b/src/GlobalMenuDrawer/index.js
@@ -63,6 +63,7 @@ const GlobalMenuDrawer = () => {
   const dailyReportEnabled = useSelector((state) => state.view.systemConfig[SYSTEM_CONFIG_FLAGS.DAILY_REPORT]);
   const drawer = useSelector((state) => state.view.drawer);
   const eventsEnabled = useSelector((state) => state.view.systemConfig[SYSTEM_CONFIG_FLAGS.EVENTS]);
+  const eventFilter = useSelector((state) => state.data.eventFilter);
   const eventTypes = useSelector((state) => state.data.eventTypes);
   const kmlExportEnabled = useSelector((state) => state.view.systemConfig[SYSTEM_CONFIG_FLAGS.KML_EXPORT]);
   const patrolManagementEnabled = useSelector((state) => state.view.systemConfig[SYSTEM_CONFIG_FLAGS.PATROL_MANAGEMENT]);
@@ -131,8 +132,13 @@ const GlobalMenuDrawer = () => {
     }
 
     return exportModals;
+  // calcEventFilterForRequest uses store.getState() to fetch the event filter,
+  // so if eventFilter is not in the dependency array, the memoization will not
+  // be invalidated when the event filter changes.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     dailyReportEnabled,
+    eventFilter,
     eventsEnabled,
     hasObservationsExportPermission,
     kmlExportEnabled,


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with our Field Events export functionality. The query parameters in the request were being memoized and changes in the event filter wouldn't trigger a recalculation.

### Relevant link(s)
* [ERA-12122](https://allenai.atlassian.net/browse/ERA-12122)
* [ERA-12134](https://allenai.atlassian.net/browse/ERA-12134)

### Any background context you want to provide(if applicable)
I injected this bug when I fully reworked our `GlobalMenuDrawer` to be accessible, semantic, and support keyboard navigation. I saw a variable in a dependency array that at first glance didn't make sense: `eventFilter`. I removed it to "clean" a bit the code. But now I understand the issue.

Our `DataExportModal` receives a URL and a parameters string as props to do the export request. In the "Field Events" implementation, the parameters string is calculated by `calcEventFilterForRequest`. The internals of this methods call `store.getState();`. This may be useful in certain scenarios, like reading the state from a utility function. But from the `GlobalMenuDrawer` perspective, this means that in the render method of a React component, we read a store value from `store.getState();` instead of a selector, which is an anti-pattern. That's why, if we don't include the `eventFilter` value from a Redux selector, the memoized `exportModals` variable won't recalculate the parameters string, resulting in the issue of "Field Events" not including the filter changes in the URL.

[ERA-12122]: https://allenai.atlassian.net/browse/ERA-12122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ERA-12134]: https://allenai.atlassian.net/browse/ERA-12134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ