### PR TITLE
Add stage deploy via ArgoCD on release branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,3 +181,16 @@ jobs:
 
       - name: Wait for health
         run: argocd app wait "$APP_NAME" --grpc-web --health --sync --timeout 300
+
+  deploy-stage:
+    needs: [config, build]
+    if: startsWith(github.ref_name, 'release-')
+    uses: PADAS/serca-pipelines/.github/workflows/_argocd-deploy.yml@main
+    with:
+      app-name: das-web-react
+      app-subdir: earthranger
+      environment: er-stage
+      image-tag: ${{ needs.config.outputs.image-tag }}
+    secrets:
+      ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+      ARGOCD_APPS_SSH_KEY: ${{ secrets.ARGOCD_APPS_SSH_KEY }}


### PR DESCRIPTION
## Summary

Adds ArgoCD deployment to er-stage when pushing to `release-*` branches (DASOPS-1899).

## Changes

- Added `deploy-stage` job in `.github/workflows/main.yml`
- Uses serca-pipelines `_argocd-deploy.yml` reusable workflow (cleaner than inline approach used for dev)
- Triggers only on `release-*` branches after build completes

## Files Changed

- `.github/workflows/main.yml`

[DASOPS-1899](https://padas.atlassian.net/browse/DASOPS-1899)

[DASOPS-1899]: https://allenai.atlassian.net/browse/DASOPS-1899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ