### PR TITLE
Add prod-me ArgoCD deployment with approval gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,3 +203,32 @@ jobs:
       app-name: das-web-react-er-stage
     secrets:
       ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+
+  approve-prod:
+    needs: [sync-stage]
+    if: startsWith(github.ref_name, 'release-')
+    runs-on: ubuntu-latest
+    environment: production-approval
+    steps:
+      - run: echo "Production deployment approved"
+
+  update-image-prod-me:
+    needs: [config, build, approve-prod]
+    if: startsWith(github.ref_name, 'release-')
+    uses: ./.github/workflows/_update-argo.yml
+    with:
+      app-name: das-web-react
+      app-subdir: earthranger
+      environment: er-prod-me
+      image-tag: ${{ needs.config.outputs.image-tag }}
+    secrets:
+      ARGOCD_APPS_SSH_KEY: ${{ secrets.ARGOCD_APPS_SSH_KEY }}
+
+  sync-prod-me:
+    needs: [config, update-image-prod-me]
+    if: startsWith(github.ref_name, 'release-')
+    uses: ./.github/workflows/_sync-argo.yml
+    with:
+      app-name: das-web-react-er-prod-me
+    secrets:
+      ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Add automated prod-me deployment via ArgoCD, triggered on release branches with manual approval.

## Changes

- Add `approve-prod` job with `production-approval` GitHub Environment gate (depends on stage sync success)
- Add `update-image-prod-me` job to update image tag in serca-argocd-apps
- Add `sync-prod-me` job to trigger ArgoCD sync

## Flow

```
release-* push → build → update-image-stage → sync-stage → approve-prod (manual) → update-image-prod-me → sync-prod-me
```

## Prerequisites

- `production-approval` GitHub Environment created (done)
- `values-er-prod-me.yaml` exists in serca-argocd-apps (done)

## Files Changed

- `.github/workflows/main.yml` — added 3 new jobs