### PR TITLE
Standardize CI/CD pipelines

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,125 @@
+name: Build & Deploy das-web-react (develop)
+on:
+  push:
+    branches:
+      - develop
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      build-args: ${{ steps.env-vars.outputs.build-args }}
+      image-tag: ${{ steps.tag.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: |
+          npm pkg set "buildbranch"="${{ github.ref_name }}"
+          npm pkg set "buildnum"="${{ github.run_number }}"
+
+      - name: Select env file for build
+        id: env-vars
+        run: echo "build-args=ENV_FILE=.env.development" >> $GITHUB_OUTPUT
+
+      - name: Generate image tag
+        id: tag
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          BRANCH_SAFE=$(echo "${GITHUB_REF_NAME}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+          echo "value=${BRANCH_SAFE}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: npm-config
+          path: package.json
+
+  build:
+    needs: config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: npm-config
+          path: .
+
+      - name: GCP Auth
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.SERVICE_ACCOUNT }}
+
+      - name: Login to serca-artifact-registry
+        uses: docker/login-action@v3
+        with:
+          registry: europe-west3-docker.pkg.dev/serca-artifact-registry
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - name: Login to padas-app
+        uses: docker/login-action@v3
+        with:
+          registry: europe-west3-docker.pkg.dev/padas-app
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/moby/buildkit:buildx-stable-1
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            europe-west3-docker.pkg.dev/serca-artifact-registry/earthranger/das-web-react
+            europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react
+          tags: |
+            type=raw,value=${{ needs.config.outputs.image-tag }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          file: Dockerfile.mt
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ needs.config.outputs.build-args }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy-dev:
+    needs: [config, build]
+    uses: ./.github/workflows/_update-argo.yml
+    with:
+      app-name: das-web-react
+      app-subdir: earthranger
+      environment: er-dev
+      image-tag: ${{ needs.config.outputs.image-tag }}
+    secrets:
+      ARGOCD_APPS_SSH_KEY: ${{ secrets.ARGOCD_APPS_SSH_KEY }}
+
+  sync-dev:
+    needs: [config, deploy-dev]
+    uses: ./.github/workflows/_sync-argo.yml
+    with:
+      app-name: das-web-react-er-dev
+    secrets:
+      ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
-name: Build das-web-react
+name: Release Deploy das-web-react
 on:
   push:
     branches:
-      - develop
       - 'release-**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,21 +27,19 @@ jobs:
         with:
           node-version: 24
       - run: |
-          npm pkg set "buildbranch"="${{ github.head_ref || github.ref_name }}"
+          npm pkg set "buildbranch"="${{ github.ref_name }}"
           npm pkg set "buildnum"="${{ github.run_number }}"
 
       - name: Select env file for build
         id: env-vars
-        run: |
-          if [[ "${GITHUB_REF_NAME}" == "develop" ]]; then
-            echo "build-args=ENV_FILE=.env.development" >> $GITHUB_OUTPUT
-          else
-            echo "build-args=ENV_FILE=.env.production" >> $GITHUB_OUTPUT
-          fi
+        run: echo "build-args=ENV_FILE=.env.production" >> $GITHUB_OUTPUT
 
-      - name: Image tag
+      - name: Generate image tag
         id: tag
-        run: echo "value=${{ github.ref_name }}-${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          BRANCH_SAFE=$(echo "${GITHUB_REF_NAME}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+          echo "value=${BRANCH_SAFE}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -111,7 +109,6 @@ jobs:
   build-st:
     name: Build ST Image (GCR)
     needs: [config]
-    if: startsWith(github.ref_name, 'release-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -162,30 +159,8 @@ jobs:
           docker push ${{ steps.gcr.outputs.path }}:latest
           docker push ${{ steps.gcr.outputs.path }}:${{ github.sha }}
 
-  update-image-dev:
+  deploy-stage:
     needs: [config, build]
-    if: github.ref_name == 'develop'
-    uses: ./.github/workflows/_update-argo.yml
-    with:
-      app-name: das-web-react
-      app-subdir: earthranger
-      environment: er-dev
-      image-tag: ${{ needs.config.outputs.image-tag }}
-    secrets:
-      ARGOCD_APPS_SSH_KEY: ${{ secrets.ARGOCD_APPS_SSH_KEY }}
-
-  sync-dev:
-    needs: [config, update-image-dev]
-    if: github.ref_name == 'develop'
-    uses: ./.github/workflows/_sync-argo.yml
-    with:
-      app-name: das-web-react-er-dev
-    secrets:
-      ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
-
-  update-image-stage:
-    needs: [config, build]
-    if: startsWith(github.ref_name, 'release-')
     uses: ./.github/workflows/_update-argo.yml
     with:
       app-name: das-web-react
@@ -196,8 +171,7 @@ jobs:
       ARGOCD_APPS_SSH_KEY: ${{ secrets.ARGOCD_APPS_SSH_KEY }}
 
   sync-stage:
-    needs: [config, update-image-stage]
-    if: startsWith(github.ref_name, 'release-')
+    needs: [config, deploy-stage]
     uses: ./.github/workflows/_sync-argo.yml
     with:
       app-name: das-web-react-er-stage
@@ -206,15 +180,13 @@ jobs:
 
   approve-prod:
     needs: [sync-stage]
-    if: startsWith(github.ref_name, 'release-')
     runs-on: ubuntu-latest
     environment: production-approval
     steps:
       - run: echo "Production deployment approved"
 
-  update-image-prod-me:
+  deploy-prod-me:
     needs: [config, build, approve-prod]
-    if: startsWith(github.ref_name, 'release-')
     uses: ./.github/workflows/_update-argo.yml
     with:
       app-name: das-web-react
@@ -225,8 +197,7 @@ jobs:
       ARGOCD_APPS_SSH_KEY: ${{ secrets.ARGOCD_APPS_SSH_KEY }}
 
   sync-prod-me:
-    needs: [config, update-image-prod-me]
-    if: startsWith(github.ref_name, 'release-')
+    needs: [config, deploy-prod-me]
     uses: ./.github/workflows/_sync-argo.yml
     with:
       app-name: das-web-react-er-prod-me


### PR DESCRIPTION
## Summary

Split monolithic `main.yml` into separate `develop.yml` and `release.yml`, standardize image tags. Public repo — uses internal reusable workflows (not serca-pipelines).

## Changes

- **Split** `main.yml` into:
  - `develop.yml` — triggers on develop, builds + deploys to er-dev
  - `release.yml` — triggers on release-*, builds + ST build + deploys stage → approval → prod-me
- **Image tag**: Changed from `branch-run_number` to `branch-short_sha`
- **Job names**: Standardized (`deploy-dev`, `deploy-stage`, `deploy-prod-me`, `approve-prod`, etc.)
- **ST build**: Kept in release.yml (still needed for legacy single-tenant)

## Standard Applied

| Convention | Value |
|-----------|-------|
| Dev workflow | `develop.yml` |
| Release workflow | `release.yml` |
| Image tag | `{branch}-{short-sha}` |
| Approval gate | `production-approval` environment |
| Primary registry | `serca-artifact-registry/earthranger` |

## Files Changed

- `.github/workflows/main.yml` → split into `develop.yml` + `release.yml`