### PR TITLE
ci: auto-deploy ERA-13210 branch to user-testing environment

### DIFF
--- a/.github/workflows/user-testing.yml
+++ b/.github/workflows/user-testing.yml
@@ -1,0 +1,127 @@
+name: Build & Deploy das-web-react (user-testing)
+# Temporary workflow for user-testing.pamdas.org (DASOPS-2062).
+# Triggers on every push to ERA-13210 (Tiffany's branch) and updates
+# the image tag in serca-argocd-apps so ArgoCD auto-syncs.
+# Remove this file after user testing is complete.
+on:
+  push:
+    branches:
+      - ERA-13210
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      build-args: ${{ steps.env-vars.outputs.build-args }}
+      image-tag: ${{ steps.tag.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+      - run: |
+          npm pkg set "buildbranch"="${{ github.ref_name }}"
+          npm pkg set "buildnum"="${{ github.run_number }}"
+
+      - name: Select env file for build
+        id: env-vars
+        run: echo "build-args=ENV_FILE=.env.development" >> $GITHUB_OUTPUT
+
+      - name: Generate image tag
+        id: tag
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          BRANCH_SAFE=$(echo "${GITHUB_REF_NAME}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+          echo "value=${BRANCH_SAFE}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: npm-config
+          path: package.json
+
+  build:
+    needs: config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: npm-config
+          path: .
+
+      - name: GCP Auth
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.SERVICE_ACCOUNT }}
+
+      - name: Login to serca-artifact-registry
+        uses: docker/login-action@v3
+        with:
+          registry: europe-west3-docker.pkg.dev/serca-artifact-registry
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - name: Login to padas-app
+        uses: docker/login-action@v3
+        with:
+          registry: europe-west3-docker.pkg.dev/padas-app
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/moby/buildkit:buildx-stable-1
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            europe-west3-docker.pkg.dev/serca-artifact-registry/earthranger/das-web-react
+            europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react
+          tags: |
+            type=raw,value=${{ needs.config.outputs.image-tag }}
+
+      - name: Read node version
+        id: node-ver
+        run: echo "value=$(cat .node-version)" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          file: Dockerfile.mt
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ${{ needs.config.outputs.build-args }}
+            NODE_VERSION=${{ steps.node-ver.outputs.value }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy-user-testing:
+    needs: [config, build]
+    uses: ./.github/workflows/_update-argo.yml
+    with:
+      app-name: das-web-react-user-testing
+      app-subdir: earthranger
+      environment: er-prod-us
+      image-tag: ${{ needs.config.outputs.image-tag }}
+    secrets:
+      ARGOCD_APPS_SSH_KEY: ${{ secrets.ARGOCD_APPS_SSH_KEY }}


### PR DESCRIPTION
## Summary

Adds a temporary CI workflow that auto-deploys the `ERA-13210` branch to `user-testing.pamdas.org` on every push, so the user-testing team always gets the latest prototype image without manual intervention.

## Changes

### Added
- `.github/workflows/user-testing.yml` — triggers on pushes to `ERA-13210`, builds and pushes the Docker image, then updates the image tag in `serca-argocd-apps` via the existing `_update-argo.yml` reusable workflow

## Technical Details

Mirrors the `develop.yml` pipeline but targets the `das-web-react-user-testing` ArgoCD app (`er-prod-us` environment). Tests are skipped to keep the feedback loop fast for the prototype iteration. The ApplicationSet already has `syncPolicy.automated` configured, so ArgoCD picks up the tag update and deploys automatically — no explicit sync step needed. `cancel-in-progress: true` ensures rapid pushes don't stack up.

This workflow is temporary and should be removed alongside the ApplicationSet and values file after user testing is complete.

## Files Changed

**1 file changed, 109 insertions(+)**

---
**Jira**: https://allenai.atlassian.net/browse/DASOPS-2062