### PR TITLE
ERA-13144: V2 schema long choice lists cause schema compilation errors/performance degradation

### DIFF
--- a/src/ReportManager/DetailsSection/SchemaForm/utils/useSchemaValidations/index.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/utils/useSchemaValidations/index.js
@@ -8,6 +8,7 @@ import { TEXT_ELEMENT_ALPHANUMERIC_FORMAT_VALIDATION_PATTERN } from '../../../..
 const ajv = new Ajv2020({ allErrors: true });
 addFormats(ajv);
 ajv.addKeyword({ keyword: 'x-section', schemaType: 'string' });
+ajv.addKeyword({ keyword: 'x-enumExtra', schemaType: 'object' });
 
 const insertErrorRecursively = (fieldName, message, errorPath, errors, t) => {
   if (errorPath.length === 0) {

--- a/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.js
+++ b/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.js
@@ -19,11 +19,14 @@ const transformChoiceListField = (
     ? choiceListFieldJSONSchema.items.anyOf
     : choiceListFieldJSONSchema.anyOf;
   const options = (choicesSubschemas ?? [])
-    .flatMap((choicesSubschema) => choicesSubschema.oneOf)
-    .map((choice) => ({
-      description: choice.description,
-      display: choice.title,
-      value: choice.const,
+    .flatMap((choicesSubschema) => choicesSubschema.enum.map((optionValue) => {
+      const optionExtra = choicesSubschema['x-enumExtra'][optionValue];
+
+      return {
+        description: optionExtra.description,
+        display: optionExtra.display,
+        value: optionValue,
+      };
     }));
 
   // Add the choice list field form element specific properties.

--- a/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.test.js
+++ b/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.test.js
@@ -168,7 +168,7 @@ describe('Utils - v2-event-schemas - transformSchemaToFormElements - transformFi
           },
           'source-4': {
             description: 'sensor_manufacturer',
-            display: 'Static Wheather Sensor',
+            display: 'Static Weather Sensor',
           },
         },
       },
@@ -218,7 +218,7 @@ describe('Utils - v2-event-schemas - transformSchemaToFormElements - transformFi
             },
             {
               description: 'sensor_manufacturer',
-              display: 'Static Wheather Sensor',
+              display: 'Static Weather Sensor',
               value: 'source-4',
             },
             {

--- a/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.test.js
+++ b/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.test.js
@@ -29,18 +29,17 @@ describe('Utils - v2-event-schemas - transformSchemaToFormElements - transformFi
           items: {
             anyOf: [
               {
-                oneOf: [
-                  {
-                    const: 'source-1',
+                enum: ['source-1', 'source-2'],
+                'x-enumExtra': {
+                  'source-1': {
                     description: 'radio_manufacturer',
-                    title: 'Ranger Radio',
+                    display: 'Ranger Radio',
                   },
-                  {
-                    const: 'source-2',
+                  'source-2': {
                     description: 'collar_manufacturer',
-                    title: 'Elephant Collar',
+                    display: 'Elephant Collar',
                   },
-                ],
+                },
               },
             ],
           },
@@ -161,27 +160,26 @@ describe('Utils - v2-event-schemas - transformSchemaToFormElements - transformFi
     jsonSchema.properties[choiceListFieldName].items.anyOf = [
       ...jsonSchema.properties[choiceListFieldName].items.anyOf,
       {
-        oneOf: [
-          {
-            const: 'source-3',
+        enum: ['source-3', 'source-4'],
+        'x-enumExtra': {
+          'source-3': {
             description: 'collar_manufacturer_2',
-            title: 'Rhino Collar',
+            display: 'Rhino Collar',
           },
-          {
-            const: 'source-4',
+          'source-4': {
             description: 'sensor_manufacturer',
-            title: 'Static Wheather Sensor',
+            display: 'Static Wheather Sensor',
           },
-        ],
+        },
       },
       {
-        oneOf: [
-          {
-            const: 'source-5',
+        enum: ['source-5'],
+        'x-enumExtra': {
+          'source-5': {
             description: 'tracker_manufacturer',
-            title: 'Vehicle Tracker',
+            display: 'Vehicle Tracker',
           },
-        ],
+        },
       },
     ];
 


### PR DESCRIPTION
## What does this PR do?
Support new version of v2 schemas with enums instead of oneOf in choice lists.

- Add custom "x-enumExtra" keyword to the AJV compiler.
- Update "transformChoiceListField" to read the options correctly from the new properties.
- Update tests.

## Evidence


### Relevant link(s)
- [ERA-13144](https://allenai.atlassian.net/browse/ERA-13144)
- [Branch Environment](https://era-13144.dev.pamdas.org)


[ERA-13144]: https://allenai.atlassian.net/browse/ERA-13144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ