### PR TITLE
ci: add prod-us ArgoCD deployment to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,3 +203,22 @@ jobs:
       app-name: das-web-react-er-prod-me
     secrets:
       ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+
+  deploy-prod-us:
+    needs: [config, build, approve-prod]
+    uses: ./.github/workflows/_update-argo.yml
+    with:
+      app-name: das-web-react
+      app-subdir: earthranger
+      environment: er-prod-us
+      image-tag: ${{ needs.config.outputs.image-tag }}
+    secrets:
+      ARGOCD_APPS_SSH_KEY: ${{ secrets.ARGOCD_APPS_SSH_KEY }}
+
+  sync-prod-us:
+    needs: [config, deploy-prod-us]
+    uses: ./.github/workflows/_sync-argo.yml
+    with:
+      app-name: das-web-react-er-prod-us
+    secrets:
+      ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Add ArgoCD deployment and sync jobs for er-prod-us to the release pipeline. Runs in parallel with prod-me after production approval gate.

## Changes

- Add `deploy-prod-us` job using local `_update-argo.yml` with `environment: er-prod-us`
- Add `sync-prod-us` job using local `_sync-argo.yml` with `app-name: das-web-react-er-prod-us`
- Same approval gate as prod-me (`approve-prod`)

**Jira**: https://allenai.atlassian.net/browse/DASOPS-1899