### PR TITLE
fix: remove non-existent 'settings' i18n namespace (splash screen 404)

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -23,7 +23,6 @@ const preloadNamespaces = [
   'menu-drawer',
   'patrols',
   'reports',
-  'settings',
   'subjects',
   'top-bar',
   'tracks',


### PR DESCRIPTION
## Summary

Removes `'settings'` from the `preloadNamespaces` list in `src/i18n.js`. The file `public/locales/en-US/settings.json` (and all other locales) has never existed in the repo, and no component uses this namespace. The app was broken by the i18next v25→v26 upgrade (Apr 27, 2026): v26 treats a 404 on a preloaded namespace as a fatal init failure, blocking the app at the splash screen.

## Changes

- Remove `'settings'` from `preloadNamespaces` in `src/i18n.js` — the file never existed, the namespace is unused

## Technical Details

- **Symptom:** `404 /locales/en-US/settings.json?v=1.39` → app never loads past splash screen
- **Root cause:** `'settings'` was added to `preloadNamespaces` in Feb 2024 without a corresponding `settings.json` file; i18next v25 silently skipped 404s, v26 does not
- **Affected:** any tenant running `release-2.139.1` (e.g. birdlifezimbabwe.pamdas.org)
- **No translation content is lost** — zero components reference this namespace

## Files Changed

- `src/i18n.js` — remove `'settings'` from preload namespace list

Fixes ERCS-7240