### PR TITLE
Retry-with-rebase on serca-argocd-apps image-tag push

### DIFF
--- a/.github/workflows/_update-argo.yml
+++ b/.github/workflows/_update-argo.yml
@@ -21,11 +21,58 @@ on:
 
 jobs:
   update:
-    uses: PADAS/serca-pipelines/.github/workflows/_argocd-update-image.yml@main
-    with:
-      app-name: ${{ inputs.app-name }}
-      app-subdir: ${{ inputs.app-subdir }}
-      environment: ${{ inputs.environment }}
-      image-tag: ${{ inputs.image-tag }}
-    secrets:
-      ARGOCD_APPS_SSH_KEY: ${{ secrets.ARGOCD_APPS_SSH_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.ARGOCD_APPS_SSH_KEY }}
+
+      - name: Update image tag in serca-argocd-apps
+        env:
+          TAG: ${{ inputs.image-tag }}
+          APP_NAME: ${{ inputs.app-name }}
+          APP_SUBDIR: ${{ inputs.app-subdir }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          MAX_RETRIES: "5"
+        run: |
+          set -euo pipefail
+
+          git clone --depth=1 git@github.com:PADAS/serca-argocd-apps.git
+          cd serca-argocd-apps
+          pip install yq
+
+          VALUES_FILE="${APP_SUBDIR:+${APP_SUBDIR}/}${APP_NAME}/values-${ENVIRONMENT}.yaml"
+          yq -Yi ".image.tag = \"${TAG}\"" "$VALUES_FILE"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$VALUES_FILE"
+          if git diff --cached --quiet; then
+            echo "No changes"
+            exit 0
+          fi
+          git commit -m "${APP_NAME}: update ${ENVIRONMENT} image to ${TAG}"
+
+          # Push with retry-on-rebase to survive concurrent pushes from parallel pipelines
+          attempt=1
+          while [ "$attempt" -le "$MAX_RETRIES" ]; do
+            if git push; then
+              echo "Push succeeded on attempt ${attempt}"
+              exit 0
+            fi
+
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to push after ${MAX_RETRIES} attempts - too much contention on serca-argocd-apps"
+              exit 1
+            fi
+
+            wait_time=$(( (RANDOM % 4) + 2 ))
+            echo "::warning::Push rejected (attempt ${attempt}/${MAX_RETRIES}). Rebasing onto origin/main and retrying in ${wait_time}s..."
+            sleep "$wait_time"
+
+            git fetch origin main
+            git rebase origin/main
+
+            attempt=$((attempt + 1))
+          done

--- a/.github/workflows/_update-argo.yml
+++ b/.github/workflows/_update-argo.yml
@@ -21,30 +21,11 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.ARGOCD_APPS_SSH_KEY }}
-
-      - name: Update image tag in serca-argocd-apps
-        env:
-          TAG: ${{ inputs.image-tag }}
-          APP_NAME: ${{ inputs.app-name }}
-          APP_SUBDIR: ${{ inputs.app-subdir }}
-          ENVIRONMENT: ${{ inputs.environment }}
-        run: |
-          git clone --depth 1 git@github.com:PADAS/serca-argocd-apps.git
-          cd serca-argocd-apps
-          pip install yq
-
-          VALUES_FILE="${APP_SUBDIR:+${APP_SUBDIR}/}${APP_NAME}/values-${ENVIRONMENT}.yaml"
-          yq -Yi ".image.tag = \"${TAG}\"" "$VALUES_FILE"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "$VALUES_FILE"
-          git diff --cached --quiet && echo "No changes" && exit 0
-          git commit -m "${APP_NAME}: update ${ENVIRONMENT} image to ${TAG}"
-          git push
+    uses: PADAS/serca-pipelines/.github/workflows/_argocd-update-image.yml@main
+    with:
+      app-name: ${{ inputs.app-name }}
+      app-subdir: ${{ inputs.app-subdir }}
+      environment: ${{ inputs.environment }}
+      image-tag: ${{ inputs.image-tag }}
+    secrets:
+      ARGOCD_APPS_SSH_KEY: ${{ secrets.ARGOCD_APPS_SSH_KEY }}


### PR DESCRIPTION
## Summary

Adds a retry-with-rebase loop around the `git push` in `_update-argo.yml` so concurrent image-tag bumps to `serca-argocd-apps` no longer lose commit races.

## Changes

### Changed
- `.github/workflows/_update-argo.yml` — wrap the single `git push` with a 5-attempt loop. Between attempts we sleep 2–6s (random jitter), `git fetch origin main`, and `git rebase origin/main`. After 5 failed attempts the job errors out with a clear `::error::` annotation.
- `set -euo pipefail` at the top of the inline script so silent failures surface.
- `git diff --cached --quiet` short-circuit stays the same (still an early `exit 0` when no tag change is needed).

## Technical Details

- Observed failure on release-2.137.1 run `24578612115`: the image-tag push lost a commit race against a parallel pipeline, and the follow-up rerun failed because the artifact-registry image tag is immutable.
- The retry pattern mirrors the one in `PADAS/serca-pipelines` (`actions/pipeline-scripts/scripts/deploy/argocd-update-image.sh` lines 88–110). We keep it inline here because das-web-react is a public repo and cannot `uses:` a workflow from the private serca-pipelines repo.
- Shallow-clone (`--depth=1`) is preserved. `git rebase origin/main` works against a shallow clone in this flow because our one local commit is a direct child of the fetched tip at clone time.
- Paired with `PADAS/serca-argocd#187`, which grants the `github-actions` ArgoCD CI account RBAC on er-dev, er-stage, er-prod, er-prod-us, and er-prod-me — without that, the subsequent `argocd app sync` step still fails.

## Files Changed

**1 file changed, 55 insertions(+), 8 deletions(-)**
