### PR TITLE
ERA-13375: Empty choices field breaks the app into wsod state.

### DIFF
--- a/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.js
+++ b/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.js
@@ -19,7 +19,7 @@ const transformChoiceListField = (
     ? choiceListFieldJSONSchema.items.anyOf
     : choiceListFieldJSONSchema.anyOf;
   const options = (choicesSubschemas ?? [])
-    .flatMap((choicesSubschema) => choicesSubschema.enum.map((optionValue) => {
+    .flatMap((choicesSubschema) => (choicesSubschema.enum ?? []).map((optionValue) => {
       const optionExtra = choicesSubschema['x-enumExtra'][optionValue];
 
       return {

--- a/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.test.js
+++ b/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.test.js
@@ -235,6 +235,49 @@ describe('Utils - v2-event-schemas - transformSchemaToFormElements - transformFi
     });
   });
 
+  it('transforms choices subschemas without enum', () => {
+    jsonSchema.properties[choiceListFieldName].items.anyOf = [
+      ...jsonSchema.properties[choiceListFieldName].items.anyOf,
+      { 'x-enumExtra': {} },
+    ];
+
+    transformChoiceListField(
+      choiceListFieldId,
+      choiceListFieldName,
+      jsonSchema,
+      uiSchema,
+      formElements,
+    );
+
+    expect(formElements).toEqual({
+      [choiceListFieldId]: {
+        details: {
+          description: 'Select the damaged source',
+          hint: 'Source',
+          inputType: CHOICE_LIST_ELEMENT_INPUT_TYPES.LIST,
+          isRequired: true,
+          label: 'Damaged source',
+          multiple: true,
+          options: [
+            {
+              description: 'radio_manufacturer',
+              display: 'Ranger Radio',
+              value: 'source-1',
+            },
+            {
+              description: 'collar_manufacturer',
+              display: 'Elephant Collar',
+              value: 'source-2',
+            },
+          ],
+          value: choiceListFieldName,
+        },
+        parentId,
+        type: FORM_ELEMENT_TYPES.CHOICE_LIST,
+      },
+    });
+  });
+
   it('transforms a single choice list field', () => {
     jsonSchema.properties[choiceListFieldName].anyOf = jsonSchema.properties[choiceListFieldName].items.anyOf;
     delete jsonSchema.properties[choiceListFieldName].items;


### PR DESCRIPTION
## What does this PR do?
Update transformChoiceListField to handle choices subschemas without enum and add corresponding test case

## Evidence
<img width="1920" height="990" alt="image" src="https://github.com/user-attachments/assets/63951149-2b76-48d5-8174-a802862ca22b" />


### Relevant link(s)
- [ERA-13375](https://allenai.atlassian.net/browse/ERA-13375)
- [Branch Environment](https://era-13375.dev.pamdas.org)


[ERA-13375]: https://allenai.atlassian.net/browse/ERA-13375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ