### PR TITLE
ERA-13506: Review state visible in event UI when Community Input is disabled

### DIFF
--- a/src/EditableItem/Footer.js
+++ b/src/EditableItem/Footer.js
@@ -1,4 +1,5 @@
 import React, { memo } from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 import Button from 'react-bootstrap/Button';
@@ -27,6 +28,13 @@ const Footer = ({
 }) => {
   const { t } = useTranslation('details-view', { keyPrefix: 'footer' });
   const { cancelTitle = t('cancelButton') } = restProps;
+
+  // Remove this flag and the conditional rendering below once community input
+  // is enabled for all tenants.
+  const communityInputEnabled = useSelector(
+    (state) => !!state.view.systemConfig.previewFeatures?.community_input_admin_enabled
+  );
+
   const isActive = isReportActive(data);
   const isInReview = data?.state === EVENT_FORM_STATES.REVIEW;
   const SaveButtonComponent = onStateToggle ? SplitButton : Button;
@@ -43,7 +51,7 @@ const Footer = ({
             label={t('stateResolveButton')}
           />
         </Dropdown.Item>}
-        {isActive && <Dropdown.Item>
+        {isActive && communityInputEnabled && <Dropdown.Item>
           <StateButton
             targetState={EVENT_FORM_STATES.REVIEW}
             onStateToggle={onStateToggle}

--- a/src/EventFilter/Filters/index.js
+++ b/src/EventFilter/Filters/index.js
@@ -3,6 +3,7 @@ import Button from 'react-bootstrap/Button';
 import isEqual from 'react-fast-compare';
 import Popover from 'react-bootstrap/Popover';
 import uniq from 'lodash-es/uniq';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 import { ReactComponent as UserIcon } from '../../common/images/icons/user-profile.svg';
@@ -20,20 +21,28 @@ import * as styles from '../styles.module.scss';
 const StateSelector = ({ onStateSelect, state }) => {
   const { t } = useTranslation('filters', { keyPrefix: 'filters' });
 
+  // Remove this flag and the `.filter` below once community input is enabled
+  // for all tenants.
+  const communityInputEnabled = useSelector(
+    (state) => !!state.view.systemConfig.previewFeatures?.community_input_admin_enabled
+  );
+
   return <ul
       className={styles.stateList}
       data-testid="state-filter-options"
     >
-    {EVENT_STATE_CHOICES.map((choice) =>
-      <li key={choice.value}>
-        <Button
-          className={isEqual(choice.value, state) ? styles.activeState : ''}
-          onClick={() => onStateSelect(choice)}
-          variant="link"
-        >
-          {t(`stateSelector.${choice.key}`)}
-        </Button>
-      </li>)}
+    {EVENT_STATE_CHOICES
+      .filter((choice) => communityInputEnabled || choice.key !== 'review')
+      .map((choice) =>
+        <li key={choice.value}>
+          <Button
+            className={isEqual(choice.value, state) ? styles.activeState : ''}
+            onClick={() => onStateSelect(choice)}
+            variant="link"
+          >
+            {t(`stateSelector.${choice.key}`)}
+          </Button>
+        </li>)}
   </ul>;
 };
 

--- a/src/EventFilter/index.test.js
+++ b/src/EventFilter/index.test.js
@@ -58,6 +58,9 @@ describe('EventFilter', () => {
         },
         feedEvents: { results: [] },
       },
+      view: {
+        systemConfig: { previewFeatures: {} },
+      },
     };
   });
 

--- a/src/EventItemContextMenu/index.js
+++ b/src/EventItemContextMenu/index.js
@@ -1,7 +1,7 @@
 import React, { memo, useCallback, useState } from 'react';
 import Dropdown from 'react-bootstrap/Dropdown';
 import MoonLoader from 'react-spinners/MoonLoader';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 import { ReactComponent as LinkIcon } from '../common/images/icons/link.svg';
@@ -49,6 +49,12 @@ const EventItemContextMenu = ({ children, className = '', report }) => {
   const { t } = useTranslation('reports', { keyPrefix: 'eventItemContextMenu' });
 
   const [isLoading, setIsLoading] = useState(false);
+
+  // Remove this flag and the conditional rendering below once community input
+  // is enabled for all tenants.
+  const communityInputEnabled = useSelector(
+    (state) => !!state.view.systemConfig.previewFeatures?.community_input_admin_enabled
+  );
 
   const isActive = isReportActive(report);
   const isInReview = report?.state === EVENT_FORM_STATES.REVIEW;
@@ -125,7 +131,7 @@ const EventItemContextMenu = ({ children, className = '', report }) => {
       {(isActive || isInReview) && <Dropdown.Item className={styles.option} onClick={() => updateReportState(EVENT_FORM_STATES.RESOLVED)}>
         {t('updateReportStateItem.resolve')} #{report.serial_number}
       </Dropdown.Item>}
-      {isActive && <Dropdown.Item className={styles.option} onClick={() => updateReportState(EVENT_FORM_STATES.REVIEW)}>
+      {isActive && communityInputEnabled && <Dropdown.Item className={styles.option} onClick={() => updateReportState(EVENT_FORM_STATES.REVIEW)}>
         {t('updateReportStateItem.review')} #{report.serial_number}
       </Dropdown.Item>}
       {isInReview && <Dropdown.Item className={styles.option} onClick={() => updateReportState(EVENT_FORM_STATES.ACTIVE)}>

--- a/src/EventItemContextMenu/index.test.js
+++ b/src/EventItemContextMenu/index.test.js
@@ -33,7 +33,7 @@ afterAll(() => server.close());
 describe('EventItemContextMenu', () => {
   let store;
   beforeEach(() => {
-    store = { data: {}, view: {} };
+    store = { data: {}, view: { systemConfig: {} } };
   });
 
   test('shows a message after updating a report status', async () => {

--- a/src/ReportManager/DetailsSection/index.js
+++ b/src/ReportManager/DetailsSection/index.js
@@ -73,6 +73,11 @@ const DetailsSection = ({
 }) => {
   const { t } = useTranslation('reports', { keyPrefix: 'reportManager.detailsSection' });
 
+  // Remove this flag and the `.filter` below once community input is enabled
+  // for all tenants.
+  const communityInputEnabled = useSelector(
+    (state) => !!state.view.systemConfig.previewFeatures?.community_input_admin_enabled
+  );
   const eventType = useSelector((state) => reportForm?.event_type ? selectEventTypeByValue(state, reportForm.event_type) : null);
   const loadingEventSchemas = useSelector((state) => state.data.eventSchemas.loading);
 
@@ -158,6 +163,7 @@ const DetailsSection = ({
             >
               {Object.values(EVENT_FORM_STATES)
                 .filter((eventState) => eventState !== EVENT_FORM_STATES.NEW_LEGACY)
+                .filter((eventState) => communityInputEnabled || eventState !== EVENT_FORM_STATES.REVIEW)
                 .map((eventState) => <Dropdown.Item
                   className={styles.stateItem}
                   eventKey={eventState}

--- a/src/ReportManager/DetailsSection/index.test.js
+++ b/src/ReportManager/DetailsSection/index.test.js
@@ -76,6 +76,9 @@ describe('ReportManager - DetailsSection', () => {
         },
         mapLocationSelection: { isPickingLocation: false },
         sideBar: {},
+        systemConfig: {
+          previewFeatures: { community_input_admin_enabled: true },
+        },
         userPreferences: { gpsFormat: GPS_FORMATS.DEG },
       },
     };

--- a/src/ReportManager/ReportDetailView/index.js
+++ b/src/ReportManager/ReportDetailView/index.js
@@ -131,8 +131,12 @@ const ReportDetailView = ({
   const reportTracker = useContext(TrackerContext);
   const { setScrollPosition } = useContext(SidebarScrollContext);
 
+  // Remove this flag and the conditional rendering below once community input
+  // is enabled for all tenants.
+  const communityInputEnabled = useSelector(
+    (state) => !!state.view.systemConfig.previewFeatures?.community_input_admin_enabled
+  );
   const eventStore = useSelector((state) => state.data.eventStore);
-  const patrolStore = useSelector((state) => state.data.patrolStore);
   const eventType = useSelector((state) => {
     if (isNewReport) {
       return selectEventTypeById(state, newReportTypeId);
@@ -141,6 +145,7 @@ const ReportDetailView = ({
       return selectEventTypeByValue(state, eventTypeValue);
     }
   });
+  const patrolStore = useSelector((state) => state.data.patrolStore);
 
   const newAttachmentRef = useRef(null);
   const newNoteRef = useRef(null);
@@ -921,7 +926,7 @@ const ReportDetailView = ({
                       {t('reportDetailView.saveSplitButton.saveAndResolveItem')}
                     </Button>
                   </Dropdown.Item>}
-                  {isActive && <Dropdown.Item className={styles.saveSplitButtonItem}>
+                  {isActive && communityInputEnabled && <Dropdown.Item className={styles.saveSplitButtonItem}>
                     <Button onClick={() => onClickSaveAndSetState(EVENT_FORM_STATES.REVIEW)} type="button" variant="primary">
                       {t('reportDetailView.saveSplitButton.saveAndReviewItem')}
                     </Button>

--- a/src/ReportManager/index.test.js
+++ b/src/ReportManager/index.test.js
@@ -68,6 +68,9 @@ describe('ReportManager', () => {
         },
         mapLocationSelection: { isPickingLocation: false },
         sideBar: {},
+        systemConfig: {
+          previewFeatures: { community_input_admin_enabled: true },
+        },
         userPreferences: { gpsFormat: GPS_FORMATS.DEG },
       },
     };

--- a/src/ducks/system-config/index.js
+++ b/src/ducks/system-config/index.js
@@ -30,10 +30,11 @@ export const setSystemConfigFromSystemStatus = (systemStatus) => (dispatch) => {
       [SYSTEM_CONFIG_FLAGS.SUBJECTS]: systemStatus[SYSTEM_CONFIG_FLAGS.SUBJECTS] ?? true,
       [SYSTEM_CONFIG_FLAGS.TABLEAU]: systemStatus[SYSTEM_CONFIG_FLAGS.TABLEAU] ?? true,
       [SYSTEM_CONFIG_FLAGS.GEO_SPAN]: systemStatus[SYSTEM_CONFIG_FLAGS.GEO_SPAN] ?? null,
-      showTrackDays: systemStatus.show_track_days,
-      sitename,
-      require_idp: !!systemStatus.require_idp,
       idp_org_id: systemStatus.idp_org_id || null,
+      previewFeatures: systemStatus.preview_features || {},
+      require_idp: !!systemStatus.require_idp,
+      sitename,
+      showTrackDays: systemStatus.show_track_days,
     },
   });
 
@@ -74,10 +75,11 @@ export const INITIAL_STATE = {
   [SYSTEM_CONFIG_FLAGS.SUBJECTS]: false,
   [SYSTEM_CONFIG_FLAGS.TABLEAU]: false,
   [SYSTEM_CONFIG_FLAGS.GEO_SPAN]: null,
-  showTrackDays: DEFAULT_SHOW_TRACK_DAYS,
-  sitename: '',
-  require_idp: null,  // null = not loaded yet
   idp_org_id: null,
+  previewFeatures: {},
+  require_idp: null,
+  sitename: '',
+  showTrackDays: DEFAULT_SHOW_TRACK_DAYS,
 };
 
 const systemConfigReducer = (state = INITIAL_STATE, action) => {

--- a/src/ducks/system-config/index.test.js
+++ b/src/ducks/system-config/index.test.js
@@ -51,6 +51,7 @@ describe('Ducks - System config', () => {
       [SYSTEM_CONFIG_FLAGS.SUBJECTS]: true,
       [SYSTEM_CONFIG_FLAGS.TABLEAU]: true,
       geoPermissionsEnabled: true,
+      preview_features: { community_input_admin_enabled: true },
       show_track_days: true,
       site_name: 'Site name',
     };
@@ -76,9 +77,12 @@ describe('Ducks - System config', () => {
         [SYSTEM_CONFIG_FLAGS.SUBJECTS]: true,
         [SYSTEM_CONFIG_FLAGS.TABLEAU]: true,
         idp_org_id: null,
+        previewFeatures: {
+          community_input_admin_enabled: true,
+        },
         require_idp: false,
-        showTrackDays: true,
         sitename: 'Site name',
+        showTrackDays: true,
       },
       type: SET_SYSTEM_CONFIG,
     });
@@ -180,6 +184,7 @@ describe('Ducks - System config', () => {
         [SYSTEM_CONFIG_FLAGS.SPATIAL_FEATURES]: true,
         [SYSTEM_CONFIG_FLAGS.SUBJECTS]: true,
         [SYSTEM_CONFIG_FLAGS.TABLEAU]: true,
+        previewFeatures: { community_input_admin_enabled: true },
         showTrackDays: true,
         sitename: 'Site name',
       };
@@ -198,6 +203,7 @@ describe('Ducks - System config', () => {
         [SYSTEM_CONFIG_FLAGS.SUBJECTS]: true,
         [SYSTEM_CONFIG_FLAGS.TABLEAU]: true,
         idp_org_id: null,
+        previewFeatures: { community_input_admin_enabled: true },
         require_idp: null,
         showTrackDays: true,
         sitename: 'Site name',


### PR DESCRIPTION
## What does this PR do?
Implement community input feature toggle in EventFilter and ReportManager components.

- Added `community_input_admin_enabled` flag to system configuration in both EventFilter and ReportManager.
- Updated state filtering logic in EventFilter and DetailsSection to conditionally render options based on the community input feature toggle.
- Enhanced test cases to reflect the new system configuration structure and feature flag.

### Relevant link(s)
- [ERA-13506](https://allenai.atlassian.net/browse/ERA-13506)
- [Branch Environment](https://era-13506.dev.pamdas.org)


[ERA-13506]: https://allenai.atlassian.net/browse/ERA-13506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ