### PR TITLE
fix: isolate per-analyzer failures so one bad analyzer can't empty the Analyzers list (ERA-13536)

### DIFF
--- a/src/ducks/analyzers.js
+++ b/src/ducks/analyzers.js
@@ -20,41 +20,48 @@ export const fetchAnalyzers = () => async (dispatch) => {
   const { data: { data } } = await axios.get(ANALYZERS_API_URL, { params: { active: true } });
 
   const analyzers = await Promise.all(data.map(async (analyzer) => {
-    const spatialEntries = Object.entries(analyzer.spatial_groups);
-    const nonNullLinks = spatialEntries.filter(entry => entry[1] !== null);
-    const fetchedFeatures = await Promise.all(nonNullLinks.map(async (link) => {
-      const { data: result } = await axios.get(link[1]);
-      const concatFeatures = [];
-      result.data.features.forEach((analyzerFeature) => {
-        const feature = analyzerFeature.features[0];
-        feature.id = featureLayerIdentifier++;
-        if (analyzer.analyzer_category === 'proximity') {
+    // isolate per-analyzer processing so one bad analyzer can't reject the
+    // whole Promise.all and wipe out the entire analyzer list
+    try {
+      const spatialEntries = Object.entries(analyzer.spatial_groups);
+      const nonNullLinks = spatialEntries.filter(entry => entry[1] !== null);
+      const fetchedFeatures = await Promise.all(nonNullLinks.map(async (link) => {
+        const { data: result } = await axios.get(link[1]);
+        const concatFeatures = [];
+        result.data.features.forEach((analyzerFeature) => {
+          const feature = analyzerFeature.features[0];
+          feature.id = featureLayerIdentifier++;
+          if (analyzer.analyzer_category === 'proximity') {
 
-          const proximityPoly = buffer(
-            feature,
-            (analyzer?.threshold_dist_meters ?? DEFAULT_PROXIMITY_ANALYZER_DISPLAY_RADIUS) / 1000,
-            {
-              steps: 32,
-              units: 'kilometers',
-            }
-          );
-          feature.geometry = proximityPoly.geometry;
-        }
-        feature.properties.admin_href = analyzer.admin_href;
-        feature.properties.title = analyzer.name;
-        feature.properties.analyzer_type = analyzer.analyzer_category;
-        feature.properties.spatial_group = feature.geometry.type + '.' + link[0];
-        feature.properties.id = feature.properties.pk;
-        concatFeatures.push(feature);
-      });
-      return concatFeatures;
-    }));
-    // flatten the feature array -
-    const features = [].concat(...fetchedFeatures);
-    return { id: analyzer.id, name: analyzer.name, type: analyzer.analyzer_category, geojson: featureCollection(features) };
+            const proximityPoly = buffer(
+              feature,
+              (analyzer?.threshold_dist_meters ?? DEFAULT_PROXIMITY_ANALYZER_DISPLAY_RADIUS) / 1000,
+              {
+                steps: 32,
+                units: 'kilometers',
+              }
+            );
+            feature.geometry = proximityPoly.geometry;
+          }
+          feature.properties.admin_href = analyzer.admin_href;
+          feature.properties.title = analyzer.name;
+          feature.properties.analyzer_type = analyzer.analyzer_category;
+          feature.properties.spatial_group = feature.geometry.type + '.' + link[0];
+          feature.properties.id = feature.properties.pk;
+          concatFeatures.push(feature);
+        });
+        return concatFeatures;
+      }));
+      // flatten the feature array -
+      const features = [].concat(...fetchedFeatures);
+      return { id: analyzer.id, name: analyzer.name, type: analyzer.analyzer_category, geojson: featureCollection(features) };
+    } catch (error) {
+      console.warn(`error processing analyzer "${analyzer.name}" (${analyzer.id})`, error);
+      return null;
+    }
   }));
 
-  const results = analyzers.filter(item => !!item.geojson.features.length);
+  const results = analyzers.filter(item => !!item && !!item.geojson.features.length);
 
   dispatch({
     type: FETCH_ANALYZERS_SUCCESS,

--- a/src/ducks/analyzers.test.js
+++ b/src/ducks/analyzers.test.js
@@ -1,0 +1,117 @@
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { fetchAnalyzers, FETCH_ANALYZERS_SUCCESS } from './analyzers';
+
+const GOOD_GEOFENCE_LINK = 'http://localhost/spatial-group/good-geofence';
+const BAD_PROXIMITY_LINK = 'http://localhost/spatial-group/bad-proximity';
+const GOOD_PROXIMITY_LINK = 'http://localhost/spatial-group/good-proximity';
+
+const makeSpatialFeature = (geometry) => ({
+  features: [{
+    type: 'Feature',
+    geometry,
+    properties: { pk: 'feature-pk' },
+  }],
+});
+
+const goodGeofenceAnalyzer = {
+  id: 'geofence-id',
+  name: 'Good Geofence',
+  analyzer_category: 'geofence',
+  admin_href: 'http://localhost/admin/geofence',
+  spatial_groups: { warning: GOOD_GEOFENCE_LINK },
+};
+
+// negative threshold over a line geometry: buffer() returns undefined, so
+// reading proximityPoly.geometry throws a TypeError for this analyzer only
+const badProximityAnalyzer = {
+  id: 'bad-proximity-id',
+  name: 'Tourist Road Proximity - Line',
+  analyzer_category: 'proximity',
+  admin_href: 'http://localhost/admin/bad-proximity',
+  threshold_dist_meters: -1.0,
+  spatial_groups: { warning: BAD_PROXIMITY_LINK },
+};
+
+const goodProximityAnalyzer = {
+  id: 'good-proximity-id',
+  name: 'Good Proximity',
+  analyzer_category: 'proximity',
+  admin_href: 'http://localhost/admin/good-proximity',
+  threshold_dist_meters: 500,
+  spatial_groups: { warning: GOOD_PROXIMITY_LINK },
+};
+
+const lineGeometry = {
+  type: 'LineString',
+  coordinates: [[0, 0], [1, 1]],
+};
+
+const pointGeometry = {
+  type: 'Point',
+  coordinates: [2, 2],
+};
+
+const polygonGeometry = {
+  type: 'Polygon',
+  coordinates: [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+};
+
+const server = setupServer(
+  http.get('*/analyzers/spatial', () => HttpResponse.json({
+    data: [goodGeofenceAnalyzer, badProximityAnalyzer, goodProximityAnalyzer],
+  })),
+  http.get(GOOD_GEOFENCE_LINK, () => HttpResponse.json({
+    data: { features: [makeSpatialFeature(polygonGeometry)] },
+  })),
+  http.get(BAD_PROXIMITY_LINK, () => HttpResponse.json({
+    data: { features: [makeSpatialFeature(lineGeometry)] },
+  })),
+  http.get(GOOD_PROXIMITY_LINK, () => HttpResponse.json({
+    data: { features: [makeSpatialFeature(pointGeometry)] },
+  })),
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('fetchAnalyzers', () => {
+  let consoleWarnSpy;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('a single failing analyzer does not prevent the others from being dispatched', async () => {
+    const dispatch = jest.fn();
+
+    await fetchAnalyzers()(dispatch);
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    const action = dispatch.mock.calls[0][0];
+    expect(action.type).toBe(FETCH_ANALYZERS_SUCCESS);
+
+    const dispatchedIds = action.payload.map(item => item.id);
+    expect(dispatchedIds).toEqual(expect.arrayContaining(['geofence-id', 'good-proximity-id']));
+    expect(dispatchedIds).not.toContain('bad-proximity-id');
+  });
+
+  test('logs a console.warn including the failed analyzer name and id', async () => {
+    const dispatch = jest.fn();
+
+    await fetchAnalyzers()(dispatch);
+
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    const warning = consoleWarnSpy.mock.calls[0][0];
+    expect(warning).toContain('Tourist Road Proximity - Line');
+    expect(warning).toContain('bad-proximity-id');
+    expect(consoleWarnSpy.mock.calls[0][1]).toBeInstanceOf(Error);
+  });
+});


### PR DESCRIPTION
## What

Fault-isolates per-analyzer processing in `fetchAnalyzers` so a single failing analyzer can no longer wipe out the entire Analyzers list.

Jira: [ERA-13536](https://allenai.atlassian.net/browse/ERA-13536)

## Why

`fetchAnalyzers` builds the analyzer list inside one `Promise.all(data.map(async (analyzer) => {...}))`. If processing **any one** analyzer throws, the whole `Promise.all` rejects, `FETCH_ANALYZERS_SUCCESS` is never dispatched, and the Analyzers sidebar list stays at its empty initial state — with no user-facing error.

This is happening on **wildlifeactdev.pamdas.org**: a proximity analyzer ("Tourist Road Proximity - Line") is configured with `threshold_dist_meters: -1.0` over a line geometry. The proximity branch buffers the feature by `threshold / 1000` km; negative-buffering a line returns `undefined` from turf, so `proximityPoly.geometry` throws a `TypeError` — and that single bad analyzer made *every* analyzer (KPR Geofence Analyzer included) disappear from the list.

## Change

- Wrap each analyzer's async processing in `try/catch`. On error, `console.warn` (name + id + error) and return `null` instead of rejecting the shared `Promise.all`.
- Filter out the `null` (failed) analyzers before the existing empty-features check.
- Proximity buffer logic is intentionally **unchanged** — guarding invalid `threshold_dist_meters` is a tracked follow-up, as is backend/admin validation.

## Tests

Added `src/ducks/analyzers.test.js` (MSW + `setupServer`, matching the repo's duck-test pattern). It reproduces the real-world failure (a valid geofence, a valid proximity, and a negative-buffer line proximity) and asserts:
- the two valid analyzers are still dispatched and the failing one is excluded;
- exactly one `console.warn` fires naming the failed analyzer.

```
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ERA-13536]: https://allenai.atlassian.net/browse/ERA-13536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ