### PR TITLE
fix: extract ArgoCD workflows into internal reusable workflows (release-2.135.1)

### DIFF
--- a/.github/workflows/_sync-argo.yml
+++ b/.github/workflows/_sync-argo.yml
@@ -1,0 +1,63 @@
+name: ArgoCD Sync (internal)
+
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        required: true
+        type: string
+      wait-timeout:
+        type: number
+        default: 300
+    secrets:
+      ARGOCD_AUTH_TOKEN:
+        required: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      ARGOCD_SERVER: ${{ vars.ARGOCD_SERVER }}
+      ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+      APP_NAME: ${{ inputs.app-name }}
+    steps:
+      - name: Install ArgoCD CLI
+        run: |
+          curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+          chmod +x argocd && sudo mv argocd /usr/local/bin/
+
+      - name: Wait for app
+        run: |
+          for i in $(seq 1 18); do
+            argocd app get "$APP_NAME" --grpc-web &>/dev/null && exit 0
+            echo "[$i/18] Not found, retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::App $APP_NAME not found after 180s" && exit 1
+
+      - name: Sync
+        run: |
+          MAX_RETRIES=3
+          RETRY_WAIT=2
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            echo "Sync attempt $attempt/$MAX_RETRIES..."
+            if argocd app sync "$APP_NAME" --grpc-web --prune; then
+              echo "Sync triggered successfully"
+              exit 0
+            fi
+            if [ $attempt -lt $MAX_RETRIES ]; then
+              echo "Sync failed — terminating in-progress operations..."
+              argocd app terminate-op "$APP_NAME" --grpc-web 2>/dev/null || true
+              sleep 2
+              argocd app get "$APP_NAME" --grpc-web --refresh > /dev/null 2>&1 || true
+              echo "Retrying in ${RETRY_WAIT}s... [Attempt $((attempt + 1))/$MAX_RETRIES]"
+              sleep "$RETRY_WAIT"
+              RETRY_WAIT=$((RETRY_WAIT * 2))
+            else
+              echo "::error::Sync failed after $MAX_RETRIES attempts"
+              exit 1
+            fi
+          done
+
+      - name: Wait for health
+        run: argocd app wait "$APP_NAME" --grpc-web --health --sync --timeout ${{ inputs.wait-timeout }}

--- a/.github/workflows/_update-argo.yml
+++ b/.github/workflows/_update-argo.yml
@@ -1,0 +1,50 @@
+name: ArgoCD Update Image (internal)
+
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        required: true
+        type: string
+      app-subdir:
+        type: string
+        default: ""
+      environment:
+        required: true
+        type: string
+      image-tag:
+        required: true
+        type: string
+    secrets:
+      ARGOCD_APPS_SSH_KEY:
+        required: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.ARGOCD_APPS_SSH_KEY }}
+
+      - name: Update image tag in serca-argocd-apps
+        env:
+          TAG: ${{ inputs.image-tag }}
+          APP_NAME: ${{ inputs.app-name }}
+          APP_SUBDIR: ${{ inputs.app-subdir }}
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          git clone --depth 1 git@github.com:PADAS/serca-argocd-apps.git
+          cd serca-argocd-apps
+          pip install yq
+
+          VALUES_FILE="${APP_SUBDIR:+${APP_SUBDIR}/}${APP_NAME}/values-${ENVIRONMENT}.yaml"
+          yq -Yi ".image.tag = \"${TAG}\"" "$VALUES_FILE"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$VALUES_FILE"
+          git diff --cached --quiet && echo "No changes" && exit 0
+          git commit -m "${APP_NAME}: update ${ENVIRONMENT} image to ${TAG}"
+          git push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,76 +108,41 @@ jobs:
   update-image:
     needs: [config, build]
     if: github.ref_name == 'develop'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.ARGOCD_APPS_SSH_KEY }}
-
-      - name: Update image tag in serca-argocd-apps
-        env:
-          TAG: ${{ needs.config.outputs.image-tag }}
-        run: |
-          git clone --depth 1 git@github.com:PADAS/serca-argocd-apps.git
-          cd serca-argocd-apps
-
-          pip install yq
-          yq -Yi ".image.tag = \"${TAG}\"" earthranger/das-web-react/values-er-dev.yaml
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add earthranger/das-web-react/values-er-dev.yaml
-          git diff --cached --quiet && echo "No changes" && exit 0
-          git commit -m "das-web-react: update er-dev image to ${TAG}"
-          git push
+    uses: ./.github/workflows/_update-argo.yml
+    with:
+      app-name: das-web-react
+      app-subdir: earthranger
+      environment: er-dev
+      image-tag: ${{ needs.config.outputs.image-tag }}
+    secrets:
+      ARGOCD_APPS_SSH_KEY: ${{ secrets.ARGOCD_APPS_SSH_KEY }}
 
   sync:
     needs: [config, update-image]
     if: github.ref_name == 'develop'
-    runs-on: ubuntu-latest
-    env:
-      ARGOCD_SERVER: ${{ vars.ARGOCD_SERVER }}
+    uses: ./.github/workflows/_sync-argo.yml
+    with:
+      app-name: das-web-react-er-dev
+    secrets:
       ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
-      APP_NAME: das-web-react-er-dev
-    steps:
-      - name: Install ArgoCD CLI
-        run: |
-          curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
-          chmod +x argocd && sudo mv argocd /usr/local/bin/
 
-      - name: Wait for app
-        run: |
-          for i in $(seq 1 18); do
-            argocd app get "$APP_NAME" --grpc-web &>/dev/null && exit 0
-            echo "[$i/18] Not found, retrying in 10s..."
-            sleep 10
-          done
-          echo "::error::App $APP_NAME not found after 180s" && exit 1
+  update-image-stage:
+    needs: [config, build]
+    if: startsWith(github.ref_name, 'release-')
+    uses: ./.github/workflows/_update-argo.yml
+    with:
+      app-name: das-web-react
+      app-subdir: earthranger
+      environment: er-stage
+      image-tag: ${{ needs.config.outputs.image-tag }}
+    secrets:
+      ARGOCD_APPS_SSH_KEY: ${{ secrets.ARGOCD_APPS_SSH_KEY }}
 
-      - name: Sync
-        run: |
-          MAX_RETRIES=3
-          RETRY_WAIT=2
-          for attempt in $(seq 1 $MAX_RETRIES); do
-            echo "Sync attempt $attempt/$MAX_RETRIES..."
-            if argocd app sync "$APP_NAME" --grpc-web --prune; then
-              echo "Sync triggered successfully"
-              exit 0
-            fi
-            if [ $attempt -lt $MAX_RETRIES ]; then
-              echo "Sync failed — terminating in-progress operations..."
-              argocd app terminate-op "$APP_NAME" --grpc-web 2>/dev/null || true
-              sleep 2
-              argocd app get "$APP_NAME" --grpc-web --refresh > /dev/null 2>&1 || true
-              echo "Retrying in ${RETRY_WAIT}s... [Attempt $((attempt + 1))/$MAX_RETRIES]"
-              sleep "$RETRY_WAIT"
-              RETRY_WAIT=$((RETRY_WAIT * 2))
-            else
-              echo "::error::Sync failed after $MAX_RETRIES attempts"
-              exit 1
-            fi
-          done
-
-      - name: Wait for health
-        run: argocd app wait "$APP_NAME" --grpc-web --health --sync --timeout 300
+  sync-stage:
+    needs: [config, update-image-stage]
+    if: startsWith(github.ref_name, 'release-')
+    uses: ./.github/workflows/_sync-argo.yml
+    with:
+      app-name: das-web-react-er-stage
+    secrets:
+      ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

This applies the same fix from the develop branch to release-2.135.1 for testing the release deployment path. GitHub prohibits public repositories from calling reusable workflows in private repositories. The solution extracts ArgoCD deployment logic into internal reusable workflows, enabling both dev and release-path deployments.

## Changes

### Added
- `.github/workflows/_update-argo.yml` – Reusable workflow to clone serca-argocd-apps, update image tag in values file, and push the commit
- `.github/workflows/_sync-argo.yml` – Reusable workflow to install ArgoCD CLI, wait for app availability, sync with retries, and verify health

### Changed
- `.github/workflows/main.yml` – Refactored all deployment jobs to use internal reusable workflows
  - `update-image` job now calls `./.github/workflows/_update-argo.yml` for er-dev environment
  - `sync` job now calls `./.github/workflows/_sync-argo.yml` for das-web-react-er-dev app
  - Added new `update-image-stage` and `sync-stage` jobs for release branches (er-stage environment)

## Technical Details

Both the develop branch (PR #1488) and this release-2.135.1 branch now use identical internal reusable workflows. This allows testing the release deployment path (release-* branch → er-stage) in parallel with the main branch fix. The workflows support parameterized inputs for environment-specific deployments while maintaining a single source of truth for deployment logic.

## Files Changed

**3 files changed, 145 insertions(+), 67 deletions(-)**

---
**Jira**: https://allenai.atlassian.net/browse/DASOPS-1899