### PR TITLE
ERA-8798: Logout does not redirect to the login screen; it throws a blank screen instead

### DIFF
--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -336,12 +336,6 @@ const Map = ({ children, onMapLoad, socket }) => {
     );
   }, [patrolTrackState, subjectTrackState, dispatch]);
 
-  const setMap = useCallback((map) => {
-    window.map = map;
-
-    onMapLoad(map);
-  }, [onMapLoad]);
-
   const onShowClusterSelectPopup = useCallback((layers, coordinates) => {
     showPopup('cluster-select', {
       layers,
@@ -678,7 +672,7 @@ const Map = ({ children, onMapLoad, socket }) => {
       <MapPrintControl />
       <TimeSliderMapControl />
     </>}
-    onMapLoaded={setMap}
+    onMapLoaded={onMapLoad}
     >
     {map && <>
       {children}

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -336,6 +336,12 @@ const Map = ({ children, onMapLoad, socket }) => {
     );
   }, [patrolTrackState, subjectTrackState, dispatch]);
 
+  const setMap = useCallback((map) => {
+    window.map = map;
+
+    onMapLoad(map);
+  }, [onMapLoad]);
+
   const onShowClusterSelectPopup = useCallback((layers, coordinates) => {
     showPopup('cluster-select', {
       layers,
@@ -672,7 +678,7 @@ const Map = ({ children, onMapLoad, socket }) => {
       <MapPrintControl />
       <TimeSliderMapControl />
     </>}
-    onMapLoaded={onMapLoad}
+    onMapLoaded={setMap}
     >
     {map && <>
       {children}

--- a/src/ducks/auth.js
+++ b/src/ducks/auth.js
@@ -40,9 +40,6 @@ const postAuthSuccess = response => (dispatch) => {
 export const clearAuth = () => (dispatch) => {
 
   return new Promise((resolve) => {
-    if (window.map) {
-      window.map.setStyle(null);
-    }
     deleteAuthTokenCookie();
     deleteTemporaryAccessTokenCookie();
     setTimeout(() => {


### PR DESCRIPTION
### What does this PR do?
Remove logic to force a map cleaning with `window.map.setStyle(null);` while clearing the auth.

### Relevant link(s)
* [ERA-8798](https://allenai.atlassian.net/browse/ERA-8798)
* [Env]()

### Any background context you want to provide(if applicable)
Here an explanation of the logout flow that causes the issue:
- User clicks the `Log Out` item from the `UserMenu`.
- This dispatches the `clearAuth` action from the `auth` duck.
- The following code was executed:
```Javascript
if (window.map) {
  window.map.setStyle(null);
}
```
- App components started to unmount, and some of them call `map` methods like `removeLayer` and `removeSource`, but the `map` object styles where nullified, causing errors to be thrown and resulting in the blank page.

That clearing of the map style was introduced in this PR: https://github.com/PADAS/das-web-react/pull/752

After chatting with @JoshuaVulcan , it seems like it was added to make sure that map features weren't preserved when switching sessions. However, by testing it manually, I noticed that every time the user logs out and logs in, a new fresh `map` instance is created. So it wouldn't make sense that old map data would be preserved. The only thing that had a smell for me is that we were storing the `map` object in `window`, which feels risky in so many ways. And that could explain why the `map` object could preserve old data between sessions. However we are not using the `map` from `window` for anything, so I cleaned that too. My theory is that this issue of `map` data being shared between session si no longer happening, but it would be ideal to test this in an environment. cc: @AlanCalvillo 

Could you guys help me testing that? Or explaining how that error was being reproduced? 

For now, I removed the mentioned code, and the log out flow is working fine.


[ERA-8798]: https://allenai.atlassian.net/browse/ERA-8798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ