### PR TITLE
fix: switch Docker builds to WIF Direct Resource Access

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -74,7 +74,6 @@ jobs:
         with:
           token_format: 'access_token'
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.SERVICE_ACCOUNT }}
 
       - name: Login to serca-artifact-registry
         uses: docker/login-action@v3

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -70,24 +70,12 @@ jobs:
 
       - name: GCP Auth
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
-          token_format: 'access_token'
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
 
-      - name: Login to serca-artifact-registry
-        uses: docker/login-action@v3
-        with:
-          registry: europe-west3-docker.pkg.dev/serca-artifact-registry
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
-
-      - name: Login to padas-app
-        uses: docker/login-action@v3
-        with:
-          registry: europe-west3-docker.pkg.dev/padas-app
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+      - name: Configure Docker
+        run: gcloud auth configure-docker europe-west3-docker.pkg.dev
 
       - uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -88,7 +88,6 @@ jobs:
         with:
           images: |
             europe-west3-docker.pkg.dev/serca-artifact-registry/earthranger/das-web-react
-            europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react
           tags: |
             type=raw,value=${{ needs.config.outputs.image-tag }}
 

--- a/.github/workflows/pr-envs.yml
+++ b/.github/workflows/pr-envs.yml
@@ -101,8 +101,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: >
-            europe-west3-docker.pkg.dev/serca-artifact-registry/earthranger/das-web-react,
-            europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react
+            europe-west3-docker.pkg.dev/serca-artifact-registry/earthranger/das-web-react
           tags: |
             type=raw,value=${{ needs.prepare.outputs.image-tag }}
             type=raw,value=pr-${{ needs.prepare.outputs.image-tag }}

--- a/.github/workflows/pr-envs.yml
+++ b/.github/workflows/pr-envs.yml
@@ -84,24 +84,12 @@ jobs:
 
       - name: GCP Auth
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
-          token_format: 'access_token'
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
 
-      - name: Login to serca-artifact-registry
-        uses: docker/login-action@v3
-        with:
-          registry: europe-west3-docker.pkg.dev/serca-artifact-registry
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
-
-      - name: Login to padas-app
-        uses: docker/login-action@v3
-        with:
-          registry: europe-west3-docker.pkg.dev/padas-app
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+      - name: Configure Docker
+        run: gcloud auth configure-docker europe-west3-docker.pkg.dev
 
       - uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/pr-envs.yml
+++ b/.github/workflows/pr-envs.yml
@@ -88,7 +88,6 @@ jobs:
         with:
           token_format: 'access_token'
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.SERVICE_ACCOUNT }}
 
       - name: Login to serca-artifact-registry
         uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,24 +71,12 @@ jobs:
 
       - name: GCP Auth
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
-          token_format: 'access_token'
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
 
-      - name: Login to serca-artifact-registry
-        uses: docker/login-action@v3
-        with:
-          registry: europe-west3-docker.pkg.dev/serca-artifact-registry
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
-
-      - name: Login to padas-app
-        uses: docker/login-action@v3
-        with:
-          registry: europe-west3-docker.pkg.dev/padas-app
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+      - name: Configure Docker
+        run: gcloud auth configure-docker europe-west3-docker.pkg.dev
 
       - uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,6 @@ jobs:
         with:
           token_format: 'access_token'
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.SERVICE_ACCOUNT }}
 
       - name: Login to serca-artifact-registry
         uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,6 @@ jobs:
         with:
           images: |
             europe-west3-docker.pkg.dev/serca-artifact-registry/earthranger/das-web-react
-            europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react
           tags: |
             type=raw,value=${{ needs.config.outputs.image-tag }}
 


### PR DESCRIPTION
## Summary

Remove `service_account` from the GCP Auth step in all three build workflows so Docker pushes use WIF Direct Resource Access instead of SA impersonation.

## Changes

### Changed

- `develop.yml`: Removed `service_account: ${{ vars.SERVICE_ACCOUNT }}` from the `GCP Auth` step
- `release.yml`: Same removal
- `pr-envs.yml`: Same removal

## Technical Details

das-web-react uses `google-github-actions/auth@v2` directly (not via `pipeline-kubernetes-*.yml`) with `token_format: 'access_token'` for docker login via `oauth2accesstoken`. Removing `service_account` while keeping `workload_identity_provider` switches the auth to WIF Direct. The `token_format: 'access_token'` stays — it's needed for the `docker/login-action` pattern and works fine without SA.

The `principalSet` binding for das-web-react (github_repo_id `159379506`) on the `earthranger` AR repo was applied via serca-iac as part of DASOPS-1949. `_deploy_legacy_kubectl.yml` deliberately retains its `service_account` since that's for kubectl deploys, not Docker pushes.

## Files Changed

**3 files changed, 3 deletions(-)**

---
**Jira**: https://allenai.atlassian.net/browse/DASOPS-1949