### PR TITLE
Backmerge release-2.140.1 into develop

### DIFF
--- a/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.js
+++ b/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.js
@@ -19,7 +19,7 @@ const transformChoiceListField = (
     ? choiceListFieldJSONSchema.items.anyOf
     : choiceListFieldJSONSchema.anyOf;
   const options = (choicesSubschemas ?? [])
-    .flatMap((choicesSubschema) => choicesSubschema.enum.map((optionValue) => {
+    .flatMap((choicesSubschema) => (choicesSubschema.enum ?? []).map((optionValue) => {
       const optionExtra = choicesSubschema['x-enumExtra'][optionValue];
 
       return {

--- a/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.test.js
+++ b/src/utils/v2-event-schemas/transformSchemaToFormElements/transformField/transformChoiceListField/index.test.js
@@ -235,6 +235,49 @@ describe('Utils - v2-event-schemas - transformSchemaToFormElements - transformFi
     });
   });
 
+  it('transforms choices subschemas without enum', () => {
+    jsonSchema.properties[choiceListFieldName].items.anyOf = [
+      ...jsonSchema.properties[choiceListFieldName].items.anyOf,
+      { 'x-enumExtra': {} },
+    ];
+
+    transformChoiceListField(
+      choiceListFieldId,
+      choiceListFieldName,
+      jsonSchema,
+      uiSchema,
+      formElements,
+    );
+
+    expect(formElements).toEqual({
+      [choiceListFieldId]: {
+        details: {
+          description: 'Select the damaged source',
+          hint: 'Source',
+          inputType: CHOICE_LIST_ELEMENT_INPUT_TYPES.LIST,
+          isRequired: true,
+          label: 'Damaged source',
+          multiple: true,
+          options: [
+            {
+              description: 'radio_manufacturer',
+              display: 'Ranger Radio',
+              value: 'source-1',
+            },
+            {
+              description: 'collar_manufacturer',
+              display: 'Elephant Collar',
+              value: 'source-2',
+            },
+          ],
+          value: choiceListFieldName,
+        },
+        parentId,
+        type: FORM_ELEMENT_TYPES.CHOICE_LIST,
+      },
+    });
+  });
+
   it('transforms a single choice list field', () => {
     jsonSchema.properties[choiceListFieldName].anyOf = jsonSchema.properties[choiceListFieldName].items.anyOf;
     delete jsonSchema.properties[choiceListFieldName].items;


### PR DESCRIPTION
Backmerge hotfixes from release-2.140.1 into develop.

## Hotfix commits
- ERA-13375: Update transformChoiceListField to handle choices subschemas without enum

Please merge this before cutting release-2.141.1.