### PR TITLE
feat: per-environment approval gates for release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,3 +212,22 @@ jobs:
       app-name: das-web-react-er-prod-me
     secrets:
       ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+
+  deploy-prod-us:
+    needs: [config, build, approve-prod-us]
+    uses: ./.github/workflows/_update-argo.yml
+    with:
+      app-name: das-web-react
+      app-subdir: earthranger
+      environment: er-prod-us
+      image-tag: ${{ needs.config.outputs.image-tag }}
+    secrets:
+      ARGOCD_APPS_SSH_KEY: ${{ secrets.ARGOCD_APPS_SSH_KEY }}
+
+  sync-prod-us:
+    needs: [config, deploy-prod-us]
+    uses: ./.github/workflows/_sync-argo.yml
+    with:
+      app-name: das-web-react-er-prod-us
+    secrets:
+      ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
 permissions:
@@ -178,15 +178,24 @@ jobs:
     secrets:
       ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
 
-  approve-prod:
+  approve-prod-me:
     needs: [sync-stage]
     runs-on: ubuntu-latest
-    environment: production-approval
+    timeout-minutes: 4320
+    environment: production-me
     steps:
-      - run: echo "Production deployment approved"
+      - run: echo "Production ME deployment approved"
+
+  approve-prod-us:
+    needs: [sync-stage]
+    runs-on: ubuntu-latest
+    timeout-minutes: 4320
+    environment: production-us
+    steps:
+      - run: echo "Production US deployment approved"
 
   deploy-prod-me:
-    needs: [config, build, approve-prod]
+    needs: [config, build, approve-prod-me]
     uses: ./.github/workflows/_update-argo.yml
     with:
       app-name: das-web-react


### PR DESCRIPTION
## Summary

Replace single `production-approval` gate with parallel per-environment approval gates. Add `deploy-prod-us` + `sync-prod-us` via ArgoCD. Consolidates das-web-react#1522.

## Changes

- **`approve-prod-me`** (environment: `production-me`) gates `deploy-prod-me` → `sync-prod-me`
- **`approve-prod-us`** (environment: `production-us`) gates new `deploy-prod-us` → `sync-prod-us`
- 72h timeout on approval jobs — pending approvals auto-expire
- Concurrency group: `${{ github.workflow }}` (not per-branch) — only 1 release pipeline active at a time

## Deployment chain

```
             ┌→ approve-prod-me → deploy-prod-me → sync-prod-me
sync-stage ──┤
             └→ approve-prod-us → deploy-prod-us → sync-prod-us
```

## Jira

[DASOPS-1958](https://allenai.atlassian.net/browse/DASOPS-1958)

[DASOPS-1958]: https://allenai.atlassian.net/browse/DASOPS-1958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ