### PR TITLE
[release-2.137.1] Retry-with-rebase on serca-argocd-apps image-tag push

### DIFF
--- a/.github/workflows/_update-argo.yml
+++ b/.github/workflows/_update-argo.yml
@@ -34,8 +34,11 @@ jobs:
           APP_NAME: ${{ inputs.app-name }}
           APP_SUBDIR: ${{ inputs.app-subdir }}
           ENVIRONMENT: ${{ inputs.environment }}
+          MAX_RETRIES: "5"
         run: |
-          git clone --depth 1 git@github.com:PADAS/serca-argocd-apps.git
+          set -euo pipefail
+
+          git clone --depth=1 git@github.com:PADAS/serca-argocd-apps.git
           cd serca-argocd-apps
           pip install yq
 
@@ -45,6 +48,31 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add "$VALUES_FILE"
-          git diff --cached --quiet && echo "No changes" && exit 0
+          if git diff --cached --quiet; then
+            echo "No changes"
+            exit 0
+          fi
           git commit -m "${APP_NAME}: update ${ENVIRONMENT} image to ${TAG}"
-          git push
+
+          # Push with retry-on-rebase to survive concurrent pushes from parallel pipelines
+          attempt=1
+          while [ "$attempt" -le "$MAX_RETRIES" ]; do
+            if git push; then
+              echo "Push succeeded on attempt ${attempt}"
+              exit 0
+            fi
+
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to push after ${MAX_RETRIES} attempts - too much contention on serca-argocd-apps"
+              exit 1
+            fi
+
+            wait_time=$(( (RANDOM % 4) + 2 ))
+            echo "::warning::Push rejected (attempt ${attempt}/${MAX_RETRIES}). Rebasing onto origin/main and retrying in ${wait_time}s..."
+            sleep "$wait_time"
+
+            git fetch origin main
+            git rebase origin/main
+
+            attempt=$((attempt + 1))
+          done


### PR DESCRIPTION
## Summary

Backport of #1543 onto `release-2.137.1`: adds retry-with-rebase around the `git push` in `_update-argo.yml` so concurrent image-tag bumps to `serca-argocd-apps` no longer lose commit races.

## Changes

### Changed
- `.github/workflows/_update-argo.yml` — 5-attempt retry loop with 2–6s random jitter, running `git fetch origin main && git rebase origin/main` between attempts.
- `set -euo pipefail` so silent failures surface.

## Technical Details

- Triggered by release-2.137.1 run `24578612115` losing a commit race; the subsequent rerun then failed on artifact-registry tag immutability.
- Retry pattern mirrors `PADAS/serca-pipelines` (`actions/pipeline-scripts/scripts/deploy/argocd-update-image.sh`). Inlined here because das-web-react is public and cannot call the private reusable workflow.
- Paired with `PADAS/serca-argocd#187` which grants the CI `github-actions` account RBAC on ER projects — without that, the downstream `argocd app sync` still fails.

## Files Changed

**1 file changed, 31 insertions(+), 3 deletions(-)**
