### PR TITLE
ERA-13509: Add EarthRanger Identity migration info box to login screen

### DIFF
--- a/public/locales/en-US/login.json
+++ b/public/locales/en-US/login.json
@@ -1,4 +1,12 @@
 {
+  "auth0Info": {
+    "title": "Set up EarthRanger Identity",
+    "intro": "EarthRanger is moving to a simpler, more secure way to sign in, called EarthRanger Identity.",
+    "signInPrompt": "If you already have EarthRanger Identity, select Sign in with email below.",
+    "convertPrompt": "First time using EarthRanger Identity? You'll first need to convert your existing account using the username and password you use today.",
+    "convertLink": "Convert your account",
+    "helpText": "Questions? Reach out to your site admin."
+  },
   "errorAlert": {
     "accessDeniedNotAuthorized": "Access denied: Your account is not authorized for this organization. Please contact your administrator.",
     "accessDeniedNoPermission": "Access denied: You do not have permission to access this application.",

--- a/src/Login/index.js
+++ b/src/Login/index.js
@@ -12,7 +12,7 @@ import {
 import appConfig from '../config';
 import { clearAuth, postAuth } from '../ducks/auth';
 import { fetchEula } from '../ducks/eula';
-import { REACT_APP_ROUTE_PREFIX, SYSTEM_CONFIG_FLAGS } from '../constants';
+import { ACCOUNT_LINKER_URL, REACT_APP_ROUTE_PREFIX, SYSTEM_CONFIG_FLAGS } from '../constants';
 import { buildAuth0AuthorizationParams } from '../utils/auth0';
 import useNavigate from '../hooks/useNavigate';
 
@@ -46,7 +46,7 @@ const LoginPage = () => {
   const [formErrors, setFormErrors] = useState({ username: null, password: null });
   const [isLoading, setIsLoading] = useState(false);
 
-  const idpOrgId = systemConfig?.idp_org_id;
+  const idpOrgId = systemConfig?.idp_org_id?.trim() || null;
   const isEULAEnabled = !!systemConfig?.[SYSTEM_CONFIG_FLAGS.EULA];
   const requireIdp = !!systemConfig?.require_idp;
 
@@ -153,6 +153,28 @@ const LoginPage = () => {
 
     <h1 className={styles.srOnly}>{t('title')}</h1>
 
+    {/* Auth0 migration guidance: shown only on common-DB sites (require_idp with
+        no idp_org_id). "Sign in with email" below auto-drives EarthRanger
+        Identity; users who have not converted their account yet are linked to
+        the server account linker. Org-scoped sites show no box. */}
+    {requireIdp && !idpOrgId && (
+      <section className={styles.infoBox} aria-labelledby="auth0-info-title">
+        <h2 className={styles.infoBoxTitle} id="auth0-info-title">
+          {t('auth0Info.title')}
+        </h2>
+
+        <p className={styles.infoBoxBody}>{t('auth0Info.intro')}</p>
+        <p className={styles.infoBoxBody}>{t('auth0Info.signInPrompt')}</p>
+
+        <p className={styles.infoBoxBody}>{t('auth0Info.convertPrompt')}</p>
+        <a className={styles.infoBoxLink} href={ACCOUNT_LINKER_URL}>
+          {t('auth0Info.convertLink')}
+        </a>
+
+        <p className={styles.helperText}>{t('auth0Info.helpText')}</p>
+      </section>
+    )}
+
     {requireIdp ? (
       <div className={styles.form}>
         <button
@@ -165,7 +187,7 @@ const LoginPage = () => {
         >
           {isAuth0Loading
             ? <MoonLoader aria-hidden color="white" size={SUBMIT_LOADER_SIZE} />
-            : t(idpOrgId?.trim() ? 'loginButtonIdp' : 'loginButtonEmail')}
+            : t(idpOrgId ? 'loginButtonIdp' : 'loginButtonEmail')}
         </button>
       </div>
     ) : (

--- a/src/Login/index.test.js
+++ b/src/Login/index.test.js
@@ -168,6 +168,75 @@ describe('Login', () => {
     });
   });
 
+  describe('Auth0 sign-in info box', () => {
+    test('renders the info box on a common-DB Auth0 site (require_idp without an organization ID)', () => {
+      store = mockStore({
+        data: { eula: { eula_url: '' } },
+        view: { systemConfig: { require_idp: true } },
+      });
+
+      renderLogin();
+
+      const infoBoxTitle = screen.getByRole('heading', { level: 2 });
+      expect(infoBoxTitle).toBeVisible();
+
+      const infoBox = infoBoxTitle.closest('section');
+      expect(infoBox).toHaveClass(loginStyles.infoBox);
+      expect(infoBox).toHaveAttribute('aria-labelledby', infoBoxTitle.id);
+
+      // Links out to the DAS-server account linker for users who have not converted.
+      const linkerLink = screen.getByRole('link', { name: 'Convert your account' });
+      expect(linkerLink).toHaveAttribute('href', expect.stringContaining('/auth/link-accounts/'));
+
+      // Additive: the Auth0 sign-in button still renders alongside the info box.
+      expect(screen.getByRole('button', { name: 'Sign in with email' })).toBeVisible();
+
+      // Helper text below the button.
+      expect(screen.getByText('Questions? Reach out to your site admin.')).toBeVisible();
+    });
+
+    test('treats a whitespace-only organization ID as common-DB and still renders the info box', () => {
+      store = mockStore({
+        data: { eula: { eula_url: '' } },
+        view: { systemConfig: { require_idp: true, idp_org_id: '   ' } },
+      });
+
+      renderLogin();
+
+      expect(screen.getByRole('heading', { level: 2 })).toBeVisible();
+      expect(screen.getByRole('link', { name: 'Convert your account' })).toBeVisible();
+      // Whitespace-only org id is treated as no org -> common-DB "Sign in with email".
+      expect(screen.getByRole('button', { name: 'Sign in with email' })).toBeVisible();
+    });
+
+    test('does not render the info box on an org-scoped Auth0 site (require_idp with an organization ID)', () => {
+      store = mockStore({
+        data: { eula: { eula_url: '' } },
+        view: { systemConfig: { require_idp: true, idp_org_id: 'org_abc' } },
+      });
+
+      renderLogin();
+
+      expect(screen.queryByRole('heading', { level: 2 })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Convert your account' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Sign in' })).toBeVisible();
+    });
+
+    test('does not render the info box on a site without Auth0 configured', () => {
+      store = mockStore({
+        data: { eula: { eula_url: '' } },
+        view: { systemConfig: { require_idp: false } },
+      });
+
+      renderLogin();
+
+      expect(screen.queryByRole('heading', { level: 2 })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Convert your account' })).not.toBeInTheDocument();
+      // The legacy username-and-password form is unchanged.
+      expect(screen.getByLabelText('Username')).toBeVisible();
+    });
+  });
+
   test('shows a sign-in failure alert when loginWithRedirect rejects', async () => {
     store = mockStore({
       data: { eula: { eula_url: '' } },

--- a/src/Login/styles.module.scss
+++ b/src/Login/styles.module.scss
@@ -98,6 +98,47 @@
     }
   }
 
+  /* Info variant of the .alertMessage callout below (blue instead of red),
+     used for the Auth0 migration guidance box. */
+  .infoBox {
+    background-color: color.adjust(colors.$bright-blue, $lightness: 52%);
+    border: 1px solid colors.$bright-blue;
+    border-radius: 0.25rem;
+    margin-bottom: 1.5rem;
+    max-width: 20rem;
+    padding: 0.75rem;
+    width: 100%;
+
+    /* Tame the global Bootstrap heading sizes inside the compact box. */
+    .infoBoxTitle {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    .infoBoxLink {
+      display: inline-block;
+      font-size: 0.875rem;
+      font-weight: 600;
+      margin-bottom: 0.75rem;
+    }
+
+    .infoBoxBody {
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    .helperText {
+      color: colors.$secondary-medium-gray;
+      font-size: 0.875rem;
+      margin-bottom: 0;
+    }
+  }
+
   .alertMessage {
     color: colors.$bright-red;
     background-color: color.adjust(colors.$bright-red, $lightness: 56%);

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -28,6 +28,10 @@ export const CLUSTERS_RADIUS = 40;
 export const API_URL = `${DAS_HOST}${REACT_APP_DAS_API_URL}`;
 export const API_V2_URL = `${DAS_HOST}${REACT_APP_DAS_API_V2_URL}`;
 
+// Server-owned (Django) account-linker page for the EarthRanger Identity (Auth0)
+// migration. Reachable before auth.
+export const ACCOUNT_LINKER_URL = `${DAS_HOST}/auth/link-accounts/`;
+
 export const STATUSES = {
   HEALTHY_STATUS: 'HEALTHY',
   WARNING_STATUS: 'WARNING',

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,7 +7,7 @@ import LocalStorageBackend from 'i18next-localstorage-backend';
 
 import { SUPPORTED_LANGUAGES } from './constants';
 
-const I18N_FILES_VERSION = '1.41';
+const I18N_FILES_VERSION = '1.42';
 
 const preloadNamespaces = [
   'components',


### PR DESCRIPTION
## ERA-13509

Jira: https://allenai.atlassian.net/browse/ERA-13509

Adds an additive info box to the ER Web login screen for the EarthRanger Identity (Auth0) migration, so users on migrating sites get on-screen guidance instead of relying on release notes, email, and Support.

### What it does
- On **common-DB Auth0 sites** (`require_idp` set, no `idp_org_id`), the login screen renders a **"Set up EarthRanger Identity"** info box above the existing "Sign in with email" button.
- The box explains the move to EarthRanger Identity, tells already-set-up users to sign in with email, and links users who haven't converted yet to the server account linker (`/auth/link-accounts/`, via a new `ACCOUNT_LINKER_URL` constant).
- **Purely additive** — no change to the login form/button logic. Org-scoped Auth0 sites (`idp_org_id` set) and non-Auth0 sites are unchanged: no box, no layout shift.
- `idp_org_id` is normalized with `trim() || null`, so a whitespace-only value is treated as "no org" and keeps the box gating and the sign-in button label in agreement.

<img width="1712" height="1877" alt="Screenshot 2026-06-25 at 20 40 55" src="https://github.com/user-attachments/assets/734536da-94cc-465c-8c2d-99eb70a59a5f" />


https://github.com/user-attachments/assets/032f0289-4024-4c8e-adfa-4f1e69b4d1bb


https://github.com/user-attachments/assets/e33981f7-996f-4786-8f72-d7d178de4951



### Accessibility
Semantic `<section aria-labelledby>` named region, `<h2>` under the page `<h1>` (no skipped levels), descriptive link text, helper text contrast passes WCAG AA. Reviewed via the ER core-reviewer (no blockers).

### Testing
- `yarn test src/Login/index.test.js` — **34/34 pass**: box present on common-DB (including a whitespace-only org id), absent on org-scoped (sign-in button still renders), absent on non-Auth0 (legacy form unchanged); asserts the account-linker link and helper text.
- ESLint clean.

### Scope notes & follow-ups
- **English only for now** — `auth0Info` strings added to `en-US/login.json`; i18next `fallbackLng: 'en-US'` covers other locales until translations land (follow-up).
- **i18n cache** — `I18N_FILES_VERSION` should be bumped at release so returning users get the updated `login.json`.
- The ticket's Trigger/AC1 say "any Auth0 site"; this is deliberately scoped to **common-DB** (where account-linking applies) per product decision — AC wording to be reconciled on the ticket.

### Why draft
Pending **PM/UX copy approval (AC5)** and **design review (AC6)**. Copy is the current working wording, not yet signed off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
