### PR TITLE
ERA-13534: Update subject historical details table with real-time observations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ public/config.js
 .env.development.local
 .env.test.local
 .env.production.local
+.claude/settings.local.json
 
 .idea
 

--- a/src/SubjectHistoricalDataModal/index.js
+++ b/src/SubjectHistoricalDataModal/index.js
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useId, useState } from 'react';
+import React, { memo, useEffect, useId, useRef, useState } from 'react';
 import flatten from 'lodash/flatten';
 import Modal from 'react-bootstrap/Modal';
 import startCase from 'lodash/startCase';
@@ -9,6 +9,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 import { fetchObservationsForSubject } from '../ducks/observations';
+import { getDeviceStatusPropertiesForSubject } from '../utils/subjects';
 import { selectCoordinatesRepresentation } from '../selectors/location';
 import useStringifyCoordinates from '../hooks/useStringifyCoordinates';
 
@@ -26,6 +27,21 @@ export const getObservationUniqProperties = (observations) => {
   const observationsDeviceProperties = observations.map((result) => result?.device_status_properties ?? []);
   const uniqPropertiesByLabel = unionBy(flatten(observationsDeviceProperties), 'label');
   return uniqPropertiesByLabel.map((property) => property.label);
+};
+
+const buildObservationFromSubject = (subject) => {
+  const recordedAt = subject.last_position?.properties?.coordinateProperties?.time ?? subject.last_position_date;
+  const coordinates = subject.last_position?.geometry?.coordinates;
+  const deviceStatusProperties = getDeviceStatusPropertiesForSubject(subject);
+
+  return {
+    id: recordedAt,
+    recorded_at: recordedAt,
+    location: coordinates ? { longitude: coordinates[0], latitude: coordinates[1] } : null,
+    device_status_properties: Array.isArray(deviceStatusProperties)
+      ? deviceStatusProperties
+      : Object.values(deviceStatusProperties ?? {}),
+  };
 };
 
 const getPageItemNumbers = (pagesCount, activePage) => {
@@ -107,6 +123,11 @@ const SubjectHistoricalDataModal = ({ subjectId, subjectIsStatic, title }) => {
   const [observationProperties, setObservationProperties] = useState([]);
   const [subjectObservations, setSubjectObservations] = useState([]);
 
+  const subject = useSelector((state) => state.data?.subjectStore?.[subjectId]);
+  const subjectLastPositionDate = subject?.last_position_date;
+
+  const lastProcessedPositionDate = useRef(subjectLastPositionDate);
+
   useEffect(() => {
     setLoadState(true);
 
@@ -123,6 +144,33 @@ const SubjectHistoricalDataModal = ({ subjectId, subjectIsStatic, title }) => {
       setObservationProperties(getObservationUniqProperties(data.results));
     });
   }, [activePage, dispatch, subjectId]);
+
+  useEffect(() => {
+    if (lastProcessedPositionDate.current === subjectLastPositionDate) {
+      return;
+    }
+    lastProcessedPositionDate.current = subjectLastPositionDate;
+
+    if (activePage !== 1 || !subject) {
+      return;
+    }
+
+    const newObservation = buildObservationFromSubject(subject);
+    const newTime = new Date(newObservation.recorded_at).getTime();
+    const existingIndex = subjectObservations.findIndex(
+      (observation) => new Date(observation.recorded_at).getTime() === newTime
+    );
+
+    if (existingIndex !== -1) {
+      setSubjectObservations((current) => current.map((observation, index) =>
+        index === existingIndex ? { ...newObservation, id: observation.id } : observation));
+      return;
+    }
+
+    setSubjectObservations((current) => [newObservation, ...current].slice(0, ITEMS_PER_PAGE));
+    setObservationsCount((count) => count + 1);
+    setObservationProperties((current) => current.length ? current : getObservationUniqProperties([newObservation]));
+  }, [subject, subjectLastPositionDate, activePage, subjectObservations]);
 
   const pagesCount = Math.ceil(observationsCount / ITEMS_PER_PAGE);
   const pageItemNumbers = getPageItemNumbers(pagesCount, activePage);

--- a/src/SubjectHistoricalDataModal/index.js
+++ b/src/SubjectHistoricalDataModal/index.js
@@ -117,13 +117,14 @@ const SubjectHistoricalDataModal = ({ subjectId, subjectIsStatic, title }) => {
   const dispatch = useDispatch();
   const { t } = useTranslation('subjects', { keyPrefix: 'subjectHistoricalDataModal' });
 
+  const subject = useSelector((state) => state.data?.subjectStore?.[subjectId]);
+
   const [activePage, setActivePage] = useState(1);
   const [loading, setLoadState] = useState(true);
   const [observationsCount, setObservationsCount] = useState(1);
   const [observationProperties, setObservationProperties] = useState([]);
   const [subjectObservations, setSubjectObservations] = useState([]);
 
-  const subject = useSelector((state) => state.data?.subjectStore?.[subjectId]);
   const subjectLastPositionDate = subject?.last_position_date;
 
   const lastProcessedPositionDate = useRef(subjectLastPositionDate);

--- a/src/SubjectHistoricalDataModal/index.js
+++ b/src/SubjectHistoricalDataModal/index.js
@@ -157,13 +157,15 @@ const SubjectHistoricalDataModal = ({ subjectId, subjectIsStatic, title }) => {
 
     const newObservation = buildObservationFromSubject(subject);
     const newTime = new Date(newObservation.recorded_at).getTime();
-    const existingIndex = subjectObservations.findIndex(
+    const isExisting = subjectObservations.some(
       (observation) => new Date(observation.recorded_at).getTime() === newTime
     );
 
-    if (existingIndex !== -1) {
-      setSubjectObservations((current) => current.map((observation, index) =>
-        index === existingIndex ? { ...newObservation, id: observation.id } : observation));
+    if (isExisting) {
+      setSubjectObservations((current) => current.map((observation) =>
+        new Date(observation.recorded_at).getTime() === newTime
+          ? { ...newObservation, id: observation.id }
+          : observation));
       return;
     }
 

--- a/src/SubjectHistoricalDataModal/index.test.js
+++ b/src/SubjectHistoricalDataModal/index.test.js
@@ -14,10 +14,7 @@ import { epsg5367 } from '../__test-helpers/fixtures/location';
 import SubjectHistoricalDataModal, { ITEMS_PER_PAGE, getObservationUniqProperties, SORT_BY } from './';
 
 // A store whose state can be mutated in place without swapping the store
-// instance. Swapping instances changes `dispatch`, which retriggers the
-// fetch effect and clobbers the realtime prepend - an artifact of the test
-// harness, not production. Mutating in place keeps `dispatch` stable and
-// notifies subscribers so `useSelector` re-reads.
+// instance. Keeps dispatch stable and useSelector re-reads.
 const mutableStore = (initialState) => {
   let state = initialState;
   const baseStore = mockStore(state);

--- a/src/SubjectHistoricalDataModal/index.test.js
+++ b/src/SubjectHistoricalDataModal/index.test.js
@@ -8,10 +8,29 @@ import { fetchObservationsForSubject } from '../ducks/observations';
 import { mockStore } from '../__test-helpers/MockStore';
 import { GPS_FORMATS } from '../utils/location';
 import mockedObservationsData from '../__test-helpers/fixtures/observations';
-import { render, waitFor, screen } from '../test-utils';
+import { render, waitFor, screen, act } from '../test-utils';
 import { epsg5367 } from '../__test-helpers/fixtures/location';
 
 import SubjectHistoricalDataModal, { ITEMS_PER_PAGE, getObservationUniqProperties, SORT_BY } from './';
+
+// A store whose state can be mutated in place without swapping the store
+// instance. Swapping instances changes `dispatch`, which retriggers the
+// fetch effect and clobbers the realtime prepend - an artifact of the test
+// harness, not production. Mutating in place keeps `dispatch` stable and
+// notifies subscribers so `useSelector` re-reads.
+const mutableStore = (initialState) => {
+  let state = initialState;
+  const baseStore = mockStore(state);
+
+  return {
+    ...baseStore,
+    getState: () => state,
+    setState: (nextState) => {
+      state = nextState;
+      baseStore.dispatch({ type: 'TEST_STATE_UPDATE' });
+    },
+  };
+};
 
 jest.mock('../ducks/observations', () => ({
   ...jest.requireActual('../ducks/observations'),
@@ -28,7 +47,20 @@ describe('SubjectHistoricalDataModal', () => {
     fetchObservationsForSubject.mockImplementation(fetchObservationsForSubjectMock);
 
     store = {
-      data: {},
+      data: {
+        subjectStore: {
+          'fake-id': {
+            last_position_date: '2026-06-30T00:00:00.000Z',
+            last_position: {
+              geometry: { coordinates: [-103.572941, 20.701133] },
+              properties: { coordinateProperties: { time: '2026-06-30T00:00:00.000Z' } },
+            },
+            device_status_properties: [
+              { label: 'speed', units: 'km', value: 42 },
+            ],
+          },
+        },
+      },
       view: {
         coordinateReferenceSystems: {
           storedSystems: [],
@@ -156,6 +188,383 @@ describe('SubjectHistoricalDataModal', () => {
         subject_id: 'fake-id',
         sort_by: SORT_BY,
       });
+    });
+  });
+
+  describe('realtime prepend', () => {
+    const updatedSubjectStore = (lastPositionDate, deviceValue, time = lastPositionDate) => ({
+      'fake-id': {
+        last_position_date: lastPositionDate,
+        last_position: {
+          geometry: { coordinates: [-103.572941, 20.701133] },
+          properties: { coordinateProperties: { time } },
+        },
+        device_status_properties: [
+          { label: 'speed', units: 'km', value: deviceValue },
+        ],
+      },
+    });
+
+    test('prepends a new observation row when last_position_date changes while on page 1', async () => {
+      const dynamicStore = mutableStore(store);
+
+      render(<Provider store={dynamicStore}>
+        <SubjectHistoricalDataModal title='Historical data' subjectId='fake-id' fetchObservationsForSubject/>
+      </Provider>);
+
+      await waitFor(() => {
+        const bodyRows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(bodyRows.length).toBe(ITEMS_PER_PAGE);
+      });
+
+      expect(screen.queryByText('777 km')).not.toBeInTheDocument();
+
+      act(() => {
+        dynamicStore.setState({
+          ...store,
+          data: {
+            ...store.data,
+            subjectStore: updatedSubjectStore('2026-06-30T01:00:00.000Z', 777),
+          },
+        });
+      });
+
+      // The new observation is prepended to the top of the page. The page is
+      // capped at ITEMS_PER_PAGE rows, so the row count stays put while the
+      // bottom row is dropped; the new row appears first.
+      await waitFor(() => {
+        const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(rows.length).toBe(ITEMS_PER_PAGE);
+        expect(within(rows[0]).getByText('777 km')).toBeInTheDocument();
+      });
+    });
+
+    test('updates the existing row in place without bumping the count when the observation instant matches', async () => {
+      fetchObservationsForSubjectMock = jest.fn(() => () => Promise.resolve({
+        count: 0,
+        results: [],
+      }));
+      fetchObservationsForSubject.mockImplementation(fetchObservationsForSubjectMock);
+
+      const dynamicStore = mutableStore(store);
+
+      render(<Provider store={dynamicStore}>
+        <SubjectHistoricalDataModal title='Historical data' subjectId='fake-id' fetchObservationsForSubject/>
+      </Provider>);
+
+      await waitFor(() => {
+        const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(rows.length).toBe(0);
+      });
+
+      // First update prepends a row recorded at the observation instant.
+      act(() => {
+        dynamicStore.setState({
+          ...store,
+          data: {
+            ...store.data,
+            subjectStore: updatedSubjectStore('2026-06-30T01:00:00.000Z', 777),
+          },
+        });
+      });
+
+      await waitFor(() => {
+        const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(rows.length).toBe(1);
+        expect(within(rows[0]).getByText('777 km')).toBeInTheDocument();
+      });
+
+      // Second update has a new last_position_date (so the effect runs) but the
+      // same observation instant, so it matches the existing row. The row's
+      // values are updated in place, the count is not bumped, and no duplicate
+      // row is added.
+      act(() => {
+        dynamicStore.setState({
+          ...store,
+          data: {
+            ...store.data,
+            subjectStore: updatedSubjectStore('2026-06-30T02:00:00.000Z', 999, '2026-06-30T01:00:00.000Z'),
+          },
+        });
+      });
+
+      await waitFor(() => {
+        const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(rows.length).toBe(1);
+        expect(within(rows[0]).getByText('999 km')).toBeInTheDocument();
+      });
+
+      const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+      expect(rows.length).toBe(1);
+      expect(screen.queryByText('777 km')).not.toBeInTheDocument();
+      // Count was not bumped, so it stays at 1 and no pagination control renders.
+      expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+
+    test('a re-delivered fetched observation replaces in place and leaves the count unchanged', async () => {
+      // API row carries a UUID id distinct from its recorded_at; the socket
+      // update arrives with the same instant in a different string format/offset.
+      const fetchedRecordedAt = '2022-02-22T07:22:05-08:00';
+      const socketTime = new Date(fetchedRecordedAt).toISOString();
+      fetchObservationsForSubjectMock = jest.fn(() => () => Promise.resolve({
+        count: 1,
+        results: [{
+          id: 'fetched-uuid-0001',
+          recorded_at: fetchedRecordedAt,
+          location: { latitude: '20.701133', longitude: '-103.572941' },
+          device_status_properties: [{ label: 'speed', units: 'km', value: 42 }],
+        }],
+      }));
+      fetchObservationsForSubject.mockImplementation(fetchObservationsForSubjectMock);
+
+      const dynamicStore = mutableStore(store);
+
+      render(<Provider store={dynamicStore}>
+        <SubjectHistoricalDataModal title='Historical data' subjectId='fake-id' fetchObservationsForSubject/>
+      </Provider>);
+
+      await waitFor(() => {
+        const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(rows.length).toBe(1);
+        expect(within(rows[0]).getByText('42 km')).toBeInTheDocument();
+      });
+
+      act(() => {
+        dynamicStore.setState({
+          ...store,
+          data: {
+            ...store.data,
+            subjectStore: updatedSubjectStore('2026-06-30T01:00:00.000Z', 999, socketTime),
+          },
+        });
+      });
+
+      await waitFor(() => {
+        const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(rows.length).toBe(1);
+        expect(within(rows[0]).getByText('999 km')).toBeInTheDocument();
+      });
+
+      // The fetched row's values are replaced in place: no duplicate row, the
+      // stale value is gone, and the count is not bumped (no extra page).
+      const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+      expect(rows.length).toBe(1);
+      expect(screen.queryByText('42 km')).not.toBeInTheDocument();
+      expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+
+    test('a position-only update with object-shaped device_status_properties does not crash and derives columns', async () => {
+      fetchObservationsForSubjectMock = jest.fn(() => () => Promise.resolve({
+        count: 0,
+        results: [],
+      }));
+      fetchObservationsForSubject.mockImplementation(fetchObservationsForSubjectMock);
+
+      const dynamicStore = mutableStore(store);
+
+      render(<Provider store={dynamicStore}>
+        <SubjectHistoricalDataModal title='Historical data' subjectId='fake-id' fetchObservationsForSubject/>
+      </Provider>);
+
+      await waitFor(() => {
+        const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(rows.length).toBe(0);
+      });
+
+      // Simulates the post-reducer state where a position-only socket frame
+      // leaves device_status_properties as a numeric-keyed object instead of an
+      // array.
+      act(() => {
+        dynamicStore.setState({
+          ...store,
+          data: {
+            ...store.data,
+            subjectStore: {
+              'fake-id': {
+                last_position_date: '2026-06-30T01:00:00.000Z',
+                last_position: {
+                  geometry: { coordinates: [-103.572941, 20.701133] },
+                  properties: { coordinateProperties: { time: '2026-06-30T01:00:00.000Z' } },
+                },
+                device_status_properties: {
+                  0: { label: 'speed', units: 'km', value: 777 },
+                  1: { label: 'temperature', units: 'c', value: 12 },
+                },
+              },
+            },
+          },
+        });
+      });
+
+      await waitFor(() => {
+        const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(rows.length).toBe(1);
+        expect(within(rows[0]).getByText('777 km')).toBeInTheDocument();
+        expect(within(rows[0]).getByText('12 c')).toBeInTheDocument();
+      });
+
+      // Columns are derived from the coerced array (real labels, not [undefined]).
+      const headers = within(screen.getByRole('table')).getAllByRole('columnheader');
+      expect(headers.some((header) => header.textContent === 'Speed')).toBe(true);
+      expect(headers.some((header) => header.textContent === 'Temperature')).toBe(true);
+    });
+
+    test('a position-only update with no last_position builds a null location and does not crash', async () => {
+      fetchObservationsForSubjectMock = jest.fn(() => () => Promise.resolve({
+        count: 0,
+        results: [],
+      }));
+      fetchObservationsForSubject.mockImplementation(fetchObservationsForSubjectMock);
+
+      const dynamicStore = mutableStore(store);
+
+      render(<Provider store={dynamicStore}>
+        <SubjectHistoricalDataModal title='Historical data' subjectId='fake-id' fetchObservationsForSubject/>
+      </Provider>);
+
+      await waitFor(() => {
+        const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(rows.length).toBe(0);
+      });
+
+      act(() => {
+        dynamicStore.setState({
+          ...store,
+          data: {
+            ...store.data,
+            subjectStore: {
+              'fake-id': {
+                last_position_date: '2026-06-30T01:00:00.000Z',
+                device_status_properties: [{ label: 'speed', units: 'km', value: 777 }],
+              },
+            },
+          },
+        });
+      });
+
+      await waitFor(() => {
+        const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(rows.length).toBe(1);
+        expect(within(rows[0]).getByText('777 km')).toBeInTheDocument();
+      });
+
+      // No location cell is rendered for the location-less row (date + speed).
+      const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+      expect(within(rows[0]).getAllByRole('cell')).toHaveLength(2);
+    });
+
+    test('a static subject renders no location column', async () => {
+      fetchObservationsForSubjectMock = jest.fn(() => () => Promise.resolve({
+        count: 0,
+        results: [],
+      }));
+      fetchObservationsForSubject.mockImplementation(fetchObservationsForSubjectMock);
+
+      const dynamicStore = mutableStore(store);
+
+      render(<Provider store={dynamicStore}>
+        <SubjectHistoricalDataModal title='Historical data' subjectId='fake-id' subjectIsStatic fetchObservationsForSubject/>
+      </Provider>);
+
+      act(() => {
+        dynamicStore.setState({
+          ...store,
+          data: {
+            ...store.data,
+            subjectStore: updatedSubjectStore('2026-06-30T01:00:00.000Z', 777),
+          },
+        });
+      });
+
+      await waitFor(() => {
+        const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(rows.length).toBe(1);
+        expect(within(rows[0]).getByText('777 km')).toBeInTheDocument();
+      });
+
+      const headers = within(screen.getByRole('table')).getAllByRole('columnheader');
+      expect(headers.some((header) => header.textContent === 'Location')).toBe(false);
+    });
+
+    test('does not prepend a new observation row when last_position_date changes while on page > 1', async () => {
+      const dynamicStore = mutableStore(store);
+      let paginationListItems, pageLink;
+
+      render(<Provider store={dynamicStore}>
+        <SubjectHistoricalDataModal title='Historical data' subjectId='fake-id' fetchObservationsForSubject/>
+      </Provider>);
+
+      await waitFor(() => {
+        paginationListItems = screen.getAllByRole('listitem');
+        pageLink = within(paginationListItems[3]).getByRole('button');
+      });
+
+      expect(pageLink).toHaveTextContent('2');
+      await userEvent.click(pageLink);
+
+      let bodyRows;
+      await waitFor(() => {
+        bodyRows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(bodyRows.length).toBe(ITEMS_PER_PAGE);
+      });
+      const rowCountBeforeUpdate = bodyRows.length;
+
+      act(() => {
+        dynamicStore.setState({
+          ...store,
+          data: {
+            ...store.data,
+            subjectStore: updatedSubjectStore('2026-06-30T01:00:00.000Z', 777),
+          },
+        });
+      });
+
+      // Give any erroneous effect a chance to fire before asserting no prepend.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      const rowsAfterUpdate = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+      expect(rowsAfterUpdate.length).toBe(rowCountBeforeUpdate);
+      expect(screen.queryByText('777 km')).not.toBeInTheDocument();
+    });
+
+    test('uses the update device properties for columns when the table is empty', async () => {
+      fetchObservationsForSubjectMock = jest.fn(() => () => Promise.resolve({
+        count: 0,
+        results: [],
+      }));
+      fetchObservationsForSubject.mockImplementation(fetchObservationsForSubjectMock);
+
+      const dynamicStore = mutableStore(store);
+
+      render(<Provider store={dynamicStore}>
+        <SubjectHistoricalDataModal title='Historical data' subjectId='fake-id' fetchObservationsForSubject/>
+      </Provider>);
+
+      await waitFor(() => {
+        const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(rows.length).toBe(0);
+      });
+
+      act(() => {
+        dynamicStore.setState({
+          ...store,
+          data: {
+            ...store.data,
+            subjectStore: updatedSubjectStore('2026-06-30T01:00:00.000Z', 777),
+          },
+        });
+      });
+
+      await waitFor(() => {
+        const rows = within(screen.getByRole('table')).getAllByRole('row').slice(1);
+        expect(rows.length).toBe(1);
+        expect(within(rows[0]).getByText('777 km')).toBeInTheDocument();
+      });
+
+      const headers = within(screen.getByRole('table')).getAllByRole('columnheader');
+      expect(headers.some((header) => header.textContent === 'Speed')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

The subject historical details table (`SubjectHistoricalDataModal`, opened from the history button in the map subject popup) fetched observations once on open and never reacted to WebSocket updates. New observations only appeared after closing/reopening the modal or paginating.

This subscribes to the subject's `last_position_date` in the store (updated by `SOCKET_SUBJECT_STATUS`) and, on page 1, **prepends** the new observation — or **replaces** an existing row matched by `recorded_at` instant — built from the subject store entry. No refetch, no loading flicker.

## Changes

- **Realtime updates:** new effect prepends/replaces observation rows on page 1 when `subjectStore[subjectId].last_position_date` changes.
- **Crash fix:** coerce `device_status_properties` to an array in `buildObservationFromSubject` — a position-only socket frame can leave the value object-shaped (`{0:…,1:…}`), which previously threw `TypeError: .find is not a function` in `ObservationRow`.
- **Dedupe/count fix:** match observations by parsed `recorded_at` instant (handles API `…-08:00` vs socket `…Z` formats) instead of a synthesized id, so re-delivered observations replace in place rather than duplicating and inflating the pagination count.
- Ignore `.claude/settings.local.json` (contains local credentials).

## Testing

`yarn jest src/SubjectHistoricalDataModal` → **15/15 pass**. New coverage: page-1 prepend, instant-based replace-in-place (no count bump), re-delivered fetched row, object-shaped device props (crash regression), null `last_position`, and static sensors.

## Notes

- Scoped to `SubjectHistoricalDataModal`; `getDeviceStatusPropertiesForSubject` and the subjects reducer were intentionally left untouched.
- The lone `react-hooks/set-state-in-effect` lint is a repo-wide migration artifact (also on the pre-existing fetch effect), left unsuppressed for symmetry.

Jira: [ERA-13534](https://allenai.atlassian.net/browse/ERA-13534)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ERA-13534]: https://allenai.atlassian.net/browse/ERA-13534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ