### PR TITLE
fix(ci): hardcode centralized WIF provider (DASOPS-1949)

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -72,7 +72,7 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v3
         with:
-          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: projects/563316706574/locations/global/workloadIdentityPools/github-actions/providers/github-oidc  # pragma: allowlist secret
 
       - name: Configure Docker
         run: gcloud auth configure-docker europe-west3-docker.pkg.dev

--- a/.github/workflows/pr-envs.yml
+++ b/.github/workflows/pr-envs.yml
@@ -86,7 +86,7 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v3
         with:
-          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: projects/563316706574/locations/global/workloadIdentityPools/github-actions/providers/github-oidc  # pragma: allowlist secret
 
       - name: Configure Docker
         run: gcloud auth configure-docker europe-west3-docker.pkg.dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v3
         with:
-          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: projects/563316706574/locations/global/workloadIdentityPools/github-actions/providers/github-oidc  # pragma: allowlist secret
 
       - name: Configure Docker
         run: gcloud auth configure-docker europe-west3-docker.pkg.dev


### PR DESCRIPTION
## Summary

Replace `${{ vars.WORKLOAD_IDENTITY_PROVIDER }}` with the hardcoded centralized `github-actions` pool path as part of the WIF Direct Resource Access migration (DASOPS-1949). No service account impersonation — the principalSet IAM bindings in serca-iac already grant the necessary Artifact Registry access for this repo.

## Changes

- `develop.yml`, `release.yml`, `pr-envs.yml`: replace repo variable with hardcoded WIF provider path

## Technical Details

The centralized `github-actions` WIF pool in `serca-tools` (project 563316706574) is the target. All principalSet bindings for `das_web_react` (repo ID 159379506) are already in place in `serca-iac/environments/serca/artifact-registry/iam/main.tf`.

## Files Changed

**3 files changed, 3 insertions(+), 3 deletions(-)**

---
**Jira**: https://allenai.atlassian.net/browse/DASOPS-1949