### PR TITLE
ERA-13529: Force symbol re-layout so cleared subjects disappear immediately

### DIFF
--- a/src/SubjectsLayer/index.js
+++ b/src/SubjectsLayer/index.js
@@ -57,20 +57,14 @@ const SubjectsLayer = ({ mapImages = {}, onSubjectClick }) => {
     setMapSubjectFeatures({ ...subjectFeatureCollection });
   }, [mapImages, subjectFeatureCollection]);
 
-  // When an unclustered symbol source's data shrinks (e.g. "Clear All" or clearing a
-  // subject group), Mapbox keeps the previously rendered symbol bucket on screen — the
-  // removed icons linger until something forces the layer to re-lay-out, which is why a
-  // pan/zoom makes them disappear. Updating the source data, repainting, and forcing a
-  // placement pass all fail to rebuild the bucket; toggling the layer's visibility does.
-  // So, once the source has finished reloading the smaller dataset, briefly toggle the
-  // unclustered subject layers' visibility to force the rebuild without moving the camera.
-  // Clustered subjects render as DOM markers, which update immediately, so this only
-  // applies when clustering is off.
+  // When an unclustered symbol source's data shrinks Mapbox keeps the
+  // previously rendered symbol bucket on screen. Toggling the layer's
+  // visibility rebuilds the bucket.
   const previousSubjectCountRef = useRef(0);
+  const currentSubjectCount = mapSubjectFeatures.features?.length ?? 0;
   useEffect(() => {
-    const currentCount = mapSubjectFeatures.features?.length ?? 0;
-    const didShrink = currentCount < previousSubjectCountRef.current;
-    previousSubjectCountRef.current = currentCount;
+    const didShrink = currentSubjectCount < previousSubjectCountRef.current;
+    previousSubjectCountRef.current = currentSubjectCount;
 
     if (!didShrink || !map || shouldSubjectsBeClustered) return;
 
@@ -91,7 +85,7 @@ const SubjectsLayer = ({ mapImages = {}, onSubjectClick }) => {
     };
     map.on('sourcedata', onSourceData);
     return () => map.off('sourcedata', onSourceData);
-  }, [map, mapSubjectFeatures, shouldSubjectsBeClustered]);
+  }, [currentSubjectCount, map, shouldSubjectsBeClustered]);
 
   const onSubjectSymbolClick = useMemo(() => withMultiLayerHandlerAwareness(
     map,

--- a/src/SubjectsLayer/index.js
+++ b/src/SubjectsLayer/index.js
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { featureCollection } from '@turf/turf';
 import { useSelector } from 'react-redux';
 
@@ -56,6 +56,42 @@ const SubjectsLayer = ({ mapImages = {}, onSubjectClick }) => {
   useEffect(() => {
     setMapSubjectFeatures({ ...subjectFeatureCollection });
   }, [mapImages, subjectFeatureCollection]);
+
+  // When an unclustered symbol source's data shrinks (e.g. "Clear All" or clearing a
+  // subject group), Mapbox keeps the previously rendered symbol bucket on screen — the
+  // removed icons linger until something forces the layer to re-lay-out, which is why a
+  // pan/zoom makes them disappear. Updating the source data, repainting, and forcing a
+  // placement pass all fail to rebuild the bucket; toggling the layer's visibility does.
+  // So, once the source has finished reloading the smaller dataset, briefly toggle the
+  // unclustered subject layers' visibility to force the rebuild without moving the camera.
+  // Clustered subjects render as DOM markers, which update immediately, so this only
+  // applies when clustering is off.
+  const previousSubjectCountRef = useRef(0);
+  useEffect(() => {
+    const currentCount = mapSubjectFeatures.features?.length ?? 0;
+    const didShrink = currentCount < previousSubjectCountRef.current;
+    previousSubjectCountRef.current = currentCount;
+
+    if (!didShrink || !map || shouldSubjectsBeClustered) return;
+
+    const rebuildLayers = () => [UNCLUSTERED_LAYER_ID, `${UNCLUSTERED_LAYER_ID}-labels`].forEach((layerId) => {
+      // Preserve the layer's current visibility (a user may have name labels turned off);
+      // a hidden layer has nothing stale to clear, so skip it.
+      if (map.getLayer(layerId) && map.getLayoutProperty(layerId, 'visibility') !== 'none') {
+        map.setLayoutProperty(layerId, 'visibility', 'none');
+        map.setLayoutProperty(layerId, 'visibility', 'visible');
+      }
+    });
+
+    const onSourceData = (event) => {
+      if (event.sourceId === UNCLUSTERED_SOURCE_ID && event.isSourceLoaded) {
+        map.off('sourcedata', onSourceData);
+        rebuildLayers();
+      }
+    };
+    map.on('sourcedata', onSourceData);
+    return () => map.off('sourcedata', onSourceData);
+  }, [map, mapSubjectFeatures, shouldSubjectsBeClustered]);
 
   const onSubjectSymbolClick = useMemo(() => withMultiLayerHandlerAwareness(
     map,

--- a/src/SubjectsLayer/index.test.js
+++ b/src/SubjectsLayer/index.test.js
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { featureCollection } from '@turf/turf';
+
+import SubjectsLayer from '.';
+import { createMapMock } from '../__test-helpers/mocks';
+import { mockStore } from '../__test-helpers/MockStore';
+import { MapContext } from '../MapContext';
+import { mockMapSubjectFeatureCollection } from '../__test-helpers/fixtures/subjects';
+
+import * as subjectSelectors from '../selectors/subjects';
+import * as clusterSelectors from '../selectors/clusters';
+
+const UNCLUSTERED_ICON_LAYER_ID = 'subject-symbol-layer-unclustered';
+const UNCLUSTERED_LABELS_LAYER_ID = 'subject-symbol-layer-unclustered-labels';
+const UNCLUSTERED_SOURCE_ID = 'subject-symbol-source';
+
+jest.mock('../utils/map', () => ({
+  ...jest.requireActual('../utils/map'),
+  addFeatureCollectionImagesToMap: jest.fn(),
+}));
+
+const store = {
+  view: {
+    showMapNames: {},
+    simplifyMapDataOnZoom: { enabled: false },
+  },
+};
+
+let getSubjectFeatureCollectionSpy, shouldClusterSpy, map;
+
+const renderSubjectsLayer = () => render(
+  <Provider store={mockStore(store)}>
+    <MapContext.Provider value={map}>
+      <SubjectsLayer mapImages={{}} onSubjectClick={jest.fn()} />
+    </MapContext.Provider>
+  </Provider>
+);
+
+describe('SubjectsLayer', () => {
+  beforeEach(() => {
+    map = createMapMock({
+      getLayer: jest.fn(() => ({})),
+      getSource: jest.fn(() => ({ setData: jest.fn() })),
+    });
+
+    getSubjectFeatureCollectionSpy = jest.spyOn(subjectSelectors, 'getMapSubjectFeatureCollectionWithVirtualPositioning');
+    shouldClusterSpy = jest.spyOn(clusterSelectors, 'selectShouldSubjectsBeClustered');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('when clustering is off and the unclustered subject feature set shrinks', () => {
+    beforeEach(() => {
+      shouldClusterSpy.mockReturnValue(false);
+
+      getSubjectFeatureCollectionSpy.mockReturnValue(mockMapSubjectFeatureCollection);
+      const { rerender } = renderSubjectsLayer();
+
+      getSubjectFeatureCollectionSpy.mockReturnValue(featureCollection([]));
+      rerender(
+        <Provider store={mockStore(store)}>
+          <MapContext.Provider value={map}>
+            <SubjectsLayer mapImages={{}} onSubjectClick={jest.fn()} />
+          </MapContext.Provider>
+        </Provider>
+      );
+    });
+
+    test('toggles the unclustered icon layer visibility off then on once the source finishes reloading', () => {
+      map.setLayoutProperty.mockClear();
+
+      map.__test__.fireHandlers('sourcedata', { sourceId: UNCLUSTERED_SOURCE_ID, isSourceLoaded: true });
+
+      const iconCalls = map.setLayoutProperty.mock.calls
+        .filter(([layerId, property]) => layerId === UNCLUSTERED_ICON_LAYER_ID && property === 'visibility')
+        .map(([, , value]) => value);
+
+      expect(iconCalls).toEqual(['none', 'visible']);
+    });
+
+    test('toggles the unclustered labels layer visibility off then on as well', () => {
+      map.setLayoutProperty.mockClear();
+
+      map.__test__.fireHandlers('sourcedata', { sourceId: UNCLUSTERED_SOURCE_ID, isSourceLoaded: true });
+
+      const labelCalls = map.setLayoutProperty.mock.calls
+        .filter(([layerId, property]) => layerId === UNCLUSTERED_LABELS_LAYER_ID && property === 'visibility')
+        .map(([, , value]) => value);
+
+      expect(labelCalls).toEqual(['none', 'visible']);
+    });
+
+    test('does not toggle visibility until the source reports it has finished loading', () => {
+      map.setLayoutProperty.mockClear();
+
+      map.__test__.fireHandlers('sourcedata', { sourceId: UNCLUSTERED_SOURCE_ID, isSourceLoaded: false });
+
+      expect(map.setLayoutProperty).not.toHaveBeenCalled();
+    });
+
+    test('does not toggle visibility for an unrelated source', () => {
+      map.setLayoutProperty.mockClear();
+
+      map.__test__.fireHandlers('sourcedata', { sourceId: 'some-other-source', isSourceLoaded: true });
+
+      expect(map.setLayoutProperty).not.toHaveBeenCalled();
+    });
+
+    test('leaves a layer untouched when its visibility is already none', () => {
+      map.getLayoutProperty.mockImplementation((layerId, property) => {
+        if (property !== 'visibility') return undefined;
+        return layerId === UNCLUSTERED_LABELS_LAYER_ID ? 'none' : 'visible';
+      });
+      map.setLayoutProperty.mockClear();
+
+      map.__test__.fireHandlers('sourcedata', { sourceId: UNCLUSTERED_SOURCE_ID, isSourceLoaded: true });
+
+      const touchedLayers = map.setLayoutProperty.mock.calls.map(([layerId]) => layerId);
+      expect(touchedLayers).not.toContain(UNCLUSTERED_LABELS_LAYER_ID);
+      expect(touchedLayers).toContain(UNCLUSTERED_ICON_LAYER_ID);
+    });
+  });
+
+  test('does not toggle visibility when clustering is on, even though the feature set shrinks', () => {
+    shouldClusterSpy.mockReturnValue(true);
+
+    getSubjectFeatureCollectionSpy.mockReturnValue(mockMapSubjectFeatureCollection);
+    const { rerender } = renderSubjectsLayer();
+
+    getSubjectFeatureCollectionSpy.mockReturnValue(featureCollection([]));
+    rerender(
+      <Provider store={mockStore(store)}>
+        <MapContext.Provider value={map}>
+          <SubjectsLayer mapImages={{}} onSubjectClick={jest.fn()} />
+        </MapContext.Provider>
+      </Provider>
+    );
+
+    map.setLayoutProperty.mockClear();
+
+    map.__test__.fireHandlers('sourcedata', { sourceId: UNCLUSTERED_SOURCE_ID, isSourceLoaded: true });
+
+    expect(map.setLayoutProperty).not.toHaveBeenCalled();
+  });
+
+  test('does not toggle visibility when the feature set does not shrink', () => {
+    shouldClusterSpy.mockReturnValue(false);
+
+    getSubjectFeatureCollectionSpy.mockReturnValue(mockMapSubjectFeatureCollection);
+    const { rerender } = renderSubjectsLayer();
+
+    // re-render with the same number of features (no shrink)
+    getSubjectFeatureCollectionSpy.mockReturnValue({ ...mockMapSubjectFeatureCollection });
+    rerender(
+      <Provider store={mockStore(store)}>
+        <MapContext.Provider value={map}>
+          <SubjectsLayer mapImages={{}} onSubjectClick={jest.fn()} />
+        </MapContext.Provider>
+      </Provider>
+    );
+
+    map.setLayoutProperty.mockClear();
+
+    map.__test__.fireHandlers('sourcedata', { sourceId: UNCLUSTERED_SOURCE_ID, isSourceLoaded: true });
+
+    expect(map.setLayoutProperty).not.toHaveBeenCalled();
+  });
+});

--- a/src/__test-helpers/mocks.js
+++ b/src/__test-helpers/mocks.js
@@ -54,6 +54,15 @@ export const createMapMock = (override = {}) => {
     }),
     setLayerZoomRange: jest.fn(),
     getLayer: jest.fn(),
+    getLayoutProperty: jest.fn(function (layerId, property) {
+      // Mapbox GL throws for layers that don't exist; mirror that so tests can't pass
+      // where production would crash calling getLayoutProperty on a missing layer.
+      if (!this.getLayer(layerId)) {
+        throw new Error(`The layer '${layerId}' does not exist in the map's style and cannot be queried for layout properties.`);
+      }
+      return property === 'visibility' ? 'visible' : undefined;
+    }),
+    isSourceLoaded: jest.fn(() => true),
     getZoom: jest.fn(() => 12.333),
     addImage: jest.fn(),
     loadImage: jest.fn(),

--- a/src/__test-helpers/mocks.js
+++ b/src/__test-helpers/mocks.js
@@ -55,8 +55,6 @@ export const createMapMock = (override = {}) => {
     setLayerZoomRange: jest.fn(),
     getLayer: jest.fn(),
     getLayoutProperty: jest.fn(function (layerId, property) {
-      // Mapbox GL throws for layers that don't exist; mirror that so tests can't pass
-      // where production would crash calling getLayoutProperty on a missing layer.
       if (!this.getLayer(layerId)) {
         throw new Error(`The layer '${layerId}' does not exist in the map's style and cannot be queried for layout properties.`);
       }


### PR DESCRIPTION
## Summary

Fixes [ERA-13529](https://allenai.atlassian.net/browse/ERA-13529): when subject clustering is **off**, clearing subjects from the map (**Clear All** or clearing a subject group) left the icons on screen until the user panned.

## Root cause

`setData` empties the `subject-symbol-source` GeoJSON source immediately (verified: `features: 0`), but Mapbox does **not** rebuild a symbol layer's rendered bucket when its source data shrinks unless the layer is forced to re-lay-out. `triggerRepaint()`, `_update(true)`, and `fadeDuration: 0` all leave the stale bucket drawn — only a camera change (pan/zoom) or a layer mutation rebuilds it. That's why panning made the icons disappear.

## Fix

In `SubjectsLayer`, when the unclustered subject set shrinks, wait for the source to finish reloading (its `sourcedata` / `isSourceLoaded` event) and toggle the unclustered subject layers' `visibility` off→on to force the rebuild — **without moving the camera** and without waiting on global `idle`. The layer's existing visibility is preserved, so a user's name-labels-off setting is respected. Clustered subjects render as DOM markers and update immediately, so this only applies when clustering is off.

## Tests

- New `src/SubjectsLayer/index.test.js` (7 tests). The regression test asserts the visibility toggle fires only after the source reloads; it was confirmed to **fail without the fix**. Guard tests cover: clustering on, no shrink, wrong source id, source not yet loaded, and an already-hidden layer being skipped.
- Added `getLayoutProperty` / `isSourceLoaded` defaults to `createMapMock`.
- `yarn test src/SubjectsLayer`: 7/7 pass. Lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ERA-13529]: https://allenai.atlassian.net/browse/ERA-13529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ