### PR TITLE
ci: queue workflow runs instead of cancelling in-progress

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   actions: read

--- a/.github/workflows/pr-envs.yml
+++ b/.github/workflows/pr-envs.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   actions: read

--- a/.github/workflows/pr-envs.yml
+++ b/.github/workflows/pr-envs.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   actions: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   actions: read


### PR DESCRIPTION
## Summary
Change concurrency behavior from cancel-in-progress to queue-in-progress across all workflows. Tests take long enough that cancelling wastes significant CI time — queuing lets the current run finish while the next one waits.

## Changes
- Set `cancel-in-progress: false` in pr-envs, develop, and release workflows
- Concurrency groups remain unchanged — only the cancellation behavior changes

## Files Changed
- `.github/workflows/pr-envs.yml`
- `.github/workflows/develop.yml`
- `.github/workflows/release.yml`