### PR TITLE
fix: use AR mirror for BuildKit image instead of Docker Hub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,9 @@ jobs:
           password: ${{ steps.auth.outputs.access_token }}
 
       - uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/moby/buildkit:buildx-stable-1
 
       - name: Docker metadata
         id: meta

--- a/.github/workflows/pr-envs.yml
+++ b/.github/workflows/pr-envs.yml
@@ -93,6 +93,9 @@ jobs:
           password: ${{ steps.auth.outputs.access_token }}
 
       - uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/moby/buildkit:buildx-stable-1
 
       - name: Docker metadata
         id: meta


### PR DESCRIPTION
## Summary

Docker builds can fail with `toomanyrequests` errors when `docker/setup-buildx-action` pulls `moby/buildkit:buildx-stable-1` from Docker Hub. This configures both `main.yml` and `pr-envs.yml` to pull the BuildKit image from our existing `virtual-docker` mirror in `serca-artifact-registry` instead.

Same fix applied to `serca-pipelines` in PADAS/serca-pipelines#76 (covers das, das-react-admin, report-form-builder). This PR covers das-web-react which has inline Docker builds since the repo is public and can't reference private reusable workflows.

## Changes

- `main.yml` — added `driver-opts` to buildx step to use AR mirror
- `pr-envs.yml` — same fix