### PR TITLE
Add download patrol track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 .env.test.local
 .env.production.local
 
+.idea
+
 !.yarn/patches
 !.yarn/plugins
 !.yarn/releases

--- a/public/locales/en-US/patrols.json
+++ b/public/locales/en-US/patrols.json
@@ -65,6 +65,7 @@
     "label": "View Patrol Options",
     "title": "Patrol Options",
     "downloadTrackButton": "Download Patrol Track",
+    "noTrackDataTooltip": "No data to download",
     "printPatrolButton": "Print Patrol",
     "restorePatrol": "Restore Patrol",
     "startPatrol": "Start Patrol"

--- a/public/locales/en-US/patrols.json
+++ b/public/locales/en-US/patrols.json
@@ -64,6 +64,7 @@
     "endPatrol": "End Patrol",
     "label": "View Patrol Options",
     "title": "Patrol Options",
+    "downloadTrackButton": "Download Patrol Track",
     "printPatrolButton": "Print Patrol",
     "restorePatrol": "Restore Patrol",
     "startPatrol": "Start Patrol"

--- a/public/locales/es/patrols.json
+++ b/public/locales/es/patrols.json
@@ -66,7 +66,7 @@
     "printPatrolButton": "Imprimir patrulla",
     "restorePatrol": "Restaurar Patrulla",
     "startPatrol": "Iniciar Patrullaje",
-    "noTrackDataTooltip": "No data to download"
+    "noTrackDataTooltip": "No hay datos para descargar"
   },
   "patrolList": {
     "emptyPatrolList": "No hay más patrullas que mostrar."

--- a/public/locales/es/patrols.json
+++ b/public/locales/es/patrols.json
@@ -65,7 +65,8 @@
     "downloadTrackButton": "Descargar ruta de patrulla",
     "printPatrolButton": "Imprimir patrulla",
     "restorePatrol": "Restaurar Patrulla",
-    "startPatrol": "Iniciar Patrullaje"
+    "startPatrol": "Iniciar Patrullaje",
+    "noTrackDataTooltip": "No data to download"
   },
   "patrolList": {
     "emptyPatrolList": "No hay más patrullas que mostrar."

--- a/public/locales/es/patrols.json
+++ b/public/locales/es/patrols.json
@@ -62,6 +62,7 @@
     "copyButton": "Copiar link del patrulla",
     "copyButtonMessage": "Link copiado",
     "endPatrol": "Finalizar Patrullaje",
+    "downloadTrackButton": "Descargar ruta de patrulla",
     "printPatrolButton": "Imprimir patrulla",
     "restorePatrol": "Restaurar Patrulla",
     "startPatrol": "Iniciar Patrullaje"

--- a/public/locales/fr/patrols.json
+++ b/public/locales/fr/patrols.json
@@ -66,7 +66,7 @@
     "printPatrolButton": "Imprimer la Patrouille",
     "restorePatrol": "Restaurer la Patrouille",
     "startPatrol": "Commencer la Patrouille",
-    "noTrackDataTooltip": "No data to download"
+    "noTrackDataTooltip": "Aucune donnée à télécharger"
   },
   "patrolList": {
     "emptyPatrolList": "Aucune patrouille à afficher."

--- a/public/locales/fr/patrols.json
+++ b/public/locales/fr/patrols.json
@@ -62,6 +62,7 @@
     "copyButton": "Copier le lien de la patrouille",
     "copyButtonMessage": "Lien copié avec succès",
     "endPatrol": "Terminer la Patrouille",
+    "downloadTrackButton": "Télécharger la Piste de la Patrouille",
     "printPatrolButton": "Imprimer la Patrouille",
     "restorePatrol": "Restaurer la Patrouille",
     "startPatrol": "Commencer la Patrouille"

--- a/public/locales/fr/patrols.json
+++ b/public/locales/fr/patrols.json
@@ -65,7 +65,8 @@
     "downloadTrackButton": "Télécharger la Piste de la Patrouille",
     "printPatrolButton": "Imprimer la Patrouille",
     "restorePatrol": "Restaurer la Patrouille",
-    "startPatrol": "Commencer la Patrouille"
+    "startPatrol": "Commencer la Patrouille",
+    "noTrackDataTooltip": "No data to download"
   },
   "patrolList": {
     "emptyPatrolList": "Aucune patrouille à afficher."

--- a/public/locales/ne-NP/patrols.json
+++ b/public/locales/ne-NP/patrols.json
@@ -62,6 +62,7 @@
         "copyButton": "गस्तीको लिकं कपि गर्नुहोस्",
         "copyButtonMessage": "लिकं कपि भयो",
         "endPatrol": "गस्ती अन्त्य गर्नुहोस्",
+        "downloadTrackButton": "गस्तीको ट्र्याक डाउनलोड गर्नुहोस्",
         "printPatrolButton": "गस्ती प्रिन्ट गर्नुहोस्",
         "restorePatrol": "गस्ती पुर्नस्थापना गर्नुहोस्",
         "startPatrol": "गस्ती सुरु गर्नुहोस्",

--- a/public/locales/ne-NP/patrols.json
+++ b/public/locales/ne-NP/patrols.json
@@ -1,85 +1,86 @@
 {
-    "addToPatrolModal": {
-        "title": "गस्तीमा थप्नुहोस्",
-        "cancel": "रद्द गर्नुहोस्",
-        "noMorePatrols": "प्रदर्शनीका लागि कुनै गस्ती छैन ।",
-        "loading": "लोड हुँदैछ…"
+  "addToPatrolModal": {
+    "title": "गस्तीमा थप्नुहोस्",
+    "cancel": "रद्द गर्नुहोस्",
+    "noMorePatrols": "प्रदर्शनीका लागि कुनै गस्ती छैन ।",
+    "loading": "लोड हुँदैछ…"
+  },
+  "detailView": {
+    "addEmptyNoteAlert": "नयाँ नोट सुरक्षित गर्न सकिएन: पुरानै नोट सुरक्षित हुन बाँकी छ",
+    "formButtons": {
+      "save": "सुरक्षित गर्नुहोस्",
+      "cancel": "रद्द गर्नुहोस्"
     },
-    "detailView": {
-        "addEmptyNoteAlert": "नयाँ नोट सुरक्षित गर्न सकिएन: पुरानै नोट सुरक्षित हुन बाँकी छ",
-        "formButtons": {
-            "save": "सुरक्षित गर्नुहोस्",
-            "cancel": "रद्द गर्नुहोस्"
-        },
-        "header": {
-            "patrolSchedule": "{{scheduledStartTime}} निर्धारण गरिएको",
-            "patrolStartButton": "सुरु",
-            "patrolRestoreButton": "पुर्नस्थापना",
-            "uiStateTitles": {
-                "active": "सकृय",
-                "cancelled": "रद्द गरियो",
-                "done": "भयो",
-                "invalid": "स्वरुप मिलेन",
-                "readyToStart": "सुरु गर्न तयार अवस्थामा",
-                "scheduled": "निर्धारित",
-                "startOverdue": "बाँकी रहेको काम सुरु गर्नुहोस्"
-            }
-        },
-        "loadingMessage": "सुरक्षित हुँदैछ…",
-        "planSection": {
-            "autoStartCheckboxLargeLabel": "यसै समय अर्थरेन्जरमा स्वतः गस्ती सुरु गर्नुहोस्",
-            "autoStartCheckboxSmallLabel": "अर्थरेन्जरमा स्वतः गस्ती सुरु गर्नुहोस्",
-            "autoEndCheckboxLargeLabel": "यसै समय अर्थरेन्जरमा स्वतः गस्ती अन्त्य गर्नुहोस्",
-            "autoEndCheckboxSmallLabel": "अर्थरेन्जरमा स्वतः गस्ती अन्त्य गर्नुहोस्",
-            "endDateLabel": "अन्त्य मिति",
-            "endTimeLabel": "अन्त्य समय",
-            "endLocationLargeLabel": "अन्त्य स्थान",
-            "endLocationSmallLabel": "स्थान",
-            "locationSelectorPlaceholder": "स्थान सेट गर्नुहोस्",
-            "objectiveLabel": "उद्देश्य",
-            "objectivePlaceholder": "गस्तीको उद्देश्य वर्णन गर्नुहोस्…",
-            "startDateLabel": "सुरु मिति",
-            "startTimeLabel": "सुरु समय",
-            "startLocationLargeLabel": "सुरु स्थान",
-            "startLocationSmallLabel": "स्थान",
-            "title": "योजना",
-            "trackedByLabel": "द्वारा ट्रयाक गरिएको",
-            "trackedByPlaceholder": "उपकरण छान्नुहोस्…"
-        },
-        "quickLinksTitles": {
-            "activity": "गतिविधि",
-            "history": "इतिहास",
-            "plan": "योजना"
-        }
+    "header": {
+      "patrolSchedule": "{{scheduledStartTime}} निर्धारण गरिएको",
+      "patrolStartButton": "सुरु",
+      "patrolRestoreButton": "पुर्नस्थापना",
+      "uiStateTitles": {
+        "active": "सकृय",
+        "cancelled": "रद्द गरियो",
+        "done": "भयो",
+        "invalid": "स्वरुप मिलेन",
+        "readyToStart": "सुरु गर्न तयार अवस्थामा",
+        "scheduled": "निर्धारित",
+        "startOverdue": "बाँकी रहेको काम सुरु गर्नुहोस्"
+      }
     },
-    "invalidDatesModal": {
-        "body": "यो गस्ती सुरक्षित गर्न सकिएन । गस्तीको अन्त्य समय सुरुवाती समय भन्दा पछि हुनुपर्छ । कृपया गस्तीको सुरुवाती समय अथवा अन्त्य समय सच्याउनुहोस्",
-        "okButton": "ठीक छ",
-        "title": "गस्ती समय मिलेन"
+    "loadingMessage": "सुरक्षित हुँदैछ…",
+    "planSection": {
+      "autoStartCheckboxLargeLabel": "यसै समय अर्थरेन्जरमा स्वतः गस्ती सुरु गर्नुहोस्",
+      "autoStartCheckboxSmallLabel": "अर्थरेन्जरमा स्वतः गस्ती सुरु गर्नुहोस्",
+      "autoEndCheckboxLargeLabel": "यसै समय अर्थरेन्जरमा स्वतः गस्ती अन्त्य गर्नुहोस्",
+      "autoEndCheckboxSmallLabel": "अर्थरेन्जरमा स्वतः गस्ती अन्त्य गर्नुहोस्",
+      "endDateLabel": "अन्त्य मिति",
+      "endTimeLabel": "अन्त्य समय",
+      "endLocationLargeLabel": "अन्त्य स्थान",
+      "endLocationSmallLabel": "स्थान",
+      "locationSelectorPlaceholder": "स्थान सेट गर्नुहोस्",
+      "objectiveLabel": "उद्देश्य",
+      "objectivePlaceholder": "गस्तीको उद्देश्य वर्णन गर्नुहोस्…",
+      "startDateLabel": "सुरु मिति",
+      "startTimeLabel": "सुरु समय",
+      "startLocationLargeLabel": "सुरु स्थान",
+      "startLocationSmallLabel": "स्थान",
+      "title": "योजना",
+      "trackedByLabel": "द्वारा ट्रयाक गरिएको",
+      "trackedByPlaceholder": "उपकरण छान्नुहोस्…"
     },
-    "patrolMenu": {
-        "cancelPatrol": "गस्ती रद्द गर्नुहोस्",
-        "copyButton": "गस्तीको लिकं कपि गर्नुहोस्",
-        "copyButtonMessage": "लिकं कपि भयो",
-        "endPatrol": "गस्ती अन्त्य गर्नुहोस्",
-        "downloadTrackButton": "गस्तीको ट्र्याक डाउनलोड गर्नुहोस्",
-        "printPatrolButton": "गस्ती प्रिन्ट गर्नुहोस्",
-        "restorePatrol": "गस्ती पुर्नस्थापना गर्नुहोस्",
-        "startPatrol": "गस्ती सुरु गर्नुहोस्",
-        "label": "गस्तीका विकल्पहरु हेर्नुहोस्",
-        "title": "गस्तीका विकल्पहरु"
-    },
-    "patrolList": {
-        "emptyPatrolList": "प्रदर्शनीका लागि कुनै गस्ती छैन ।"
-    },
-    "patrolListItem": {
-        "restoreButton": "पुर्नस्थापना गर्नुहोस्",
-        "scheduledTitle": "निर्धारण गरियो:",
-        "startButton": "सुरु गर्नुहोस्"
-    },
-    "trackToggleButton": {
-        "tracksPinned": "ट्रयाकहरु पिन गरियो",
-        "tracksOn": "ट्रयाक अन गर्नुहोस्",
-        "tracksOff": "ट्रयाक अफ गर्नुहोस्"
+    "quickLinksTitles": {
+      "activity": "गतिविधि",
+      "history": "इतिहास",
+      "plan": "योजना"
     }
+  },
+  "invalidDatesModal": {
+    "body": "यो गस्ती सुरक्षित गर्न सकिएन । गस्तीको अन्त्य समय सुरुवाती समय भन्दा पछि हुनुपर्छ । कृपया गस्तीको सुरुवाती समय अथवा अन्त्य समय सच्याउनुहोस्",
+    "okButton": "ठीक छ",
+    "title": "गस्ती समय मिलेन"
+  },
+  "patrolMenu": {
+    "cancelPatrol": "गस्ती रद्द गर्नुहोस्",
+    "copyButton": "गस्तीको लिकं कपि गर्नुहोस्",
+    "copyButtonMessage": "लिकं कपि भयो",
+    "endPatrol": "गस्ती अन्त्य गर्नुहोस्",
+    "downloadTrackButton": "गस्तीको ट्र्याक डाउनलोड गर्नुहोस्",
+    "printPatrolButton": "गस्ती प्रिन्ट गर्नुहोस्",
+    "restorePatrol": "गस्ती पुर्नस्थापना गर्नुहोस्",
+    "startPatrol": "गस्ती सुरु गर्नुहोस्",
+    "label": "गस्तीका विकल्पहरु हेर्नुहोस्",
+    "title": "गस्तीका विकल्पहरु",
+    "noTrackDataTooltip": "No data to download"
+  },
+  "patrolList": {
+    "emptyPatrolList": "प्रदर्शनीका लागि कुनै गस्ती छैन ।"
+  },
+  "patrolListItem": {
+    "restoreButton": "पुर्नस्थापना गर्नुहोस्",
+    "scheduledTitle": "निर्धारण गरियो:",
+    "startButton": "सुरु गर्नुहोस्"
+  },
+  "trackToggleButton": {
+    "tracksPinned": "ट्रयाकहरु पिन गरियो",
+    "tracksOn": "ट्रयाक अन गर्नुहोस्",
+    "tracksOff": "ट्रयाक अफ गर्नुहोस्"
+  }
 }

--- a/public/locales/ne-NP/patrols.json
+++ b/public/locales/ne-NP/patrols.json
@@ -68,7 +68,7 @@
     "startPatrol": "गस्ती सुरु गर्नुहोस्",
     "label": "गस्तीका विकल्पहरु हेर्नुहोस्",
     "title": "गस्तीका विकल्पहरु",
-    "noTrackDataTooltip": "No data to download"
+    "noTrackDataTooltip": "डाउनलोड गर्न कुनै डेटा छैन"
   },
   "patrolList": {
     "emptyPatrolList": "प्रदर्शनीका लागि कुनै गस्ती छैन ।"

--- a/public/locales/pt/patrols.json
+++ b/public/locales/pt/patrols.json
@@ -66,7 +66,7 @@
     "printPatrolButton": "Imprimir patrulha",
     "restorePatrol": "Restaurar patrulha",
     "startPatrol": "Iniciar patrulha",
-    "noTrackDataTooltip": "No data to download"
+    "noTrackDataTooltip": "Nenhum dado para baixar"
   },
   "patrolList": {
     "emptyPatrolList": "Não há patrulhas para mostrar"

--- a/public/locales/pt/patrols.json
+++ b/public/locales/pt/patrols.json
@@ -62,6 +62,7 @@
         "copyButton": "Copiar link de patrulha",
         "copyButtonMessage": "Link copiado",
         "endPatrol": "Finalizar patrulha",
+        "downloadTrackButton": "Baixar trilha da patrulha",
         "printPatrolButton": "Imprimir patrulha",
         "restorePatrol": "Restaurar patrulha",
         "startPatrol": "Iniciar patrulha"

--- a/public/locales/pt/patrols.json
+++ b/public/locales/pt/patrols.json
@@ -1,83 +1,84 @@
 {
-    "addToPatrolModal": {
-        "title": "Adicionar à Patrulha",
-        "cancel": "Cancelar",
-        "noMorePatrols": "Não há mais patrulhas para mostrar",
-        "loading": "Carregando..."
+  "addToPatrolModal": {
+    "title": "Adicionar à Patrulha",
+    "cancel": "Cancelar",
+    "noMorePatrols": "Não há mais patrulhas para mostrar",
+    "loading": "Carregando..."
+  },
+  "detailView": {
+    "addEmptyNoteAlert": "Não é possivel adicionar uma nova anotação: existe uma anotação vazia que ainda não foi salva",
+    "formButtons": {
+      "save": "Salvar",
+      "cancel": "Cancelar"
     },
-    "detailView": {
-        "addEmptyNoteAlert": "Não é possivel adicionar uma nova anotação: existe uma anotação vazia que ainda não foi salva",
-        "formButtons": {
-            "save": "Salvar",
-            "cancel": "Cancelar"
-        },
-        "header": {
-            "patrolSchedule": "Programada para  {{scheduledStartTime}}",
-            "patrolStartButton": "Iniciar",
-            "patrolRestoreButton": "Restaurar",
-            "uiStateTitles": {
-                "active": "Ativa",
-                "cancelled": "Cancelada",
-                "done": "Finalizada",
-                "invalid": "Configuração inválida",
-                "readyToStart": "Pronta para começar",
-                "scheduled": "Programada",
-                "startOverdue": "Início atrasado"
-            }
-        },
-        "loadingMessage": "Salvando...",
-        "planSection": {
-            "autoStartCheckboxLargeLabel": "Iniciar automaticamente a patrulha em EarthRanger no horário programado",
-            "autoStartCheckboxSmallLabel": "Iniciar automaticamente a patrulha em EarthRanger",
-            "autoEndCheckboxLargeLabel": "Finalizar automaticamente a patrulha em EarthRanger no horário programado",
-            "autoEndCheckboxSmallLabel": "Finalizar automaticamente a patrulha em EarthRanger",
-            "endDateLabel": "Data da finalização",
-            "endTimeLabel": "Hora da finalização",
-            "endLocationLargeLabel": "Localização da finalização",
-            "endLocationSmallLabel": "Localização",
-            "locationSelectorPlaceholder": "Definir localização",
-            "objectiveLabel": "Objetivo",
-            "objectivePlaceholder": "Descrever o propósito da patrulha...",
-            "startDateLabel": "Data de início:",
-            "startTimeLabel": "Hora de início:",
-            "startLocationLargeLabel": "Localização de início:",
-            "startLocationSmallLabel": "Localização",
-            "title": "Plano",
-            "trackedByLabel": "Rastreado por:",
-            "trackedByPlaceholder": "Selecionar dispositivo..."
-        },
-        "quickLinksTitles": {
-            "activity": "Atividade",
-            "history": "Histórico",
-            "plan": "Plano"
-        }
+    "header": {
+      "patrolSchedule": "Programada para  {{scheduledStartTime}}",
+      "patrolStartButton": "Iniciar",
+      "patrolRestoreButton": "Restaurar",
+      "uiStateTitles": {
+        "active": "Ativa",
+        "cancelled": "Cancelada",
+        "done": "Finalizada",
+        "invalid": "Configuração inválida",
+        "readyToStart": "Pronta para começar",
+        "scheduled": "Programada",
+        "startOverdue": "Início atrasado"
+      }
     },
-    "invalidDatesModal": {
-        "body": "Esta patrulha não pode ser salva. A hora de finalização de uma patrulha deve ser posterior à hora de início. Por favor, corrija a hora de início ou finalização da patrulha.",
-        "okButton": "Ok",
-        "title": "Datas de patrulha inválidas."
+    "loadingMessage": "Salvando...",
+    "planSection": {
+      "autoStartCheckboxLargeLabel": "Iniciar automaticamente a patrulha em EarthRanger no horário programado",
+      "autoStartCheckboxSmallLabel": "Iniciar automaticamente a patrulha em EarthRanger",
+      "autoEndCheckboxLargeLabel": "Finalizar automaticamente a patrulha em EarthRanger no horário programado",
+      "autoEndCheckboxSmallLabel": "Finalizar automaticamente a patrulha em EarthRanger",
+      "endDateLabel": "Data da finalização",
+      "endTimeLabel": "Hora da finalização",
+      "endLocationLargeLabel": "Localização da finalização",
+      "endLocationSmallLabel": "Localização",
+      "locationSelectorPlaceholder": "Definir localização",
+      "objectiveLabel": "Objetivo",
+      "objectivePlaceholder": "Descrever o propósito da patrulha...",
+      "startDateLabel": "Data de início:",
+      "startTimeLabel": "Hora de início:",
+      "startLocationLargeLabel": "Localização de início:",
+      "startLocationSmallLabel": "Localização",
+      "title": "Plano",
+      "trackedByLabel": "Rastreado por:",
+      "trackedByPlaceholder": "Selecionar dispositivo..."
     },
-    "patrolMenu": {
-        "cancelPatrol": "Cancelar Patrulha",
-        "copyButton": "Copiar link de patrulha",
-        "copyButtonMessage": "Link copiado",
-        "endPatrol": "Finalizar patrulha",
-        "downloadTrackButton": "Baixar trilha da patrulha",
-        "printPatrolButton": "Imprimir patrulha",
-        "restorePatrol": "Restaurar patrulha",
-        "startPatrol": "Iniciar patrulha"
-    },
-    "patrolList": {
-        "emptyPatrolList": "Não há patrulhas para mostrar"
-    },
-    "patrolListItem": {
-        "restoreButton": "Restaurar",
-        "scheduledTitle": "Programada:",
-        "startButton": "Iniciar"
-    },
-    "trackToggleButton": {
-        "tracksPinned": "Rastros fixados",
-        "tracksOn": "Rastros ativados",
-        "tracksOff": "Rastros desativados"
+    "quickLinksTitles": {
+      "activity": "Atividade",
+      "history": "Histórico",
+      "plan": "Plano"
     }
+  },
+  "invalidDatesModal": {
+    "body": "Esta patrulha não pode ser salva. A hora de finalização de uma patrulha deve ser posterior à hora de início. Por favor, corrija a hora de início ou finalização da patrulha.",
+    "okButton": "Ok",
+    "title": "Datas de patrulha inválidas."
+  },
+  "patrolMenu": {
+    "cancelPatrol": "Cancelar Patrulha",
+    "copyButton": "Copiar link de patrulha",
+    "copyButtonMessage": "Link copiado",
+    "endPatrol": "Finalizar patrulha",
+    "downloadTrackButton": "Baixar trilha da patrulha",
+    "printPatrolButton": "Imprimir patrulha",
+    "restorePatrol": "Restaurar patrulha",
+    "startPatrol": "Iniciar patrulha",
+    "noTrackDataTooltip": "No data to download"
+  },
+  "patrolList": {
+    "emptyPatrolList": "Não há patrulhas para mostrar"
+  },
+  "patrolListItem": {
+    "restoreButton": "Restaurar",
+    "scheduledTitle": "Programada:",
+    "startButton": "Iniciar"
+  },
+  "trackToggleButton": {
+    "tracksPinned": "Rastros fixados",
+    "tracksOn": "Rastros ativados",
+    "tracksOff": "Rastros desativados"
+  }
 }

--- a/public/locales/sw/patrols.json
+++ b/public/locales/sw/patrols.json
@@ -68,7 +68,7 @@
     "printPatrolButton": "Chapisha Doria",
     "restorePatrol": "Rejesha Doria",
     "startPatrol": "Anza Doria",
-    "noTrackDataTooltip": "No data to download"
+    "noTrackDataTooltip": "Hakuna data ya kupakua"
   },
   "patrolList": {
     "emptyPatrolList": "Hakuna doria za kuonyesha."

--- a/public/locales/sw/patrols.json
+++ b/public/locales/sw/patrols.json
@@ -67,7 +67,8 @@
     "downloadTrackButton": "Pakua Njia ya Doria",
     "printPatrolButton": "Chapisha Doria",
     "restorePatrol": "Rejesha Doria",
-    "startPatrol": "Anza Doria"
+    "startPatrol": "Anza Doria",
+    "noTrackDataTooltip": "No data to download"
   },
   "patrolList": {
     "emptyPatrolList": "Hakuna doria za kuonyesha."

--- a/public/locales/sw/patrols.json
+++ b/public/locales/sw/patrols.json
@@ -64,6 +64,7 @@
     "endPatrol": "Maliza Doria",
     "label": "Angalia Chaguzi za Doria",
     "title": "Chaguzi za Doria",
+    "downloadTrackButton": "Pakua Njia ya Doria",
     "printPatrolButton": "Chapisha Doria",
     "restorePatrol": "Rejesha Doria",
     "startPatrol": "Anza Doria"

--- a/src/PatrolMenu/index.js
+++ b/src/PatrolMenu/index.js
@@ -52,23 +52,23 @@ const PatrolMenu = ({
   );
 
   const doesPatrolLeaderHaveTracksWithinPatrolTimeRange = useMemo(() => {
-    if (patrolLeaderTrackTimes?.length > 0) {
-      const patrolStartTimeStamp = patrolTimeRange?.start_time
-        ? new Date(patrolTimeRange.start_time).getTime()
-        : null;
-      const patrolEndTimeStamp = patrolTimeRange?.end_time
-        ? new Date(patrolTimeRange.end_time).getTime()
-        : null;
-      if (!patrolStartTimeStamp && !patrolEndTimeStamp) {
-        return true;
-      }
-      return patrolLeaderTrackTimes.some((trackTime) => {
-        const trackTimeStamp = new Date(trackTime).getTime();
-        return (!patrolStartTimeStamp || trackTimeStamp >= patrolStartTimeStamp)
-          && (!patrolEndTimeStamp || trackTimeStamp <= patrolEndTimeStamp);
-      });
-    }
-    return false;
+    if (!patrolLeaderTrackTimes?.length) return false;
+
+    const patrolStartTimestamp = patrolTimeRange?.start_time
+      ? new Date(patrolTimeRange.start_time).getTime()
+      : null;
+    const patrolEndTimestamp = patrolTimeRange?.end_time
+      ? new Date(patrolTimeRange.end_time).getTime()
+      : null;
+
+    if (!patrolStartTimestamp && !patrolEndTimestamp) return true;
+
+    // Track times are sorted newest-first; check range overlap using only the first/last entries
+    const trackNewest = new Date(patrolLeaderTrackTimes[0]).getTime();
+    const trackOldest = new Date(patrolLeaderTrackTimes[patrolLeaderTrackTimes.length - 1]).getTime();
+
+    return (!patrolStartTimestamp || trackNewest >= patrolStartTimestamp)
+      && (!patrolEndTimestamp || trackOldest <= patrolEndTimestamp);
   }, [patrolLeaderTrackTimes, patrolTimeRange]);
 
   const patrolIsDone = useMemo(() => {
@@ -148,6 +148,8 @@ const PatrolMenu = ({
       });
   }, [patrol.serial_number, patrolLeader, patrolTimeRange]);
 
+  const isDownloadDisabled = !patrolLeader || !doesPatrolLeaderHaveTracksWithinPatrolTimeRange;
+
   const handlePrint = useReactToPrint({
     contentRef: printableContentRef,
     documentTitle: `${patrol.serial_number} ${patrolTitle} `,
@@ -194,23 +196,23 @@ const PatrolMenu = ({
       </KebabMenu.Option>
     }
 
-    <OverlayTrigger
-      placement="top"
-      overlay={(!patrolLeader || !doesPatrolLeaderHaveTracksWithinPatrolTimeRange)
-        ? <Tooltip>{t('noTrackDataTooltip')}</Tooltip>
-        : <span />
-      }
-    >
-      <span>
-        <KebabMenu.Option
-          disabled={!patrolLeader || !doesPatrolLeaderHaveTracksWithinPatrolTimeRange}
-          onClick={handleDownloadTrack}
+    {isDownloadDisabled
+      ? <OverlayTrigger
+          placement="top"
+          overlay={<Tooltip id="download-track-tooltip">{t('noTrackDataTooltip')}</Tooltip>}
         >
-          <DownloadArrowIcon data-testid="download-arrow-icon" />
-          {t('downloadTrackButton')}
-        </KebabMenu.Option>
-      </span>
-    </OverlayTrigger>
+        <span>
+          <KebabMenu.Option disabled onClick={handleDownloadTrack}>
+            <DownloadArrowIcon data-testid="download-arrow-icon" />
+            {t('downloadTrackButton')}
+          </KebabMenu.Option>
+        </span>
+      </OverlayTrigger>
+      : <KebabMenu.Option onClick={handleDownloadTrack}>
+        <DownloadArrowIcon data-testid="download-arrow-icon" />
+        {t('downloadTrackButton')}
+      </KebabMenu.Option>
+    }
   </KebabMenu>;
 };
 

--- a/src/PatrolMenu/index.js
+++ b/src/PatrolMenu/index.js
@@ -1,5 +1,7 @@
 import React, { memo, useMemo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
 import { useReactToPrint } from 'react-to-print';
 import { useTranslation } from 'react-i18next';
 
@@ -44,17 +46,30 @@ const PatrolMenu = ({
   const { hasPatrolsUpdatePermission } = usePatrolsPermissions();
   const patrolLeader = patrol.patrol_segments[0]?.leader;
   const patrolTimeRange = patrol.patrol_segments[0]?.time_range;
-  const patrolLeaderTrackHasPoints = useSelector((state) => {
-    const times = state.data.tracks[patrolLeader?.id]?.track?.features?.[0]?.properties?.coordinateProperties?.times;
-    if (!times?.length) return false;
-    const since = patrolTimeRange?.start_time ? new Date(patrolTimeRange.start_time).getTime() : null;
-    const until = patrolTimeRange?.end_time ? new Date(patrolTimeRange.end_time).getTime() : null;
-    if (!since && !until) return true;
-    return times.some((time) => {
-      const t = new Date(time).getTime();
-      return (!since || t >= since) && (!until || t <= until);
-    });
-  });
+
+  const patrolLeaderTrackTimes = useSelector((state) =>
+    state.data.tracks[patrolLeader?.id]?.track?.features?.[0]?.properties?.coordinateProperties?.times
+  );
+
+  const doesPatrolLeaderHaveTracksWithinPatrolTimeRange = useMemo(() => {
+    if (patrolLeaderTrackTimes?.length > 0) {
+      const patrolStartTimeStamp = patrolTimeRange?.start_time
+        ? new Date(patrolTimeRange.start_time).getTime()
+        : null;
+      const patrolEndTimeStamp = patrolTimeRange?.end_time
+        ? new Date(patrolTimeRange.end_time).getTime()
+        : null;
+      if (!patrolStartTimeStamp && !patrolEndTimeStamp) {
+        return true;
+      }
+      return patrolLeaderTrackTimes.some((trackTime) => {
+        const trackTimeStamp = new Date(trackTime).getTime();
+        return (!patrolStartTimeStamp || trackTimeStamp >= patrolStartTimeStamp)
+          && (!patrolEndTimeStamp || trackTimeStamp <= patrolEndTimeStamp);
+      });
+    }
+    return false;
+  }, [patrolLeaderTrackTimes, patrolTimeRange]);
 
   const patrolIsDone = useMemo(() => {
     return patrolState === PATROL_UI_STATES.DONE;
@@ -118,13 +133,19 @@ const PatrolMenu = ({
   }, [canEnd, onPatrolChange, patrolStartStopTitle]);
 
   const handleDownloadTrack = useCallback(() => {
+    if (!patrolLeader) return;
+
     patrolListItemTracker.track('Download patrol track from patrol list item kebab menu');
 
     const params = {};
     if (patrolTimeRange?.start_time) params.since = patrolTimeRange.start_time;
     if (patrolTimeRange?.end_time) params.until = patrolTimeRange.end_time;
 
-    downloadFileFromUrl(TRACKS_API_URL(patrolLeader.id), { params, filename: `Patrol_${patrol.serial_number}_${patrolLeader.name}.geojson` });
+    const sanitizedLeaderName = patrolLeader.name.replace(/[/\\:*?"<>|]/g, '_').trim();
+    void downloadFileFromUrl(TRACKS_API_URL(patrolLeader.id), { params, filename: `Patrol_${patrol.serial_number}_${sanitizedLeaderName}.geojson` })
+      .catch((error) => {
+        console.error('Failed to download patrol track', error);
+      });
   }, [patrol.serial_number, patrolLeader, patrolTimeRange]);
 
   const handlePrint = useReactToPrint({
@@ -173,15 +194,23 @@ const PatrolMenu = ({
       </KebabMenu.Option>
     }
 
-    <span title={(!patrolLeader || !patrolLeaderTrackHasPoints) ? t('noTrackDataTooltip') : ''}>
-      <KebabMenu.Option
-        disabled={!patrolLeader || !patrolLeaderTrackHasPoints}
-        onClick={handleDownloadTrack}
-      >
-        <DownloadArrowIcon data-testid="download-arrow-icon" />
-        {t('downloadTrackButton')}
-      </KebabMenu.Option>
-    </span>
+    <OverlayTrigger
+      placement="top"
+      overlay={(!patrolLeader || !doesPatrolLeaderHaveTracksWithinPatrolTimeRange)
+        ? <Tooltip>{t('noTrackDataTooltip')}</Tooltip>
+        : <span />
+      }
+    >
+      <span>
+        <KebabMenu.Option
+          disabled={!patrolLeader || !doesPatrolLeaderHaveTracksWithinPatrolTimeRange}
+          onClick={handleDownloadTrack}
+        >
+          <DownloadArrowIcon data-testid="download-arrow-icon" />
+          {t('downloadTrackButton')}
+        </KebabMenu.Option>
+      </span>
+    </OverlayTrigger>
   </KebabMenu>;
 };
 

--- a/src/PatrolMenu/index.js
+++ b/src/PatrolMenu/index.js
@@ -199,7 +199,7 @@ const PatrolMenu = ({
     {isDownloadDisabled
       ? <OverlayTrigger
           placement="top"
-          overlay={<Tooltip id="download-track-tooltip">{t('noTrackDataTooltip')}</Tooltip>}
+          overlay={<Tooltip id={`download-track-tooltip-${patrol.id}`}>{t('noTrackDataTooltip')}</Tooltip>}
         >
         <span>
           <KebabMenu.Option disabled onClick={handleDownloadTrack}>

--- a/src/PatrolMenu/index.js
+++ b/src/PatrolMenu/index.js
@@ -1,4 +1,5 @@
 import React, { memo, useMemo, useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import { useReactToPrint } from 'react-to-print';
 import { useTranslation } from 'react-i18next';
 
@@ -41,6 +42,19 @@ const PatrolMenu = ({
   const patrolState = calcPatrolState(patrol);
 
   const { hasPatrolsUpdatePermission } = usePatrolsPermissions();
+  const patrolLeader = patrol.patrol_segments[0]?.leader;
+  const patrolTimeRange = patrol.patrol_segments[0]?.time_range;
+  const patrolLeaderTrackHasPoints = useSelector((state) => {
+    const times = state.data.tracks[patrolLeader?.id]?.track?.features?.[0]?.properties?.coordinateProperties?.times;
+    if (!times?.length) return false;
+    const since = patrolTimeRange?.start_time ? new Date(patrolTimeRange.start_time).getTime() : null;
+    const until = patrolTimeRange?.end_time ? new Date(patrolTimeRange.end_time).getTime() : null;
+    if (!since && !until) return true;
+    return times.some((time) => {
+      const t = new Date(time).getTime();
+      return (!since || t >= since) && (!until || t <= until);
+    });
+  });
 
   const patrolIsDone = useMemo(() => {
     return patrolState === PATROL_UI_STATES.DONE;
@@ -103,9 +117,6 @@ const PatrolMenu = ({
     }
   }, [canEnd, onPatrolChange, patrolStartStopTitle]);
 
-  const patrolLeader = patrol.patrol_segments[0]?.leader;
-  const patrolTimeRange = patrol.patrol_segments[0]?.time_range;
-
   const handleDownloadTrack = useCallback(() => {
     patrolListItemTracker.track('Download patrol track from patrol list item kebab menu');
 
@@ -162,12 +173,15 @@ const PatrolMenu = ({
       </KebabMenu.Option>
     }
 
-    { !!patrolLeader &&
-      <KebabMenu.Option onClick={handleDownloadTrack}>
+    <span title={(!patrolLeader || !patrolLeaderTrackHasPoints) ? t('noTrackDataTooltip') : ''}>
+      <KebabMenu.Option
+        disabled={!patrolLeader || !patrolLeaderTrackHasPoints}
+        onClick={handleDownloadTrack}
+      >
         <DownloadArrowIcon data-testid="download-arrow-icon" />
         {t('downloadTrackButton')}
       </KebabMenu.Option>
-    }
+    </span>
   </KebabMenu>;
 };
 

--- a/src/PatrolMenu/index.js
+++ b/src/PatrolMenu/index.js
@@ -2,6 +2,7 @@ import React, { memo, useMemo, useCallback } from 'react';
 import { useReactToPrint } from 'react-to-print';
 import { useTranslation } from 'react-i18next';
 
+import { ReactComponent as DownloadArrowIcon } from '../common/images/icons/download-arrow.svg';
 import { ReactComponent as PrinterIcon } from '../common/images/icons/printer-outline.svg';
 import { ReactComponent as ClipIcon } from '../common/images/icons/link.svg';
 import { ReactComponent as PlayIcon } from '../common/images/icons/play-circle.svg';
@@ -10,10 +11,12 @@ import { ReactComponent as CloseIcon } from '../common/images/icons/close-icon.s
 import { ReactComponent as RestoreIcon } from '../common/images/icons/restore.svg';
 
 import { DAS_HOST, PATROL_UI_STATES, PATROL_API_STATES } from '../constants';
+import { TRACKS_API_URL } from '../ducks/tracks';
 import { usePatrolsPermissions } from '../hooks/usePermissions';
 import { trackEventFactory, PATROL_LIST_ITEM_CATEGORY } from '../utils/analytics';
 import { canEndPatrol, calcPatrolState } from '../utils/patrols';
 import { basePrintingStyles } from '../utils/styles';
+import { downloadFileFromUrl } from '../utils/download';
 
 import TextCopyBtn from '../TextCopyBtn';
 import KebabMenu from '../KebabMenu';
@@ -100,6 +103,19 @@ const PatrolMenu = ({
     }
   }, [canEnd, onPatrolChange, patrolStartStopTitle]);
 
+  const patrolLeader = patrol.patrol_segments[0]?.leader;
+  const patrolTimeRange = patrol.patrol_segments[0]?.time_range;
+
+  const handleDownloadTrack = useCallback(() => {
+    patrolListItemTracker.track('Download patrol track from patrol list item kebab menu');
+
+    const params = {};
+    if (patrolTimeRange?.start_time) params.since = patrolTimeRange.start_time;
+    if (patrolTimeRange?.end_time) params.until = patrolTimeRange.end_time;
+
+    downloadFileFromUrl(TRACKS_API_URL(patrolLeader.id), { params, filename: `Patrol_${patrol.serial_number}_${patrolLeader.name}.geojson` });
+  }, [patrol.serial_number, patrolLeader, patrolTimeRange]);
+
   const handlePrint = useReactToPrint({
     contentRef: printableContentRef,
     documentTitle: `${patrol.serial_number} ${patrolTitle} `,
@@ -143,6 +159,13 @@ const PatrolMenu = ({
       <KebabMenu.Option onClick={handlePrint}>
         <PrinterIcon data-testid="printer-icon" />
         {t('printPatrolButton')}
+      </KebabMenu.Option>
+    }
+
+    { !!patrolLeader &&
+      <KebabMenu.Option onClick={handleDownloadTrack}>
+        <DownloadArrowIcon data-testid="download-arrow-icon" />
+        {t('downloadTrackButton')}
       </KebabMenu.Option>
     }
   </KebabMenu>;

--- a/src/PatrolMenu/index.test.js
+++ b/src/PatrolMenu/index.test.js
@@ -15,6 +15,12 @@ jest.mock('react-to-print', () => ({
   useReactToPrint: jest.fn(),
 }));
 
+jest.mock('../store', () => ({}));
+
+jest.mock('../ducks/tracks', () => ({
+  TRACKS_API_URL: (id) => `/api/v1.0/subject/${id}/tracks/`,
+}));
+
 describe('PatrolMenu', () => {
 
   let useReactToPrintMock = null;
@@ -33,6 +39,7 @@ describe('PatrolMenu', () => {
     data: {
       patrolTypes,
       patrolStore: patrols.reduce((p, acc = {}) => ({ ...acc, [p.id]: p })),
+      tracks: {},
     },
     view: {
       systemConfig: {
@@ -130,6 +137,66 @@ describe('PatrolMenu', () => {
     expect(onPatrolChange).toHaveBeenCalledWith({
       patrol_segments: [{ time_range: { end_time: null } }],
       state: 'open'
+    });
+  });
+
+  describe('Download Patrol Track button', () => {
+    // patrols[1] has a leader and a start_time, making it suitable for track tests
+    const patrolWithLeader = patrols[1];
+    const leaderId = patrolWithLeader.patrol_segments[0].leader.id;
+    const patrolStartTime = patrolWithLeader.patrol_segments[0].time_range.start_time;
+
+    const makeTrackStore = (times) => ({
+      ...minimumNecessaryStoreStructure,
+      data: {
+        ...minimumNecessaryStoreStructure.data,
+        tracks: {
+          [leaderId]: {
+            track: {
+              features: [{
+                properties: { coordinateProperties: { times } },
+              }],
+            },
+          },
+        },
+      },
+    });
+
+    const openMenu = async () => {
+      await userEvent.click(screen.getByRole('button'));
+    };
+
+    const getDownloadOption = () =>
+      screen.getByText('Download Patrol Track').closest('a');
+
+    test('is disabled when patrol has no leader', async () => {
+      renderPatrolMenu({ ...initialProps, patrol: patrols[0] });
+      await openMenu();
+      expect(getDownloadOption()).toHaveClass('disabled');
+    });
+
+    test('is disabled when leader has no track in the store', async () => {
+      renderPatrolMenu({ ...initialProps, patrol: patrolWithLeader });
+      await openMenu();
+      expect(getDownloadOption()).toHaveClass('disabled');
+    });
+
+    test('is disabled when track has no points within the patrol time range', async () => {
+      // All times are before the patrol start_time
+      const beforeStart = new Date(new Date(patrolStartTime).getTime() - 60000).toISOString();
+      const store = makeTrackStore([beforeStart]);
+      renderPatrolMenu({ ...initialProps, patrol: patrolWithLeader }, store);
+      await openMenu();
+      expect(getDownloadOption()).toHaveClass('disabled');
+    });
+
+    test('is enabled when track has points within the patrol time range', async () => {
+      // Time is after the patrol start_time
+      const afterStart = new Date(new Date(patrolStartTime).getTime() + 60000).toISOString();
+      const store = makeTrackStore([afterStart]);
+      renderPatrolMenu({ ...initialProps, patrol: patrolWithLeader }, store);
+      await openMenu();
+      expect(getDownloadOption()).not.toHaveClass('disabled');
     });
   });
 

--- a/src/PatrolMenu/index.test.js
+++ b/src/PatrolMenu/index.test.js
@@ -224,6 +224,51 @@ describe('PatrolMenu', () => {
         })
       );
     });
+
+    test('passes until param when patrol has an end_time', async () => {
+      const patrolEndTime = new Date(new Date(patrolStartTime).getTime() + 3600000).toISOString();
+      const trackTime = new Date(new Date(patrolStartTime).getTime() + 1800000).toISOString();
+      const patrolWithEndTime = {
+        ...patrolWithLeader,
+        patrol_segments: [{
+          ...patrolWithLeader.patrol_segments[0],
+          time_range: { start_time: patrolStartTime, end_time: patrolEndTime },
+        }],
+      };
+      const store = makeTrackStore([trackTime]);
+      renderPatrolMenu({ ...initialProps, patrol: patrolWithEndTime }, store);
+      await openMenu();
+
+      await userEvent.click(screen.getByText('Download Patrol Track'));
+
+      expect(downloadFileFromUrl).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          params: expect.objectContaining({ since: patrolStartTime, until: patrolEndTime }),
+        })
+      );
+    });
+
+    test('sanitizes invalid characters in leader name for the filename', async () => {
+      const afterStart = new Date(new Date(patrolStartTime).getTime() + 60000).toISOString();
+      const patrolWithSpecialName = {
+        ...patrolWithLeader,
+        patrol_segments: [{
+          ...patrolWithLeader.patrol_segments[0],
+          leader: { ...patrolWithLeader.patrol_segments[0].leader, name: 'John/Doe:Test' },
+        }],
+      };
+      const store = makeTrackStore([afterStart]);
+      renderPatrolMenu({ ...initialProps, patrol: patrolWithSpecialName }, store);
+      await openMenu();
+
+      await userEvent.click(screen.getByText('Download Patrol Track'));
+
+      expect(downloadFileFromUrl).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ filename: expect.stringContaining('John_Doe_Test') })
+      );
+    });
   });
 
   test('starts a patrol using menu option', async () => {

--- a/src/PatrolMenu/index.test.js
+++ b/src/PatrolMenu/index.test.js
@@ -9,6 +9,7 @@ import { useReactToPrint } from 'react-to-print';
 
 import { PERMISSION_KEYS, PERMISSIONS, SYSTEM_CONFIG_FLAGS } from '../constants';
 import { render, screen } from '../test-utils';
+import { downloadFileFromUrl } from '../utils/download';
 
 jest.mock('react-to-print', () => ({
   ...jest.requireActual('react-to-print'),
@@ -19,6 +20,10 @@ jest.mock('../store', () => ({}));
 
 jest.mock('../ducks/tracks', () => ({
   TRACKS_API_URL: (id) => `/api/v1.0/subject/${id}/tracks/`,
+}));
+
+jest.mock('../utils/download', () => ({
+  downloadFileFromUrl: jest.fn(() => Promise.resolve()),
 }));
 
 describe('PatrolMenu', () => {
@@ -38,7 +43,7 @@ describe('PatrolMenu', () => {
   const minimumNecessaryStoreStructure = {
     data: {
       patrolTypes,
-      patrolStore: patrols.reduce((p, acc = {}) => ({ ...acc, [p.id]: p })),
+      patrolStore: patrols.reduce((acc, p) => ({ ...acc, [p.id]: p }), {}),
       tracks: {},
     },
     view: {
@@ -141,6 +146,10 @@ describe('PatrolMenu', () => {
   });
 
   describe('Download Patrol Track button', () => {
+    beforeEach(() => {
+      downloadFileFromUrl.mockImplementation(() => Promise.resolve());
+    });
+
     // patrols[1] has a leader and a start_time, making it suitable for track tests
     const patrolWithLeader = patrols[1];
     const leaderId = patrolWithLeader.patrol_segments[0].leader.id;
@@ -197,6 +206,23 @@ describe('PatrolMenu', () => {
       renderPatrolMenu({ ...initialProps, patrol: patrolWithLeader }, store);
       await openMenu();
       expect(getDownloadOption()).not.toHaveClass('disabled');
+    });
+
+    test('calls downloadFileFromUrl with correct url, params, and filename when clicked', async () => {
+      const afterStart = new Date(new Date(patrolStartTime).getTime() + 60000).toISOString();
+      const store = makeTrackStore([afterStart]);
+      renderPatrolMenu({ ...initialProps, patrol: patrolWithLeader }, store);
+      await openMenu();
+
+      await userEvent.click(screen.getByText('Download Patrol Track'));
+
+      expect(downloadFileFromUrl).toHaveBeenCalledWith(
+        `/api/v1.0/subject/${leaderId}/tracks/`,
+        expect.objectContaining({
+          params: expect.objectContaining({ since: patrolStartTime }),
+          filename: `Patrol_${patrolWithLeader.serial_number}_${patrolWithLeader.patrol_segments[0].leader.name}.geojson`,
+        })
+      );
     });
   });
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,7 +7,7 @@ import LocalStorageBackend from 'i18next-localstorage-backend';
 
 import { SUPPORTED_LANGUAGES } from './constants';
 
-const I18N_FILES_VERSION = '1.36';
+const I18N_FILES_VERSION = '1.37';
 
 const preloadNamespaces = [
   'components',


### PR DESCRIPTION
## What does this PR do?

This pull request adds a new "Download Patrol Track" feature to the patrol options menu, allowing users to download the patrol track as a GeoJSON file. The feature is implemented with localization support across multiple languages and integrates with analytics tracking.

**Feature: Download Patrol Track**

* Added a new "Download Patrol Track" option to the `KebabMenu` in the `PatrolMenu` component, which allows users to download the patrol track as a `.geojson` file for the patrol leader. The download uses the patrol's serial number and leader's name for the filename, and includes analytics tracking. (`src/PatrolMenu/index.js`) [[1]](diffhunk://#diff-b48b4cf86b2cbe86d2d82f414cb0ca130c293649e71a3b16dfc17722e4e33de0R106-R118) [[2]](diffhunk://#diff-b48b4cf86b2cbe86d2d82f414cb0ca130c293649e71a3b16dfc17722e4e33de0R164-R170)
* Imported the necessary `DownloadArrowIcon`, `TRACKS_API_URL`, and `downloadFileFromUrl` utilities to support the download functionality. (`src/PatrolMenu/index.js`) [[1]](diffhunk://#diff-b48b4cf86b2cbe86d2d82f414cb0ca130c293649e71a3b16dfc17722e4e33de0R5) [[2]](diffhunk://#diff-b48b4cf86b2cbe86d2d82f414cb0ca130c293649e71a3b16dfc17722e4e33de0R14-R19)

**Localization Updates**

* Added the "downloadTrackButton" translation key for English, Spanish, French, Nepali, Portuguese, and Swahili locales to support the new menu option. (`public/locales/en-US/patrols.json`, `public/locales/es/patrols.json`, `public/locales/fr/patrols.json`, `public/locales/ne-NP/patrols.json`, `public/locales/pt/patrols.json`, `public/locales/sw/patrols.json`) [[1]](diffhunk://#diff-b60f03a7462c05e307e607ac2f6b4d8caadadfb1d2575450ad087111a8ad7092R67) [[2]](diffhunk://#diff-a44df95d00640a065bd7e8a03cdf6f5c93e3463788b72546dfc45b8c257192cbR65) [[3]](diffhunk://#diff-6a70ca17864c5f89ca48f0ba9ba98883af41efb70ce7fc34ebc1ec5f33ab64aaR65) [[4]](diffhunk://#diff-e3c0b49f7b98c23d2ce4c11ebe5838a03e6e5922194364dd42a33d69c9da74c2R65) [[5]](diffhunk://#diff-a9bb5871e460c6fe3a8b93f027d43c8a066b4f5b83f23cc09c26265e594c4836R65) [[6]](diffhunk://#diff-2f4efd3b56b0f8757f06ada4c04811c5197dbb833831958e5beb36f3d8bdd2afR67)
## Evidence


### Relevant link(s)
- [ERA-13106](https://allenai.atlassian.net/browse/ERA-13106)
- [Branch Environment](https://era-13106.dev.pamdas.org)

## Notes


[ERA-13106]: https://allenai.atlassian.net/browse/ERA-13106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ