### PR TITLE
Migrate PR workflow to inline Docker build with dual registry

### DIFF
--- a/.github/workflows/pr-envs.yml
+++ b/.github/workflows/pr-envs.yml
@@ -1,26 +1,30 @@
-name: Build das-server on Pull Request
+name: Pull Request Workflow
+
 on:
   pull_request:
     types:
       - labeled
       - synchronize
-      - reopened
+      - opened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  pull-requests: write
 
 jobs:
   config:
-    if: contains(github.event.pull_request.labels.*.name, 'deploy')
     runs-on: ubuntu-latest
-    outputs:
-      build-args: ${{ steps.env-vars.outputs.build-args }}
-    environment: 
-      name: ${{ github.head_ref }}
-      url: "https://${{ github.head_ref }}.dev.pamdas.org"
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: "22"
       - run: |
           npm pkg set "buildbranch"="${{ github.event.pull_request.head.sha }}"
           npm pkg set "buildnum"="${{ github.run_number }}"
@@ -28,21 +32,61 @@ jobs:
         with:
           name: npm-config
           path: package.json
-      - name: Select env file for build
-        id: env-vars
-        run: |
-          # PR envs deploy to *.dev.pamdas.org, so always use the development config.
-          echo "build-args=ENV_FILE=.env.development" >> $GITHUB_OUTPUT
 
   build:
-    if: contains(github.event.pull_request.labels.*.name, 'deploy')
-    needs: config
-    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@main
-    with:
-      environment: padas-app
-      repository: europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react
-      tag: ${{ github.event.pull_request.head.sha }}
-      dockerfile: Dockerfile.mt
-      artifact-download: true
-      artifact-name: npm-config
-      build-args: ${{ needs.config.outputs.build-args || '' }}
+    needs: [config]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: npm-config
+          path: .
+
+      - name: GCP Auth
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.SERVICE_ACCOUNT }}
+
+      - name: Login to serca-artifact-registry
+        uses: docker/login-action@v3
+        with:
+          registry: europe-west3-docker.pkg.dev/serca-artifact-registry
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - name: Login to padas-app
+        uses: docker/login-action@v3
+        with:
+          registry: europe-west3-docker.pkg.dev/padas-app
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            europe-west3-docker.pkg.dev/serca-artifact-registry/earthranger/das-web-react
+            europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react
+          tags: |
+            type=raw,value=${{ github.event.pull_request.head.sha }}
+            type=raw,value=pr-${{ github.event.pull_request.head.sha }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          file: Dockerfile.mt
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ENV_FILE=.env.development
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Replace `gundi-workflows/build_docker.yml` with inline Docker build logic (das-web-react is a **public** repo and cannot call reusable workflows from serca-pipelines which is internal)
- Remove deploy label gate: build runs on **every PR**
- Add dual registry push: serca-artifact-registry (primary) + padas-app (secondary)
- Remove GitHub environment declaration
- Add GHA cache (`cache-from`/`cache-to`) for faster builds
- Image tags: `{sha}` and `pr-{sha}` pushed to both registries
- Add concurrency group with cancel-in-progress

## Test plan

- [ ] Open a test PR and verify config + build jobs run without deploy label
- [ ] Verify Docker image is pushed to both serca-artifact-registry and padas-app
- [ ] Verify image tags match expected format (`{sha}` and `pr-{sha}`)
- [ ] Verify GHA cache is populated on first run and used on subsequent pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)