### PR TITLE
ERA-11250 Swap in new cookie manager by Osano

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# CLAUDE.md
+
+## Code Style
+
+- Use arrow function notation (`const fn = () => {}`) — no `function` declarations.
+- Single quotes for strings.
+- Semicolons required.
+- Trailing commas in multi-line objects and arrays.
+
+## Vite Plugins
+
+- Order plugins by relevance: core framework plugins first (react, svgr), utility/injection plugins last.

--- a/public/index.html
+++ b/public/index.html
@@ -44,14 +44,6 @@
     -->
   <script data-jsd-embedded data-key="e1d5f5e4-1bf6-43ce-ae10-972895d6c040"
     data-base-url="https://jsd-widget.atlassian.com" src="https://jsd-widget.atlassian.com/assets/embed.js"></script>
-  <% if (process.env.NODE_ENV==='production' ) { %>
-    <!-- Osano Cookies Consent Notice start for pamdas.org -->
-    <script src="https://cmp.osano.com/AzqB4OUPPVD5j8EeT/bc796e8a-d3d4-4a74-b9c7-f737cbc3379b/osano.js"></script>
-    <style>
-      .osano-cm-widget{display: none;}
-    </style>
-    <!-- Osano Cookies Consent Notice end for pamdas.org -->
-  <% } %>
 </body>
 
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,31 +2,27 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 
-function osanoPlugin() {
-  return {
-    name: 'inject-osano',
-    apply: 'build',
-    transformIndexHtml: {
-      order: 'pre',
-      handler() {
-        return [
-          {
-            tag: 'style',
-            children: '.osano-cm-widget{display: none;}',
-            injectTo: 'head',
-          },
-          {
-            tag: 'script',
-            attrs: {
-              src: 'https://cmp.osano.com/AzqB4OUPPVD5j8EeT/bc796e8a-d3d4-4a74-b9c7-f737cbc3379b/osano.js',
-            },
-            injectTo: 'body',
-          },
-        ];
+const osanoPlugin = () => ({
+  name: 'inject-osano',
+  apply: 'build',
+  transformIndexHtml: {
+    order: 'pre',
+    handler: () => [
+      {
+        tag: 'style',
+        children: '.osano-cm-widget{display: none;}',
+        injectTo: 'head',
       },
-    },
-  };
-}
+      {
+        tag: 'script',
+        attrs: {
+          src: 'https://cmp.osano.com/AzqB4OUPPVD5j8EeT/bc796e8a-d3d4-4a74-b9c7-f737cbc3379b/osano.js',
+        },
+        injectTo: 'body',
+      },
+    ],
+  },
+});
 
 export default defineConfig({
   build: {
@@ -54,7 +50,6 @@ export default defineConfig({
   },
 
   plugins: [
-    osanoPlugin(),
     react(),
 
     // Match CRA SVG transformation.
@@ -66,6 +61,8 @@ export default defineConfig({
         namedExport: 'ReactComponent',
       },
     }),
+
+    osanoPlugin(),
   ],
 
   server: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,15 +11,15 @@ function osanoPlugin() {
       handler() {
         return [
           {
+            tag: 'style',
+            children: '.osano-cm-widget{display: none;}',
+            injectTo: 'head',
+          },
+          {
             tag: 'script',
             attrs: {
               src: 'https://cmp.osano.com/AzqB4OUPPVD5j8EeT/bc796e8a-d3d4-4a74-b9c7-f737cbc3379b/osano.js',
             },
-            injectTo: 'body',
-          },
-          {
-            tag: 'style',
-            children: '.osano-cm-widget{display: none;}',
             injectTo: 'body',
           },
         ];

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,24 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 
+function osanoPlugin() {
+  return {
+    name: 'inject-osano',
+    transformIndexHtml: {
+      order: 'pre',
+      handler(html, ctx) {
+        if (ctx.server) return html;
+        const osanoSnippet = `
+    <!-- Osano Cookies Consent Notice start for pamdas.org -->
+    <script src="https://cmp.osano.com/AzqB4OUPPVD5j8EeT/bc796e8a-d3d4-4a74-b9c7-f737cbc3379b/osano.js"></script>
+    <style>.osano-cm-widget{display: none;}</style>
+    <!-- Osano Cookies Consent Notice end for pamdas.org -->`;
+        return html.replace('</body>', `${osanoSnippet}\n</body>`);
+      },
+    },
+  };
+}
+
 export default defineConfig({
   build: {
     // Match CRA build output directory.
@@ -28,6 +46,7 @@ export default defineConfig({
   },
 
   plugins: [
+    osanoPlugin(),
     react(),
 
     // Match CRA SVG transformation.

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,16 +5,24 @@ import svgr from 'vite-plugin-svgr';
 function osanoPlugin() {
   return {
     name: 'inject-osano',
+    apply: 'build',
     transformIndexHtml: {
       order: 'pre',
-      handler(html, ctx) {
-        if (ctx.server) return html;
-        const osanoSnippet = `
-    <!-- Osano Cookies Consent Notice start for pamdas.org -->
-    <script src="https://cmp.osano.com/AzqB4OUPPVD5j8EeT/bc796e8a-d3d4-4a74-b9c7-f737cbc3379b/osano.js"></script>
-    <style>.osano-cm-widget{display: none;}</style>
-    <!-- Osano Cookies Consent Notice end for pamdas.org -->`;
-        return html.replace('</body>', `${osanoSnippet}\n</body>`);
+      handler() {
+        return [
+          {
+            tag: 'script',
+            attrs: {
+              src: 'https://cmp.osano.com/AzqB4OUPPVD5j8EeT/bc796e8a-d3d4-4a74-b9c7-f737cbc3379b/osano.js',
+            },
+            injectTo: 'body',
+          },
+          {
+            tag: 'style',
+            children: '.osano-cm-widget{display: none;}',
+            injectTo: 'body',
+          },
+        ];
       },
     },
   };


### PR DESCRIPTION
feat: update config in vite.
ix: A osanoPlugin() Vite plugin in vite.config.js that uses transformIndexHtml to inject the Osano snippet. It checks ctx.server — when
  present, the dev server is running (local dev), so it skips injection. During vite build (used by all CI/CD deployments), ctx.server is
  undefined, so the script gets injected.

