### PR TITLE
ERA-12946: Center jump-to feature in visible map area when sidebar is open

### DIFF
--- a/src/SideBar/MapLayersTab/FeaturesTab/FeatureListItem.js
+++ b/src/SideBar/MapLayersTab/FeaturesTab/FeatureListItem.js
@@ -2,7 +2,8 @@ import React, { memo, useContext } from 'react';
 import { useDispatch } from 'react-redux';
 import { center, bboxPolygon } from '@turf/turf';
 
-
+import { BREAKPOINTS } from '../../../constants';
+import { useMatchMedia } from '../../../hooks';
 import { showFeatures } from '../../../ducks/map-layer-filter';
 import { setMapFeatureHighlightIDs } from '../../../ducks/mapFeatureHighlight';
 import { showPopup } from '../../../ducks/popup';
@@ -20,8 +21,11 @@ import * as styles from '../styles.module.scss';
 const mapLayerTracker = trackEventFactory(MAP_LAYERS_CATEGORY);
 
 // eslint-disable-next-line react/display-name
+const SIDEBAR_WIDTH_PIXELS = 512;
+
 const FeatureListItem = memo((props) => {
   const map = useContext(MapContext);
+  const isMediumLayoutOrLarger = useMatchMedia(BREAKPOINTS.screenIsMediumLayoutOrLarger);
 
   const dispatch = useDispatch();
 
@@ -54,7 +58,8 @@ const FeatureListItem = memo((props) => {
     dispatch(
       showFeatures(props.id)
     );
-    map.fitBounds(props.bounds, { duration: 0, minZoom: 5, maxZoom: 16, padding: 20 });
+    const leftPadding = isMediumLayoutOrLarger ? SIDEBAR_WIDTH_PIXELS + 20 : 20;
+    map.fitBounds(props.bounds, { duration: 0, minZoom: 5, maxZoom: 16, padding: { top: 20, bottom: 20, right: 20, left: leftPadding } });
     highlightClickedFeatureSymbol(map, SYMBOLS_LAYER_ID, props.id);
     setTimeout(() => {
       setFeatureActiveStateByID(map, props.id, true);


### PR DESCRIPTION
## Summary
- `FeatureListItem.onJumpButtonClick` was calling `map.fitBounds` with a hardcoded `padding: 20`, centering the feature on the full window
- Now computes left padding as `SIDEBAR_WIDTH_PIXELS + 20` (532px) on medium+ layouts so the feature lands in the center of the visible map area to the right of the sidebar
- Uses the same `useMatchMedia(BREAKPOINTS.screenIsMediumLayoutOrLarger)` pattern as `useJumpToLocation`

Jira: [ERA-12946](https://allenai.atlassian.net/browse/ERA-12946)

## Test plan
- [ ] Open the sidebar to the Map Layers / Features tab
- [ ] Click the jump-to button on a spatial feature
- [ ] Verify the feature is centered in the visible map area (right of sidebar), not the full window
- [ ] Verify behavior is unchanged when the sidebar is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ERA-12946]: https://allenai.atlassian.net/browse/ERA-12946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ