### PR TITLE
Fix WSOD when v2 choice list field has no choices

### DIFF
--- a/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.js
+++ b/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.js
@@ -19,7 +19,7 @@ const transformChoiceListField = (
     ? choiceListFieldJSONSchema.items.anyOf
     : choiceListFieldJSONSchema.anyOf;
   const options = (choicesSubschemas ?? [])
-    .flatMap((choicesSubschema) => choicesSubschema.enum.map((optionValue) => {
+    .flatMap((choicesSubschema) => (choicesSubschema.enum ?? []).map((optionValue) => {
       const optionExtra = choicesSubschema['x-enumExtra'][optionValue];
 
       return {

--- a/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.test.js
+++ b/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.test.js
@@ -277,6 +277,22 @@ describe('Utils - v2-event-schemas - transformSchemaToFormElements - transformFi
     });
   });
 
+  it('produces empty options when a subschema has no enum key (backend empty-choices fix)', () => {
+    jsonSchema.properties[choiceListFieldName].items.anyOf = [
+      { 'not': {}, 'x-enumExtra': {} },
+    ];
+
+    transformChoiceListField(
+      choiceListFieldId,
+      choiceListFieldName,
+      jsonSchema,
+      uiSchema,
+      formElements,
+    );
+
+    expect(formElements[choiceListFieldId].details.options).toEqual([]);
+  });
+
   it('transforms a choice list field with missing properties', () => {
     delete jsonSchema.properties[choiceListFieldName].description;
     delete jsonSchema.properties[choiceListFieldName].items.anyOf;


### PR DESCRIPTION
## Summary

- Backend PR #3975 fixed `enum: []` (invalid JSON Schema) by dropping the `enum` key and using `not: {}` for empty choice lists.
- This left `transformChoiceListField` crashing with `TypeError: Cannot read properties of undefined (reading 'map')` because it assumed `choicesSubschema.enum` always exists.
- Fix: guard the `.map()` call with `?? []` so a missing `enum` yields an empty options array (empty dropdown) instead of a crash.

## Test plan

- [ ] Added unit test covering the `{ not: {}, 'x-enumExtra': {} }` subschema shape — confirms `options` is `[]` instead of throwing.
- [ ] Open an event form for a v2 event type whose choice list has zero choices — should render with an empty dropdown, no WSOD.

Relates to [ERA-13375](https://allenai.atlassian.net/browse/ERA-13375)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ERA-13375]: https://allenai.atlassian.net/browse/ERA-13375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ