### PR TITLE
[ERA-12387] Adding 'include_empty_location' param to subject historical observations query

### DIFF
--- a/src/SubjectHistoricalDataModal/index.js
+++ b/src/SubjectHistoricalDataModal/index.js
@@ -112,6 +112,7 @@ const SubjectHistoricalDataModal = ({ subjectId, subjectIsStatic, title }) => {
 
     dispatch(fetchObservationsForSubject({
       subject_id: subjectId,
+      include_empty_location: true,
       page: activePage,
       page_size: ITEMS_PER_PAGE,
       sort_by: SORT_BY,


### PR DESCRIPTION
### What does this PR do?
- Shows subject observations with sensor readings but a 0,0 location, which were previously excluded from view

### How does it look
-N/A

### Relevant link(s)
* https://allenai.atlassian.net/browse/ERA-12387

