### PR TITLE
ERA-13228 Fix basemap tile layer maxZoom and maxNativeZoom having no effect

### DIFF
--- a/src/BaseLayerRenderer/TileLayerRenderer.js
+++ b/src/BaseLayerRenderer/TileLayerRenderer.js
@@ -17,14 +17,15 @@ const RASTER_SOURCE_OPTIONS = {
 
 const RenderFunction = ({ children }) => <>{children}</>;
 
-const SourceComponent = ({ id, tileUrl, sourceConfig }) => {
-  const config = useMemo(() => ({
-    ...RASTER_SOURCE_OPTIONS,
-    tiles: [
-      tileUrl,
-    ],
-    ...sourceConfig,
-  }), [sourceConfig, tileUrl]);
+const SourceComponent = ({ id, layer }) => {
+  const config = useMemo(() => {
+    const { sourceConfig } = calcConfigForMapAndSourceFromLayer(layer);
+    return {
+      ...RASTER_SOURCE_OPTIONS,
+      tiles: [layer.attributes.url],
+      ...sourceConfig,
+    };
+  }, [layer]);
 
   useMapSources([{ id }], config);
 
@@ -40,15 +41,24 @@ const TileLayerRenderer = (props) => {
     layers.find(({ id }) => id === currentBaseLayer?.id)
   , [currentBaseLayer?.id, layers]);
 
-  const { mapConfig, sourceConfig } = useMemo(() =>
-    calcConfigForMapAndSourceFromLayer(currentBaseLayer)
-  , [currentBaseLayer]);
+  const { mapConfig } = useMemo(() =>
+    calcConfigForMapAndSourceFromLayer(activeLayer ?? currentBaseLayer)
+  , [activeLayer, currentBaseLayer]);
 
   useEffect(() => {
-    if (map) {
+    if (!map) return;
+
+    const assertZoomLimits = () => {
       map.setMaxZoom(mapConfig.maxzoom || MAX_ZOOM);
       map.setMinZoom(mapConfig.minzoom || MIN_ZOOM);
-    }
+    };
+
+    assertZoomLimits();
+    // Re-assert after GL finishes async source processing, which can override
+    // transform.maxZoom when a source has maxzoom set (e.g. from maxNativeZoom).
+    map.once('idle', assertZoomLimits);
+
+    return () => map.off('idle', assertZoomLimits);
   }, [map, mapConfig]);
 
   useMapLayers([{
@@ -65,7 +75,7 @@ const TileLayerRenderer = (props) => {
     .filter(layer => TILE_LAYER_SOURCE_TYPES.includes(layer.attributes.type))
     .map(layer =>
       <RenderFunction key={layer.id}>
-        <SourceComponent id={`layer-source-${layer.id}`} sourceConfig={sourceConfig} tileUrl={layer.attributes.url} />
+        <SourceComponent id={`layer-source-${layer.id}`} layer={layer} />
       </RenderFunction>
     );
 };

--- a/src/BaseLayerRenderer/TileLayerRenderer.js
+++ b/src/BaseLayerRenderer/TileLayerRenderer.js
@@ -5,7 +5,7 @@ import { TILE_LAYER_SOURCE_TYPES, MAX_ZOOM, MIN_ZOOM } from '../constants';
 
 import { POLYGONS_LAYER_ID as BEFORE_LAYER_ID } from '../SpatialFeaturesLayer';
 
-import { calcConfigForMapAndSourceFromLayer } from '../utils/layers';
+import { calculateSourceConfigurationFromLayer, calculateMapConfigurationFromLayer } from '../utils/layers';
 import useMapSources from '../hooks/useMapSources';
 import useMapLayers from '../hooks/useMapLayers';
 
@@ -18,14 +18,12 @@ const RASTER_SOURCE_OPTIONS = {
 const RenderFunction = ({ children }) => <>{children}</>;
 
 const SourceComponent = ({ id, layer }) => {
-  const config = useMemo(() => {
-    const { sourceConfig } = calcConfigForMapAndSourceFromLayer(layer);
-    return {
-      ...RASTER_SOURCE_OPTIONS,
-      tiles: [layer.attributes.url],
-      ...sourceConfig,
-    };
-  }, [layer]);
+  // useMemo keeps config referentially stable so useMapSources doesn't re-run on every render.
+  const config = useMemo(() => ({
+    ...RASTER_SOURCE_OPTIONS,
+    tiles: [layer.attributes.url],
+    ...calculateSourceConfigurationFromLayer(layer),
+  }), [layer]);
 
   useMapSources([{ id }], config);
 
@@ -41,8 +39,9 @@ const TileLayerRenderer = (props) => {
     layers.find(({ id }) => id === currentBaseLayer?.id)
   , [currentBaseLayer?.id, layers]);
 
-  const { mapConfig } = useMemo(() =>
-    calcConfigForMapAndSourceFromLayer(activeLayer ?? currentBaseLayer)
+  // useMemo keeps mapConfig referentially stable so the useEffect below doesn't re-run on every render.
+  const mapConfig = useMemo(() =>
+    calculateMapConfigurationFromLayer(activeLayer ?? currentBaseLayer)
   , [activeLayer, currentBaseLayer]);
 
   useEffect(() => {

--- a/src/BaseLayerRenderer/TileLayerRenderer.test.js
+++ b/src/BaseLayerRenderer/TileLayerRenderer.test.js
@@ -1,0 +1,147 @@
+import React from 'react';
+
+import { render } from '../test-utils';
+import { MapContext } from '../App';
+import { createMapMock } from '../__test-helpers/mocks';
+import {
+  withMaxMinAndMaxNativeZoom,
+  withMaxZoom,
+  withMinZoom,
+  withNoZoomConfig,
+} from '../__test-helpers/fixtures/layers';
+import { MAX_ZOOM, MIN_ZOOM } from '../constants';
+
+import TileLayerRenderer from './TileLayerRenderer';
+
+describe('TileLayerRenderer', () => {
+  let map;
+
+  beforeEach(() => {
+    map = createMapMock();
+  });
+
+  const renderComponent = (props) => render(
+    <MapContext.Provider value={map}>
+      <TileLayerRenderer {...props} />
+    </MapContext.Provider>
+  );
+
+  describe('interactive zoom limits', () => {
+    test('sets maxZoom from layer configuration', () => {
+      renderComponent({ layers: [withMaxZoom], currentBaseLayer: withMaxZoom });
+
+      expect(map.setMaxZoom).toHaveBeenCalledWith(19);
+    });
+
+    test('maxNativeZoom does not affect the interactive zoom limit', () => {
+      // withMaxMinAndMaxNativeZoom has maxZoom: 19 and maxNativeZoom: 17
+      renderComponent({ layers: [withMaxMinAndMaxNativeZoom], currentBaseLayer: withMaxMinAndMaxNativeZoom });
+
+      expect(map.setMaxZoom).toHaveBeenCalledWith(19);
+      expect(map.setMaxZoom).not.toHaveBeenCalledWith(17);
+    });
+
+    test('falls back to MAX_ZOOM when no maxZoom is configured', () => {
+      renderComponent({ layers: [withNoZoomConfig], currentBaseLayer: withNoZoomConfig });
+
+      expect(map.setMaxZoom).toHaveBeenCalledWith(MAX_ZOOM);
+    });
+
+    test('sets minZoom from layer configuration', () => {
+      // withMinZoom has minZoom: 19
+      renderComponent({ layers: [withMinZoom], currentBaseLayer: withMinZoom });
+
+      expect(map.setMinZoom).toHaveBeenCalledWith(19);
+    });
+
+    test('falls back to MIN_ZOOM when no minZoom is configured', () => {
+      renderComponent({ layers: [withMaxZoom], currentBaseLayer: withMaxZoom });
+
+      expect(map.setMinZoom).toHaveBeenCalledWith(MIN_ZOOM);
+    });
+
+    test('registers an idle listener to re-assert zoom limits after async source processing', () => {
+      renderComponent({ layers: [withMaxZoom], currentBaseLayer: withMaxZoom });
+
+      expect(map.once).toHaveBeenCalledWith('idle', expect.any(Function));
+    });
+
+    test('removes the idle listener on unmount', () => {
+      const { unmount } = renderComponent({ layers: [withMaxZoom], currentBaseLayer: withMaxZoom });
+
+      unmount();
+
+      expect(map.off).toHaveBeenCalledWith('idle', expect.any(Function));
+    });
+  });
+
+  describe('zoom config source precedence', () => {
+    test('uses fresh activeLayer from layers over stale persisted currentBaseLayer', () => {
+      const staleCurrentBaseLayer = {
+        ...withMaxZoom,
+        attributes: { ...withMaxZoom.attributes, configuration: { maxZoom: 5 } },
+      };
+
+      renderComponent({
+        layers: [withMaxZoom],              // fresh from API: maxZoom 19
+        currentBaseLayer: staleCurrentBaseLayer, // stale persisted: maxZoom 5
+      });
+
+      expect(map.setMaxZoom).toHaveBeenCalledWith(19);
+      expect(map.setMaxZoom).not.toHaveBeenCalledWith(5);
+    });
+
+    test('falls back to currentBaseLayer zoom config when no matching layer is in layers', () => {
+      // currentBaseLayer (withMaxZoom) is not in the layers list, so activeLayer is undefined
+      renderComponent({
+        layers: [withMinZoom],
+        currentBaseLayer: withMaxZoom, // maxZoom: 19, used as fallback
+      });
+
+      expect(map.setMaxZoom).toHaveBeenCalledWith(19);
+    });
+  });
+
+  describe('per-layer raster source configuration', () => {
+    beforeEach(() => {
+      map.getSource.mockReturnValue(undefined);
+    });
+
+    test('maps maxNativeZoom to source maxzoom to control tile fetching', () => {
+      // withMaxMinAndMaxNativeZoom has maxNativeZoom: 17 — tiles above zoom 17 are re-used
+      renderComponent({ layers: [withMaxMinAndMaxNativeZoom], currentBaseLayer: withMaxMinAndMaxNativeZoom });
+
+      expect(map.addSource).toHaveBeenCalledWith(
+        `layer-source-${withMaxMinAndMaxNativeZoom.id}`,
+        expect.objectContaining({ maxzoom: 17 })
+      );
+    });
+
+    test('does not set source maxzoom when maxNativeZoom is absent', () => {
+      renderComponent({ layers: [withMaxZoom], currentBaseLayer: withMaxZoom });
+
+      const call = map.addSource.mock.calls.find(([id]) => id === `layer-source-${withMaxZoom.id}`);
+      expect(call).toBeDefined();
+      expect(call[1]).not.toHaveProperty('maxzoom');
+    });
+
+    test('creates a separate source for each tile layer', () => {
+      renderComponent({
+        layers: [withMaxMinAndMaxNativeZoom, withMaxZoom],
+        currentBaseLayer: withMaxMinAndMaxNativeZoom,
+      });
+
+      expect(map.addSource).toHaveBeenCalledWith(`layer-source-${withMaxMinAndMaxNativeZoom.id}`, expect.anything());
+      expect(map.addSource).toHaveBeenCalledWith(`layer-source-${withMaxZoom.id}`, expect.anything());
+    });
+
+    test('includes the layer tile URL in the source tiles array', () => {
+      renderComponent({ layers: [withMaxZoom], currentBaseLayer: withMaxZoom });
+
+      expect(map.addSource).toHaveBeenCalledWith(
+        `layer-source-${withMaxZoom.id}`,
+        expect.objectContaining({ tiles: [withMaxZoom.attributes.url] })
+      );
+    });
+  });
+});

--- a/src/utils/layers.js
+++ b/src/utils/layers.js
@@ -1,7 +1,6 @@
-export const calcConfigForMapAndSourceFromLayer = (layer) => {
+export const calculateSourceConfigurationFromLayer = (layer) => {
   const config = layer?.attributes?.configuration;
   const sourceConfig = {};
-  const mapConfig = {};
 
   if (config) {
     if (config.maxNativeZoom) {
@@ -9,6 +8,18 @@ export const calcConfigForMapAndSourceFromLayer = (layer) => {
     }
     if (config.minZoom) {
       sourceConfig.minzoom = config.minZoom;
+    }
+  }
+
+  return sourceConfig;
+};
+
+export const calculateMapConfigurationFromLayer = (layer) => {
+  const config = layer?.attributes?.configuration;
+  const mapConfig = {};
+
+  if (config) {
+    if (config.minZoom) {
       mapConfig.minzoom = config.minZoom;
     }
     if (config.maxZoom) {
@@ -16,5 +27,5 @@ export const calcConfigForMapAndSourceFromLayer = (layer) => {
     }
   }
 
-  return { mapConfig, sourceConfig };
+  return mapConfig;
 };

--- a/src/utils/layers.test.js
+++ b/src/utils/layers.test.js
@@ -1,31 +1,44 @@
-import { calcConfigForMapAndSourceFromLayer } from './layers';
+import { calculateSourceConfigurationFromLayer, calculateMapConfigurationFromLayer } from './layers';
 
 import { withMaxMinAndMaxNativeZoom, withMaxZoom, withMinZoom, withNoZoomConfig } from '../__test-helpers/fixtures/layers';
 
 
-describe('#calcConfigForMapAndSourceFromLayer', () => {
+describe('#calculateSourceConfigurationFromLayer', () => {
   test('setting source max zoom from maxNativeZoom', () => {
-    const { sourceConfig } = calcConfigForMapAndSourceFromLayer(withMaxMinAndMaxNativeZoom);
+    const sourceConfig = calculateSourceConfigurationFromLayer(withMaxMinAndMaxNativeZoom);
 
     expect(sourceConfig.maxzoom).toEqual(withMaxMinAndMaxNativeZoom.attributes.configuration.maxNativeZoom);
   });
 
-  test('setting map max zoom from maxzoom', () => {
-    const { mapConfig } = calcConfigForMapAndSourceFromLayer(withMaxZoom);
+  test('setting source min zoom from minZoom', () => {
+    const sourceConfig = calculateSourceConfigurationFromLayer(withMinZoom);
+
+    expect(sourceConfig.minzoom).toEqual(withMinZoom.attributes.configuration.minZoom);
+  });
+
+  test('no zoom config available', () => {
+    const sourceConfig = calculateSourceConfigurationFromLayer(withNoZoomConfig);
+
+    expect(sourceConfig).toEqual({});
+  });
+});
+
+describe('#calculateMapConfigurationFromLayer', () => {
+  test('setting map max zoom from maxZoom', () => {
+    const mapConfig = calculateMapConfigurationFromLayer(withMaxZoom);
 
     expect(mapConfig.maxzoom).toEqual(withMaxZoom.attributes.configuration.maxZoom);
   });
 
-  test('setting map and source min zoom from minZoom', () => {
-    const { mapConfig, sourceConfig } = calcConfigForMapAndSourceFromLayer(withMinZoom);
+  test('setting map min zoom from minZoom', () => {
+    const mapConfig = calculateMapConfigurationFromLayer(withMinZoom);
 
     expect(mapConfig.minzoom).toEqual(withMinZoom.attributes.configuration.minZoom);
-    expect(sourceConfig.minzoom).toEqual(withMinZoom.attributes.configuration.minZoom);
   });
 
-  test('no min or max zoom available', () => {
-    const config = calcConfigForMapAndSourceFromLayer(withNoZoomConfig);
+  test('no zoom config available', () => {
+    const mapConfig = calculateMapConfigurationFromLayer(withNoZoomConfig);
 
-    expect(config).toEqual({ mapConfig: {}, sourceConfig: {} });
+    expect(mapConfig).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary
- Each `SourceComponent` now derives its own `sourceConfig` from its own `layer` prop, so per-layer `maxNativeZoom` is correctly applied to each raster source. Previously all sources shared a single config derived from `currentBaseLayer`, and `useMapSources` silently ignored config changes for already-existing sources.
- `mapConfig` (which drives `map.setMaxZoom`/`map.setMinZoom`) is now computed from `activeLayer` (always fresh from the API via `baseLayers`) with fallback to `currentBaseLayer`, preventing stale `redux-persist` state from capping interactive zoom at the wrong value on initial load.
- Zoom limits are re-asserted on the Mapbox GL `idle` event as a defensive measure against async source processing overriding `transform.maxZoom`.

Jira: [ERA-13228](https://allenai.atlassian.net/browse/ERA-13228)

## Test plan
- [ ] 13 new automated tests added in `TileLayerRenderer.test.js` — all passing
- [ ] Verify `maxZoom` sets the interactive zoom ceiling correctly on initial load
- [ ] Verify `maxNativeZoom` causes tile overzooming above its value without capping interactive zoom
- [ ] Verify both settings work correctly on first load without needing to switch layers and back

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ERA-13228]: https://allenai.atlassian.net/browse/ERA-13228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ