### PR TITLE
ci: upgrade GCP auth to v3 in legacy deploy workflow

### DIFF
--- a/.github/workflows/_deploy_legacy_kubectl.yml
+++ b/.github/workflows/_deploy_legacy_kubectl.yml
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: GCP Auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ inputs.service_account || vars.SERVICE_ACCOUNT }}


### PR DESCRIPTION
## Summary

Upgrades `google-github-actions/auth` from v2 to v3 in the local legacy deploy workflow, aligning it with the version already used in `develop.yml` and `pr-envs.yml`.

## Changes

### Fixed
- `_deploy_legacy_kubectl.yml`: `auth@v2` → `auth@v3`

## Files Changed

**1 file changed, 1 insertion(+), 1 deletion(-)**