### PR TITLE
ERA-13526: App crashes on save when attachment field with minItems is in a conditional section

### DIFF
--- a/src/ReportManager/DetailsSection/SchemaForm/utils/useSchemaValidations/index.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/utils/useSchemaValidations/index.js
@@ -40,8 +40,12 @@ const useSchemaValidations = (schema) => {
 
   const runValidations = useCallback((formData) => {
     if (!validate(formData)) {
+      // The "if" keyword only reports that an if/then combinator failed to match, but carries no field-level
+      // information of its own.
+      const fieldErrors = validate.errors.filter(({ keyword }) => keyword !== 'if');
+
       // If the validation returned errors we iterate them.
-      return validate.errors.reduce((accumulator, error) => {
+      return fieldErrors.reduce((accumulator, error) => {
         // First we calculate the error path, the field id and the message. The error path tells us if the erroneus
         // field is nested in a collection and in which of its items.
         const errorPath = error.instancePath.split('/').slice(1);

--- a/src/ReportManager/DetailsSection/SchemaForm/utils/useSchemaValidations/index.test.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/utils/useSchemaValidations/index.test.js
@@ -638,6 +638,59 @@ describe('ReportManager - DetailsSection - SchemaForm - Utils - useSchemaValidat
     }));
   });
 
+  it('returns only the inner field error for a failing if/then conditional', () => {
+    schema.json.properties.trigger = {
+      default: '',
+      deprecated: false,
+      description: '',
+      title: 'Trigger field',
+      type: 'string',
+    };
+    schema.json.properties.attachment_1 = {
+      default: '',
+      deprecated: false,
+      description: '',
+      title: 'Attachment field',
+      type: 'string',
+    };
+    schema.json.allOf = [
+      {
+        if: {
+          properties: { trigger: { const: 'yes' } },
+          required: ['trigger'],
+        },
+        then: { required: ['attachment_1'] },
+      },
+    ];
+    schema.ui.fields.trigger = {
+      inputType: 'SHORT_TEXT',
+      placeholder: '',
+      type: 'TEXT',
+      parent: 'section-_PdgePvPWyACfu9sgN_F6',
+    };
+    schema.ui.fields.attachment_1 = {
+      inputType: 'SHORT_TEXT',
+      placeholder: '',
+      type: 'TEXT',
+      parent: 'section-_PdgePvPWyACfu9sgN_F6',
+    };
+    schema.ui.sections['section-_PdgePvPWyACfu9sgN_F6'].leftColumn = [
+      { name: 'trigger', type: 'field' },
+      { name: 'attachment_1', type: 'field' },
+    ];
+    const formData = { trigger: 'yes' };
+
+    const { result } = renderHook(() => useSchemaValidations(schema), { wrapper: Wrapper });
+
+    const runValidations = result.current;
+
+    expect(runValidations(formData)).toEqual({
+      attachment_1: {
+        message: 'This is a required field.',
+      },
+    });
+  });
+
   it('injects nested errors in collection item forms', () => {
     schema.json.properties.collection_1 = {
       deprecated: false,


### PR DESCRIPTION
## What does this PR do?
Refine validation error handling in `useSchemaValidations`.

Updated the validation logic to filter out `'if'` keyword errors, ensuring that only relevant field-level errors are returned. Added a new test case to verify that the correct inner field error is returned for a failing if/then conditional in the schema.

## Evidence
The section that contains both attachment fields are conditional:
<img width="1920" height="988" alt="image" src="https://github.com/user-attachments/assets/3540675e-e7aa-448d-81d6-b8eadc25b63d" />


### Relevant link(s)
- [ERA-13526](https://allenai.atlassian.net/browse/ERA-13526)
- [Branch Environment](https://era-13526.dev.pamdas.org)

## Notes
Note that the bug wasn't related to Attachment fields as it was reported. Other validation errors inside conditional sections could have triggered the issue too. All are fixed now.

https://allenai.atlassian.net/browse/ERA-13508 is a related issue that should be fixed with the changes of this PR.


[ERA-13526]: https://allenai.atlassian.net/browse/ERA-13526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ