### PR TITLE
ci: drop build-st job (gcr.io/padas-app/circleci)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,59 +124,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  build-st:
-    name: Build ST Image (GCR)
-    needs: [config]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: npm-config
-          path: .
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.node-version'
-
-      - name: GCP Auth
-        id: auth
-        uses: google-github-actions/auth@v2
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure GCR Docker auth
-        run: gcloud auth configure-docker
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Build
-        run: CI=false yarn build
-
-      - name: Sanitize branch name for GCR path
-        id: gcr
-        run: |
-          BRANCH="${GITHUB_REF_NAME}"
-          SANITIZED=$(echo "$BRANCH" | sed 's/[^/A-Za-z0-9_-]/_/g' | tr '[:upper:]' '[:lower:]')
-          echo "path=gcr.io/padas-app/circleci/das-web-react/${SANITIZED}" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push ST image
-        run: |
-          docker build -f Dockerfile.prod \
-            -t ${{ steps.gcr.outputs.path }}:latest \
-            -t ${{ steps.gcr.outputs.path }}:${{ github.sha }} \
-            .
-          docker push ${{ steps.gcr.outputs.path }}:latest
-          docker push ${{ steps.gcr.outputs.path }}:${{ github.sha }}
-
   deploy-stage:
     needs: [config, build, test]
     uses: ./.github/workflows/_update-argo.yml


### PR DESCRIPTION
Remove the `build-st` job that published `Dockerfile.prod` to `gcr.io/padas-app/circleci/das-web-react/*`. All legacy deploys now consume images from `serca-artifact-registry` exclusively — no downstream job ever referenced `build-st` in its `needs`.

## Changes

- Remove `build-st` job from `release.yml`
  - Built via `Dockerfile.prod` → `gcr.io/padas-app/circleci/das-web-react/<branch>` using legacy `secrets.WIF_PROVIDER`/`WIF_SERVICE_ACCOUNT`
  - Zero downstream dependencies: all prod/stage/prod-me/prod-us deploys and legacy-kubectl jobs depend on the `build` job (serca AR + padas-app/er-mt)

## Files Changed

- `.github/workflows/release.yml`

Jira: [DASOPS-2066](https://padas.atlassian.net/browse/DASOPS-2066)

[DASOPS-2066]: https://allenai.atlassian.net/browse/DASOPS-2066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ