### PR TITLE
fix: switch Docker builds to WIF Direct Resource Access (#1615)

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -70,25 +70,12 @@ jobs:
 
       - name: GCP Auth
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
-          token_format: 'access_token'
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.SERVICE_ACCOUNT }}
 
-      - name: Login to serca-artifact-registry
-        uses: docker/login-action@v3
-        with:
-          registry: europe-west3-docker.pkg.dev/serca-artifact-registry
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
-
-      - name: Login to padas-app
-        uses: docker/login-action@v3
-        with:
-          registry: europe-west3-docker.pkg.dev/padas-app
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+      - name: Configure Docker
+        run: gcloud auth configure-docker europe-west3-docker.pkg.dev
 
       - uses: docker/setup-buildx-action@v3
         with:
@@ -101,7 +88,6 @@ jobs:
         with:
           images: |
             europe-west3-docker.pkg.dev/serca-artifact-registry/earthranger/das-web-react
-            europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react
           tags: |
             type=raw,value=${{ needs.config.outputs.image-tag }}
 

--- a/.github/workflows/pr-envs.yml
+++ b/.github/workflows/pr-envs.yml
@@ -84,25 +84,12 @@ jobs:
 
       - name: GCP Auth
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
-          token_format: 'access_token'
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.SERVICE_ACCOUNT }}
 
-      - name: Login to serca-artifact-registry
-        uses: docker/login-action@v3
-        with:
-          registry: europe-west3-docker.pkg.dev/serca-artifact-registry
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
-
-      - name: Login to padas-app
-        uses: docker/login-action@v3
-        with:
-          registry: europe-west3-docker.pkg.dev/padas-app
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+      - name: Configure Docker
+        run: gcloud auth configure-docker europe-west3-docker.pkg.dev
 
       - uses: docker/setup-buildx-action@v3
         with:
@@ -114,8 +101,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: >
-            europe-west3-docker.pkg.dev/serca-artifact-registry/earthranger/das-web-react,
-            europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react
+            europe-west3-docker.pkg.dev/serca-artifact-registry/earthranger/das-web-react
           tags: |
             type=raw,value=${{ needs.prepare.outputs.image-tag }}
             type=raw,value=pr-${{ needs.prepare.outputs.image-tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,25 +71,12 @@ jobs:
 
       - name: GCP Auth
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
-          token_format: 'access_token'
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.SERVICE_ACCOUNT }}
 
-      - name: Login to serca-artifact-registry
-        uses: docker/login-action@v3
-        with:
-          registry: europe-west3-docker.pkg.dev/serca-artifact-registry
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
-
-      - name: Login to padas-app
-        uses: docker/login-action@v3
-        with:
-          registry: europe-west3-docker.pkg.dev/padas-app
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+      - name: Configure Docker
+        run: gcloud auth configure-docker europe-west3-docker.pkg.dev
 
       - uses: docker/setup-buildx-action@v3
         with:
@@ -102,7 +89,6 @@ jobs:
         with:
           images: |
             europe-west3-docker.pkg.dev/serca-artifact-registry/earthranger/das-web-react
-            europe-west3-docker.pkg.dev/padas-app/er-mt/das-web-react
           tags: |
             type=raw,value=${{ needs.config.outputs.image-tag }}
 


### PR DESCRIPTION
Cherry-pick of ca65291cff21b1ea41c089b180bce3aede97dd60 from `develop` into `release-2.142.1`.

This is required to fix CI on the release branch.

Original PR: #1615

🤖 Generated with [Claude Code](https://claude.com/claude-code)