### PR TITLE
ERA-13417: Attachment Field Status UI

### DIFF
--- a/public/locales/en-US/reports.json
+++ b/public/locales/en-US/reports.json
@@ -183,6 +183,7 @@
             "maxItemsAlert_other": "You can only add up to {{count}} files.",
             "downloadButtonLabel": "Download {{fileName}}",
             "expandButtonLabel": "Expand {{fileName}}",
+            "pendingLabel": "Pending",
             "removeButtonLabel": "Remove {{fileName}}",
             "requiredLabel": "(required)",
             "uploadErrorLabel": "Upload failed",

--- a/public/locales/es/reports.json
+++ b/public/locales/es/reports.json
@@ -172,6 +172,7 @@
             "maxItemsAlert_other": "Solo puedes añadir hasta {{count}} archivos.",
             "downloadButtonLabel": "Descargar {{fileName}}",
             "expandButtonLabel": "Expandir {{fileName}}",
+            "pendingLabel": "Pendiente",
             "removeButtonLabel": "Eliminar {{fileName}}",
             "requiredLabel": "(obligatorio)",
             "uploadErrorLabel": "Error al subir",

--- a/public/locales/fr/reports.json
+++ b/public/locales/fr/reports.json
@@ -172,6 +172,7 @@
             "maxItemsAlert_other": "Vous ne pouvez ajouter que {{count}} fichiers au maximum.",
             "downloadButtonLabel": "Télécharger {{fileName}}",
             "expandButtonLabel": "Agrandir {{fileName}}",
+            "pendingLabel": "En attente",
             "removeButtonLabel": "Supprimer {{fileName}}",
             "requiredLabel": "(obligatoire)",
             "uploadErrorLabel": "Échec du téléversement",

--- a/public/locales/ne-NP/reports.json
+++ b/public/locales/ne-NP/reports.json
@@ -352,6 +352,7 @@
             "maxItemsAlert_other": "तपाईं बढीमा {{count}} फाइलहरू मात्र थप्न सक्नुहुन्छ।",
             "downloadButtonLabel": "{{fileName}} डाउनलोड गर्नुहोस्",
             "expandButtonLabel": "{{fileName}} विस्तार गर्नुहोस्",
+            "pendingLabel": "बाँकी",
             "removeButtonLabel": "{{fileName}} हटाउनुहोस्",
             "requiredLabel": "(आवश्यक)",
             "uploadErrorLabel": "अपलोड असफल भयो",

--- a/public/locales/pt/reports.json
+++ b/public/locales/pt/reports.json
@@ -172,6 +172,7 @@
             "maxItemsAlert_other": "Você só pode adicionar até {{count}} arquivos.",
             "downloadButtonLabel": "Baixar {{fileName}}",
             "expandButtonLabel": "Expandir {{fileName}}",
+            "pendingLabel": "Pendente",
             "removeButtonLabel": "Remover {{fileName}}",
             "requiredLabel": "(obrigatório)",
             "uploadErrorLabel": "Falha no envio",

--- a/public/locales/sw/reports.json
+++ b/public/locales/sw/reports.json
@@ -177,6 +177,7 @@
             "maxItemsAlert_other": "Unaweza kuongeza faili {{count}} pekee.",
             "downloadButtonLabel": "Pakua {{fileName}}",
             "expandButtonLabel": "Panua {{fileName}}",
+            "pendingLabel": "Inasubiri",
             "removeButtonLabel": "Ondoa {{fileName}}",
             "requiredLabel": "(inahitajika)",
             "uploadErrorLabel": "Upakiaji umeshindwa",

--- a/src/ReportManager/DetailsSection/SchemaForm/formElements/Attachment/index.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/formElements/Attachment/index.js
@@ -111,12 +111,14 @@ const AttachmentListItem = ({ actionButtonRefs, attachment, onRemove, readOnly }
   };
 
   let icon = <AttachmentIcon />;
-  if (attachment.status === 'pending' || attachment.status === 'uploading') {
+  if (attachment.status === 'in_progress') {
     icon = <span
-      className={`${styles.uploadProgress} ${attachment.status === 'pending' ? styles.pending : ''}`}
+      className={`${styles.uploadProgress} ${attachment.progress === null ? styles.indeterminate : ''}`}
       data-testid={`upload-progress-${attachment.uploadId}`}
-      style={{ '--upload-progress': `${Math.round(attachment.progress * 100)}%` }}
+      style={{ '--upload-progress': `${Math.round((attachment.progress ?? 0) * 100)}%` }}
     />;
+  } else if (attachment.status === 'unknown') {
+    icon = <CloudUploadIcon />;
   } else if (attachment.thumbnailImageSource) {
     icon = <img alt="" className={styles.thumbnail} src={attachment.thumbnailImageSource}/>;
   } else if (attachment.fileType === 'audio') {
@@ -126,7 +128,20 @@ const AttachmentListItem = ({ actionButtonRefs, attachment, onRemove, readOnly }
   }
 
   let actionButton = null;
-  if (attachment.status === 'saved') {
+  if (attachment.isLocalUpload) {
+    if (!readOnly) {
+      actionButton = <button
+          aria-label={t('removeButtonLabel', { fileName: attachment.name })}
+          className={styles.actionButton}
+          onClick={() => onRemove()}
+          ref={actionButtonRef}
+          title={t('removeButtonLabel', { fileName: attachment.name })}
+          type="button"
+        >
+        <TrashCanIcon aria-hidden="true" />
+      </button>;
+    }
+  } else if (attachment.status === 'complete') {
     if (attachment.fileType === 'image') {
       actionButton = <button
         aria-label={t('expandButtonLabel', { fileName: attachment.name })}
@@ -157,23 +172,14 @@ const AttachmentListItem = ({ actionButtonRefs, attachment, onRemove, readOnly }
         <DownloadArrowIcon aria-hidden="true" />
       </button>;
     }
-  } else if (!readOnly) {
-    actionButton = <button
-        aria-label={t('removeButtonLabel', { fileName: attachment.name })}
-        className={styles.actionButton}
-        onClick={() => onRemove()}
-        ref={actionButtonRef}
-        title={t('removeButtonLabel', { fileName: attachment.name })}
-        type="button"
-      >
-      <TrashCanIcon aria-hidden="true" />
-    </button>;
   }
 
   return <li className={styles.attachmentListItem}>
     <span aria-hidden="true" className={styles.icon}>{icon}</span>
 
     <span className={styles.name}>{attachment.name}</span>
+
+    {attachment.status === 'unknown' && <span className={styles.pendingLabel}>{t('pendingLabel')}</span>}
 
     {attachment.status === 'failed' && <span className={styles.error}>{t('uploadErrorLabel')}</span>}
 
@@ -216,11 +222,12 @@ const Attachment = ({ attachmentsMetadata, details, error, id, onFieldChange, re
 
     return {
       fileType: attachmentMetadata?.file_type ?? getFileCategoryFromMimeType(upload?.fileType ?? ''),
+      isLocalUpload: !!upload,
       name: attachmentMetadata?.filename?.split('/').pop() ?? upload?.filename,
       originalImageSource: attachmentImageSources.original ?? upload?.objectUrl,
       originalUrl: attachmentMetadata?.files?.original,
-      progress: upload?.progress,
-      status: upload?.status ?? 'saved',
+      progress: upload?.progress ?? null,
+      status: upload?.status ?? attachmentMetadata.status ?? 'complete',
       thumbnailImageSource: attachmentImageSources.thumbnail ?? upload?.objectUrl,
       uploadId: attachment?.uploadId,
     };
@@ -268,9 +275,17 @@ const Attachment = ({ attachmentsMetadata, details, error, id, onFieldChange, re
 
   const onClickRemove = (attachment) => {
     const attachmentIndex = attachments.indexOf(attachment);
-    const nextAttachment = attachments[attachmentIndex + 1] ?? attachments[attachmentIndex - 1];
-    nextFocusTargetRef.current = nextAttachment
-      ? actionButtonRefs.current.get(nextAttachment.uploadId)
+
+    // Focus the next attachment that has an action button.
+    const remainingAttachmentsFocusOrder = [
+      ...attachments.slice(attachmentIndex + 1),
+      ...attachments.slice(0, attachmentIndex).reverse(),
+    ];
+    const attachmentToFocus = remainingAttachmentsFocusOrder.find(
+      (attachment) => actionButtonRefs.current.has(attachment.uploadId)
+    );
+    nextFocusTargetRef.current = attachmentToFocus
+      ? actionButtonRefs.current.get(attachmentToFocus.uploadId)
       : chooseFileButtonRef.current;
 
     onFieldChange(id, [...value.slice(0, attachmentIndex), ...value.slice(attachmentIndex + 1)]);
@@ -318,7 +333,7 @@ const Attachment = ({ attachmentsMetadata, details, error, id, onFieldChange, re
     if (prevUploads !== null) {
       // Uploads changed. Announce status transitions.
       const newlyCompletedUploads = Object.values(uploads).filter(
-        (upload) => upload?.status === 'completed' && prevUploads[upload.uploadId]?.status !== 'completed'
+        (upload) => upload?.status === 'complete' && prevUploads[upload.uploadId]?.status !== 'complete'
       );
       const newlyFailedUploads = Object.values(uploads).filter(
         (upload) => upload?.status === 'failed' && prevUploads[upload.uploadId]?.status !== 'failed'

--- a/src/ReportManager/DetailsSection/SchemaForm/formElements/Attachment/index.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/formElements/Attachment/index.js
@@ -164,6 +164,7 @@ const AttachmentListItem = ({ actionButtonRefs, attachment, onRemove, readOnly }
       actionButton = <button
         aria-label={t('downloadButtonLabel', { fileName: attachment.name })}
         className={styles.actionButton}
+        disabled={!attachment.originalUrl}
         onClick={() => downloadFileFromUrl(attachment.originalUrl, { filename: attachment.name })}
         ref={actionButtonRef}
         title={t('downloadButtonLabel', { fileName: attachment.name })}

--- a/src/ReportManager/DetailsSection/SchemaForm/formElements/Attachment/index.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/formElements/Attachment/index.js
@@ -282,9 +282,11 @@ const Attachment = ({ attachmentsMetadata, details, error, id, onFieldChange, re
       ...attachments.slice(attachmentIndex + 1),
       ...attachments.slice(0, attachmentIndex).reverse(),
     ];
-    const attachmentToFocus = remainingAttachmentsFocusOrder.find(
-      (attachment) => actionButtonRefs.current.has(attachment.uploadId)
-    );
+    const attachmentToFocus = remainingAttachmentsFocusOrder.find((attachment) => {
+      const node = actionButtonRefs.current.get(attachment.uploadId);
+
+      return node && !node.disabled;
+    });
     nextFocusTargetRef.current = attachmentToFocus
       ? actionButtonRefs.current.get(attachmentToFocus.uploadId)
       : chooseFileButtonRef.current;

--- a/src/ReportManager/DetailsSection/SchemaForm/formElements/Attachment/index.test.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/formElements/Attachment/index.test.js
@@ -276,30 +276,45 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
     expect(screen.getByRole('status')).toHaveTextContent('Uploading test.pdf');
   });
 
-  test('shows the pending upload progress indicator when a file is being prepared', () => {
+  test('shows an indeterminate progress indicator when a file is being prepared', () => {
     const uploadStore = mockStore({
-      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', fileType: 'application/pdf', progress: 0, status: 'pending' } } },
+      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', fileType: 'application/pdf', progress: null, status: 'in_progress' } } },
     });
     renderAttachmentField({ value: [{ uploadId: 'test-upload-id' }] }, uploadStore);
 
     const progressIndicator = screen.getByTestId('upload-progress-test-upload-id');
 
     expect(progressIndicator).toBeInTheDocument();
-    expect(progressIndicator).toHaveClass('pending');
+    expect(progressIndicator).toHaveClass('indeterminate');
     expect(progressIndicator).toHaveStyle({ '--upload-progress': '0%' });
   });
 
-  test('shows the uploading progress indicator with its current progress', () => {
+  test('shows the in-progress upload progress indicator with its current progress', () => {
     const uploadStore = mockStore({
-      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', fileType: 'application/pdf', progress: 0.6, status: 'uploading' } } },
+      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', fileType: 'application/pdf', progress: 0.6, status: 'in_progress' } } },
     });
     renderAttachmentField({ value: [{ uploadId: 'test-upload-id' }] }, uploadStore);
 
     const progressIndicator = screen.getByTestId('upload-progress-test-upload-id');
 
     expect(progressIndicator).toBeInTheDocument();
-    expect(progressIndicator).not.toHaveClass('pending');
+    expect(progressIndicator).not.toHaveClass('indeterminate');
     expect(progressIndicator).toHaveStyle({ '--upload-progress': '60%' });
+  });
+
+  test('shows an indeterminate progress indicator for a remote in-progress upload', () => {
+    renderAttachmentField({
+      attachmentsMetadata: {
+        'saved-1': { filename: 'file1.pdf', file_type: 'document', status: 'in_progress' },
+      },
+      value: [{ uploadId: 'saved-1' }],
+    });
+
+    const progressIndicator = screen.getByTestId('upload-progress-saved-1');
+
+    expect(progressIndicator).toBeInTheDocument();
+    expect(progressIndicator).toHaveClass('indeterminate');
+    expect(progressIndicator).toHaveStyle({ '--upload-progress': '0%' });
   });
 
   test('shows a thumbnail image for a saved image attachment after fetching its data', async () => {
@@ -423,9 +438,9 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
     expect(screen.queryByRole('button', { name: 'Remove file1.pdf' })).not.toBeInTheDocument();
   });
 
-  test('shows the remove button for a pending upload', () => {
+  test('shows the remove button for an local in-progress upload', () => {
     const uploadStore = mockStore({
-      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', fileType: 'application/pdf', progress: 0, status: 'pending' } } },
+      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', fileType: 'application/pdf', progress: 0, status: 'in_progress' } } },
     });
     renderAttachmentField({ value: [{ uploadId: 'test-upload-id' }] }, uploadStore);
 
@@ -437,13 +452,41 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
     expect(removeButton).toHaveAttribute('title', 'Remove test.pdf');
   });
 
-  test('does not show the remove button for a pending upload in read-only mode', () => {
+  test('does not show the remove button for an local in-progress upload in read-only mode', () => {
     const uploadStore = mockStore({
-      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', fileType: 'application/pdf', progress: 0, status: 'pending' } } },
+      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', fileType: 'application/pdf', progress: 0, status: 'in_progress' } } },
     });
     renderAttachmentField({ readOnly: true, value: [{ uploadId: 'test-upload-id' }] }, uploadStore);
 
     expect(screen.queryByRole('button', { name: 'Remove test.pdf' })).not.toBeInTheDocument();
+  });
+
+  test('does not show an action button for a remote in-progress upload', () => {
+    renderAttachmentField({
+      attachmentsMetadata: {
+        'saved-1': { filename: 'file1.pdf', file_type: 'document', status: 'in_progress' },
+      },
+      value: [{ uploadId: 'saved-1' }],
+    });
+
+    expect(screen.queryByRole('button', { name: 'Remove file1.pdf' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Download file1.pdf' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Expand file1.pdf' })).not.toBeInTheDocument();
+  });
+
+  test('shows a pending label for a remote upload with unknown status and does not show an action button', () => {
+    renderAttachmentField({
+      attachmentsMetadata: {
+        'saved-1': { filename: 'file1.pdf', file_type: 'document', status: 'unknown' },
+      },
+      value: [{ uploadId: 'saved-1' }],
+    });
+
+    expect(screen.getByText('file1.pdf')).toBeVisible();
+    expect(screen.getByText('Pending')).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'Remove file1.pdf' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Download file1.pdf' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Expand file1.pdf' })).not.toBeInTheDocument();
   });
 
   test('shows the upload error text for a failed upload', () => {
@@ -541,7 +584,7 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
 
   test('dispatches removeFile when the remove button is clicked', async () => {
     const uploadStore = mockStore({
-      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', fileType: 'application/pdf', progress: 0, status: 'pending' } } },
+      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', fileType: 'application/pdf', progress: 0, status: 'in_progress' } } },
     });
     renderAttachmentField({ value: [{ uploadId: 'test-upload-id' }] }, uploadStore);
 
@@ -553,7 +596,7 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
 
   test('calls onFieldChange when the remove button is clicked', async () => {
     const uploadStore = mockStore({
-      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', fileType: 'application/pdf', progress: 0, status: 'pending' } } },
+      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', fileType: 'application/pdf', progress: 0, status: 'in_progress' } } },
     });
     renderAttachmentField({ value: [{ uploadId: 'test-upload-id' }] }, uploadStore);
 
@@ -564,12 +607,12 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
 
   test('announces completed uploads to screen readers', () => {
     const pendingStore = mockStore({
-      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', progress: 0, status: 'pending' } } },
+      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', progress: 0, status: 'in_progress' } } },
     });
     const { rerender } = renderAttachmentField({ value: [{ uploadId: 'test-upload-id' }] }, pendingStore);
 
     const completedStore = mockStore({
-      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', progress: 1, status: 'completed' } } },
+      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', progress: 1, status: 'complete' } } },
     });
     rerender(
       <Provider store={completedStore}>
@@ -590,7 +633,7 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
 
   test('announces failed uploads to screen readers', () => {
     const pendingStore = mockStore({
-      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', progress: 0, status: 'pending' } } },
+      data: { userContent: { 'test-upload-id': { uploadId: 'test-upload-id', filename: 'test.pdf', progress: 0, status: 'in_progress' } } },
     });
     const { rerender } = renderAttachmentField({ value: [{ uploadId: 'test-upload-id' }] }, pendingStore);
 
@@ -617,8 +660,8 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
   test('announces multiple completed uploads to screen readers', () => {
     const pendingStore = mockStore({
       data: { userContent: {
-        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', progress: 0, status: 'pending' },
-        'upload-2': { uploadId: 'upload-2', filename: 'file2.pdf', progress: 0, status: 'pending' },
+        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', progress: 0, status: 'in_progress' },
+        'upload-2': { uploadId: 'upload-2', filename: 'file2.pdf', progress: 0, status: 'in_progress' },
       } },
     });
     const { rerender } = renderAttachmentField({
@@ -627,8 +670,8 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
 
     const completedStore = mockStore({
       data: { userContent: {
-        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', progress: 1, status: 'completed' },
-        'upload-2': { uploadId: 'upload-2', filename: 'file2.pdf', progress: 1, status: 'completed' },
+        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', progress: 1, status: 'complete' },
+        'upload-2': { uploadId: 'upload-2', filename: 'file2.pdf', progress: 1, status: 'complete' },
       } },
     });
     rerender(
@@ -651,8 +694,8 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
   test('announces multiple failed uploads to screen readers', () => {
     const pendingStore = mockStore({
       data: { userContent: {
-        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', progress: 0, status: 'pending' },
-        'upload-2': { uploadId: 'upload-2', filename: 'file2.pdf', progress: 0, status: 'pending' },
+        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', progress: 0, status: 'in_progress' },
+        'upload-2': { uploadId: 'upload-2', filename: 'file2.pdf', progress: 0, status: 'in_progress' },
       } },
     });
     const { rerender } = renderAttachmentField({
@@ -685,8 +728,8 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
   test('announces both completed and failed uploads when they occur in the same update', () => {
     const pendingStore = mockStore({
       data: { userContent: {
-        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', progress: 0, status: 'pending' },
-        'upload-2': { uploadId: 'upload-2', filename: 'file2.pdf', progress: 0, status: 'pending' },
+        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', progress: 0, status: 'in_progress' },
+        'upload-2': { uploadId: 'upload-2', filename: 'file2.pdf', progress: 0, status: 'in_progress' },
       } },
     });
     const { rerender } = renderAttachmentField({
@@ -695,7 +738,7 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
 
     const mixedStore = mockStore({
       data: { userContent: {
-        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', progress: 1, status: 'completed' },
+        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', progress: 1, status: 'complete' },
         'upload-2': { uploadId: 'upload-2', filename: 'file2.pdf', progress: 0, status: 'failed' },
       } },
     });
@@ -714,52 +757,22 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
     );
 
     expect(screen.getByRole('status')).toHaveTextContent('file1.pdf uploaded');
-    expect(screen.getByRole('status')).toHaveTextContent("file2.pdf couldn't be uploaded");
+    expect(screen.getByRole('status')).toHaveTextContent('file2.pdf couldn\'t be uploaded');
   });
 
-  test('moves focus to the next remove button when removing an item', async () => {
+  test('moves focus to the closest action button when removing an attachment', async () => {
     const uploadStore = mockStore({
       data: { userContent: {
-        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', fileType: 'application/pdf', progress: 0, status: 'pending' },
-        'upload-2': { uploadId: 'upload-2', filename: 'file2.pdf', fileType: 'application/pdf', progress: 0, status: 'pending' },
+        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', fileType: 'application/pdf', progress: 0, status: 'in_progress' },
       } },
     });
+    const attachmentsMetadata = {
+      'saved-1': { filename: 'file2.pdf', file_type: 'document', status: 'unknown' },
+      'saved-2': { filename: 'file3.pdf', file_type: 'document', files: { original: 'https://example.com/file3.pdf' } },
+    };
     const { rerender } = renderAttachmentField({
-      value: [{ uploadId: 'upload-1' }, { uploadId: 'upload-2' }],
-    }, uploadStore);
-
-    await userEvent.click(screen.getByRole('button', { name: 'Remove file1.pdf' }));
-
-    const uploadStoreAfterRemove = mockStore({
-      data: { userContent: {
-        'upload-2': { uploadId: 'upload-2', filename: 'file2.pdf', fileType: 'application/pdf', progress: 0, status: 'pending' },
-      } },
-    });
-    rerender(
-      <Provider store={uploadStoreAfterRemove}>
-        <TrackerContext.Provider value={null}>
-          <Attachment
-            details={details}
-            error={undefined}
-            id="attachment-1"
-            onFieldChange={onFieldChange}
-            value={[{ uploadId: 'upload-2' }]}
-          />
-        </TrackerContext.Provider>
-      </Provider>
-    );
-
-    expect(screen.getByRole('button', { name: 'Remove file2.pdf' })).toHaveFocus();
-  });
-
-  test('moves focus to the choose file button when removing the last item', async () => {
-    const uploadStore = mockStore({
-      data: { userContent: {
-        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', fileType: 'application/pdf', progress: 0, status: 'pending' },
-      } },
-    });
-    const { rerender } = renderAttachmentField({
-      value: [{ uploadId: 'upload-1' }],
+      attachmentsMetadata,
+      value: [{ uploadId: 'upload-1' }, { uploadId: 'saved-1' }, { uploadId: 'saved-2' }],
     }, uploadStore);
 
     await userEvent.click(screen.getByRole('button', { name: 'Remove file1.pdf' }));
@@ -768,11 +781,46 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
       <Provider store={store}>
         <TrackerContext.Provider value={null}>
           <Attachment
+            attachmentsMetadata={attachmentsMetadata}
             details={details}
             error={undefined}
             id="attachment-1"
             onFieldChange={onFieldChange}
-            value={[]}
+            value={[{ uploadId: 'saved-1' }, { uploadId: 'saved-2' }]}
+          />
+        </TrackerContext.Provider>
+      </Provider>
+    );
+
+    expect(screen.getByRole('button', { name: 'Download file3.pdf' })).toHaveFocus();
+  });
+
+  test('moves focus to the choose file button when there are no attachments with action buttons remaining', async () => {
+    const uploadStore = mockStore({
+      data: { userContent: {
+        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', fileType: 'application/pdf', progress: 0, status: 'in_progress' },
+      } },
+    });
+    const attachmentsMetadata = {
+      'saved-1': { filename: 'file2.pdf', file_type: 'document', status: 'unknown' },
+    };
+    const { rerender } = renderAttachmentField({
+      attachmentsMetadata,
+      value: [{ uploadId: 'upload-1' }, { uploadId: 'saved-1' }],
+    }, uploadStore);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove file1.pdf' }));
+
+    rerender(
+      <Provider store={store}>
+        <TrackerContext.Provider value={null}>
+          <Attachment
+            attachmentsMetadata={attachmentsMetadata}
+            details={details}
+            error={undefined}
+            id="attachment-1"
+            onFieldChange={onFieldChange}
+            value={[{ uploadId: 'saved-1' }]}
           />
         </TrackerContext.Provider>
       </Provider>

--- a/src/ReportManager/DetailsSection/SchemaForm/formElements/Attachment/index.test.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/formElements/Attachment/index.test.js
@@ -840,6 +840,43 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
     expect(screen.getByRole('button', { name: 'Choose File' })).toHaveFocus();
   });
 
+  test('skips a disabled action button and moves focus to the choose file button', async () => {
+    const uploadStore = mockStore({
+      data: { userContent: {
+        'upload-1': { uploadId: 'upload-1', filename: 'file1.pdf', fileType: 'application/pdf', progress: 0, status: 'in_progress' },
+      } },
+    });
+    const attachmentsMetadata = {
+      'saved-1': { filename: 'file2.pdf', file_type: 'document' },
+    };
+    const { rerender } = renderAttachmentField({
+      attachmentsMetadata,
+      value: [{ uploadId: 'upload-1' }, { uploadId: 'saved-1' }],
+    }, uploadStore);
+
+    const downloadButton = screen.getByRole('button', { name: 'Download file2.pdf' });
+    expect(downloadButton).toBeDisabled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove file1.pdf' }));
+
+    rerender(
+      <Provider store={store}>
+        <TrackerContext.Provider value={null}>
+          <Attachment
+            attachmentsMetadata={attachmentsMetadata}
+            details={details}
+            error={undefined}
+            id="attachment-1"
+            onFieldChange={onFieldChange}
+            value={[{ uploadId: 'saved-1' }]}
+          />
+        </TrackerContext.Provider>
+      </Provider>
+    );
+
+    expect(screen.getByRole('button', { name: 'Choose File' })).toHaveFocus();
+  });
+
   test('applies the dragging-over style when dragging a file over the component', () => {
     renderAttachmentField();
 

--- a/src/ReportManager/DetailsSection/SchemaForm/formElements/Attachment/index.test.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/formElements/Attachment/index.test.js
@@ -427,6 +427,17 @@ describe('ReportManager - DetailsSection - SchemaForm - formElements - Attachmen
     expect(downloadButton).toHaveAttribute('title', 'Download file1.pdf');
   });
 
+  test('disables the download button for a saved non-image attachment with no original URL', () => {
+    renderAttachmentField({
+      attachmentsMetadata: {
+        'saved-1': { filename: 'file1.pdf', file_type: 'document' },
+      },
+      value: [{ uploadId: 'saved-1' }],
+    });
+
+    expect(screen.getByRole('button', { name: 'Download file1.pdf' })).toBeDisabled();
+  });
+
   test('does not show a remove button for a saved attachment', () => {
     renderAttachmentField({
       attachmentsMetadata: {

--- a/src/ReportManager/DetailsSection/SchemaForm/formElements/Attachment/styles.module.scss
+++ b/src/ReportManager/DetailsSection/SchemaForm/formElements/Attachment/styles.module.scss
@@ -103,7 +103,7 @@
           transition: --upload-progress 200ms ease;
           width: 1.75rem;
 
-          &.pending {
+          &.indeterminate {
             animation: uploadProgressSpin 0.8s linear infinite;
             animation-direction: reverse;
             background: conic-gradient(colors.$light-gray-border 25%, colors.$bright-blue 25%);
@@ -117,6 +117,12 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+      }
+
+      .pendingLabel {
+        flex-shrink: 0;
+        font-weight: 700;
+        margin-right: 0.75rem;
       }
 
       .error {

--- a/src/ReportManager/DetailsSection/SchemaForm/index.test.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/index.test.js
@@ -550,7 +550,7 @@ describe('ReportManager - DetailsSection - SchemaForm', () => {
 
     renderSchemaForm(
       { formData: { text_field: 'a text value', attachment_field: [{ uploadId: 'pending-upload-id' }] } },
-      { data: { userContent: { 'pending-upload-id': { uploadId: 'pending-upload-id', filename: 'test.pdf', progress: 0, status: 'pending' } } } }
+      { data: { userContent: { 'pending-upload-id': { uploadId: 'pending-upload-id', filename: 'test.pdf', progress: null, status: 'in_progress' } } } }
     );
 
     const alert = screen.getByRole('alert');

--- a/src/ReportManager/DetailsSection/SchemaForm/utils/useUploadValidations/index.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/utils/useUploadValidations/index.js
@@ -13,10 +13,7 @@ const computeUploadErrors = (formData, formElements, userContent, t, parentColle
     if (formElements[fieldId]?.type === FORM_ELEMENT_TYPES.ATTACHMENT) {
       if (Array.isArray(fieldValue) && fieldValue.length > 0) {
         // The field is an attachment with uploads.
-        const hasPending = fieldValue.some(
-          ({ uploadId }) => userContent[uploadId]?.status === 'pending'
-            || userContent[uploadId]?.status === 'uploading'
-        );
+        const hasPending = fieldValue.some(({ uploadId }) => userContent[uploadId]?.status === 'in_progress');
         const hasFailed = fieldValue.some(({ uploadId }) => userContent[uploadId]?.status === 'failed');
         if (hasPending) {
           // The attachment has pending uploads.

--- a/src/ReportManager/DetailsSection/SchemaForm/utils/useUploadValidations/index.test.js
+++ b/src/ReportManager/DetailsSection/SchemaForm/utils/useUploadValidations/index.test.js
@@ -45,7 +45,7 @@ describe('ReportManager - DetailsSection - SchemaForm - Utils - useUploadValidat
 
   it('returns the upload in progress error', () => {
     store.data.userContent = {
-      'upload-1': { status: 'pending' },
+      'upload-1': { status: 'in_progress' },
       'upload-2': { status: 'success' },
     };
     const formData = {
@@ -81,28 +81,9 @@ describe('ReportManager - DetailsSection - SchemaForm - Utils - useUploadValidat
     });
   });
 
-  it('returns the upload in progress error when the upload status is uploading', () => {
-    store.data.userContent = {
-      'upload-1': { status: 'uploading' },
-      'upload-2': { status: 'success' },
-    };
-    const formData = {
-      textField: 'some text',
-      attachmentField: [{ uploadId: 'upload-1' }],
-      collectionField: [{ attachmentField: [{ uploadId: 'upload-2' }] }],
-    };
-
-    const { result } = renderHook(() => useUploadValidations(formElements), { wrapper: Wrapper });
-    const runValidations = result.current;
-
-    expect(runValidations(formData)).toEqual({
-      attachmentField: { message: 'Please wait for files to finish uploading.' },
-    });
-  });
-
   it('prioritizes the upload in progress error over the upload failed error', () => {
     store.data.userContent = {
-      'upload-1': { status: 'pending' },
+      'upload-1': { status: 'in_progress' },
       'upload-1b': { status: 'failed' },
       'upload-2': { status: 'success' },
     };
@@ -139,7 +120,7 @@ describe('ReportManager - DetailsSection - SchemaForm - Utils - useUploadValidat
   it('nests errors in collection item forms', () => {
     store.data.userContent = {
       'upload-1': { status: 'success' },
-      'upload-2': { status: 'pending' },
+      'upload-2': { status: 'in_progress' },
     };
     const formData = {
       textField: 'some text',

--- a/src/ducks/user-content/index.js
+++ b/src/ducks/user-content/index.js
@@ -55,7 +55,7 @@ export const startChunkedUpload = async (file, uploadId, dispatch) => {
 
     const { chunk_size: chunkSize, num_chunks: numChunks } = initiateChunkedUploadResponse.data.data;
 
-    dispatch({ payload: { progress: 0, status: 'uploading', uploadId }, type: SET_CHUNKED_UPLOAD_STATUS });
+    dispatch({ payload: { progress: 0, status: 'in_progress', uploadId }, type: SET_CHUNKED_UPLOAD_STATUS });
 
     for (let chunkIndex = 0; chunkIndex < numChunks; chunkIndex++) {
       const chunkOffset = chunkIndex * chunkSize;
@@ -68,14 +68,14 @@ export const startChunkedUpload = async (file, uploadId, dispatch) => {
       );
 
       dispatch({
-        payload: { progress: (chunkIndex + 1) / numChunks, status: 'uploading', uploadId },
+        payload: { progress: (chunkIndex + 1) / numChunks, status: 'in_progress', uploadId },
         type: SET_CHUNKED_UPLOAD_STATUS,
       });
     }
 
     await axios.post(COMPLETE_CHUNKED_UPLOAD_API_URL(uploadId), {}, { signal: abortController.signal });
 
-    dispatch({ payload: { progress: 1, status: 'completed', uploadId }, type: SET_CHUNKED_UPLOAD_STATUS });
+    dispatch({ payload: { progress: 1, status: 'complete', uploadId }, type: SET_CHUNKED_UPLOAD_STATUS });
   } catch {
     if (!abortController.signal.aborted) {
       dispatch({ payload: { status: 'failed', uploadId }, type: SET_CHUNKED_UPLOAD_STATUS });
@@ -93,8 +93,8 @@ export const uploadFile = (file) => (dispatch) => {
       filename: file.name,
       fileType: file.type,
       objectUrl: file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined,
-      progress: 0,
-      status: 'pending',
+      progress: null,
+      status: 'in_progress',
       uploadId,
     },
     type: SET_CHUNKED_UPLOAD_STATUS,

--- a/src/ducks/user-content/index.test.js
+++ b/src/ducks/user-content/index.test.js
@@ -104,7 +104,7 @@ describe('Ducks - User content', () => {
     expect(revokeObjectURLSpy).toHaveBeenCalledWith(mockObjectUrl);
   });
 
-  test('uploadFile dispatches the SET_CHUNKED_UPLOAD_STATUS action when the upload state is pending', async () => {
+  test('uploadFile dispatches the SET_CHUNKED_UPLOAD_STATUS action when the upload state is in progress', async () => {
     const dispatch = jest.fn();
     const file = new File(['content'], 'test.pdf', { type: 'application/pdf' });
 
@@ -115,15 +115,15 @@ describe('Ducks - User content', () => {
         filename: 'test.pdf',
         fileType: 'application/pdf',
         objectUrl: undefined,
-        progress: 0,
-        status: 'pending',
+        progress: null,
+        status: 'in_progress',
         uploadId: MOCK_UPLOAD_ID,
       },
       type: SET_CHUNKED_UPLOAD_STATUS,
     });
   });
 
-  test('uploadFile includes an object URL in the pending dispatch for image files', async () => {
+  test('uploadFile includes an object URL in the initial dispatch for image files', async () => {
     const mockObjectUrl = 'blob:http://localhost/mock-url';
     jest.spyOn(URL, 'createObjectURL').mockReturnValue(mockObjectUrl);
 
@@ -137,15 +137,15 @@ describe('Ducks - User content', () => {
         filename: 'test.jpg',
         fileType: 'image/jpeg',
         objectUrl: mockObjectUrl,
-        progress: 0,
-        status: 'pending',
+        progress: null,
+        status: 'in_progress',
         uploadId: MOCK_UPLOAD_ID,
       },
       type: SET_CHUNKED_UPLOAD_STATUS,
     });
   });
 
-  test('uploadFile dispatches the SET_CHUNKED_UPLOAD_STATUS action when the upload state is uploading', async () => {
+  test('uploadFile dispatches the SET_CHUNKED_UPLOAD_STATUS action once the upload starts', async () => {
     const dispatch = jest.fn();
     const file = new File(['content'], 'test.pdf', { type: 'application/pdf' });
     const abortController = new AbortController();
@@ -154,12 +154,12 @@ describe('Ducks - User content', () => {
     await startChunkedUpload(file, MOCK_UPLOAD_ID, dispatch);
 
     expect(dispatch).toHaveBeenCalledWith({
-      payload: { progress: 0, status: 'uploading', uploadId: MOCK_UPLOAD_ID },
+      payload: { progress: 0, status: 'in_progress', uploadId: MOCK_UPLOAD_ID },
       type: SET_CHUNKED_UPLOAD_STATUS,
     });
   });
 
-  test('uploadFile dispatches the SET_CHUNKED_UPLOAD_STATUS action when the upload state is completed', async () => {
+  test('uploadFile dispatches the SET_CHUNKED_UPLOAD_STATUS action when the upload state is complete', async () => {
     const dispatch = jest.fn();
     const file = new File(['content'], 'test.pdf', { type: 'application/pdf' });
     const abortController = new AbortController();
@@ -168,7 +168,7 @@ describe('Ducks - User content', () => {
     await startChunkedUpload(file, MOCK_UPLOAD_ID, dispatch);
 
     expect(dispatch).toHaveBeenCalledWith({
-      payload: { progress: 1, status: 'completed', uploadId: MOCK_UPLOAD_ID },
+      payload: { progress: 1, status: 'complete', uploadId: MOCK_UPLOAD_ID },
       type: SET_CHUNKED_UPLOAD_STATUS,
     });
   });
@@ -189,11 +189,11 @@ describe('Ducks - User content', () => {
     await startChunkedUpload(file, MOCK_UPLOAD_ID, dispatch);
 
     expect(dispatch).toHaveBeenCalledWith({
-      payload: { progress: 0.5, status: 'uploading', uploadId: MOCK_UPLOAD_ID },
+      payload: { progress: 0.5, status: 'in_progress', uploadId: MOCK_UPLOAD_ID },
       type: SET_CHUNKED_UPLOAD_STATUS,
     });
     expect(dispatch).toHaveBeenCalledWith({
-      payload: { progress: 1, status: 'uploading', uploadId: MOCK_UPLOAD_ID },
+      payload: { progress: 1, status: 'in_progress', uploadId: MOCK_UPLOAD_ID },
       type: SET_CHUNKED_UPLOAD_STATUS,
     });
   });
@@ -239,7 +239,7 @@ describe('Ducks - User content', () => {
           filename: 'test.pdf',
           fileType: 'application/pdf',
           progress: 0.5,
-          status: 'uploading',
+          status: 'in_progress',
           uploadId: MOCK_UPLOAD_ID,
         },
       };
@@ -253,7 +253,7 @@ describe('Ducks - User content', () => {
           filename: 'test.pdf',
           fileType: 'application/pdf',
           progress: 1,
-          status: 'completed',
+          status: 'complete',
           uploadId: MOCK_UPLOAD_ID,
         },
       };
@@ -266,8 +266,8 @@ describe('Ducks - User content', () => {
       const payload = {
         filename: 'test.pdf',
         fileType: 'application/pdf',
-        progress: 0,
-        status: 'pending',
+        progress: null,
+        status: 'in_progress',
         uploadId: MOCK_UPLOAD_ID,
       };
       const action = { payload, type: SET_CHUNKED_UPLOAD_STATUS };
@@ -275,8 +275,8 @@ describe('Ducks - User content', () => {
         [MOCK_UPLOAD_ID]: {
           filename: 'test.pdf',
           fileType: 'application/pdf',
-          progress: 0,
-          status: 'pending',
+          progress: null,
+          status: 'in_progress',
           uploadId: MOCK_UPLOAD_ID,
         },
       };
@@ -290,18 +290,18 @@ describe('Ducks - User content', () => {
           filename: 'test.pdf',
           fileType: 'application/pdf',
           progress: 0,
-          status: 'uploading',
+          status: 'in_progress',
           uploadId: MOCK_UPLOAD_ID,
         },
       };
-      const payload = { progress: 0.5, status: 'uploading', uploadId: MOCK_UPLOAD_ID };
+      const payload = { progress: 0.5, status: 'in_progress', uploadId: MOCK_UPLOAD_ID };
       const action = { payload, type: SET_CHUNKED_UPLOAD_STATUS };
       const expectedState = {
         [MOCK_UPLOAD_ID]: {
           filename: 'test.pdf',
           fileType: 'application/pdf',
           progress: 0.5,
-          status: 'uploading',
+          status: 'in_progress',
           uploadId: MOCK_UPLOAD_ID,
         },
       };


### PR DESCRIPTION
## What does this PR do?
Read the attachment status from the event metadata to properly render the attachment. Also, standardize the attachment statuses in the client-side to match the backend-side statuses provided through the metadata:
- `in_progress`: show the spinner. If it's a local upload, the ring fills following the progress of the upload; if its remote, it's a simple spinner.
- `complete`: show the image preview or the appropriate icon and a download icon. If it's a local uplaod, we show the trach icon button since the file can still be removed.
- `unknown`: show a `PENDING` legend.

## Evidence
<img width="1920" height="990" alt="image" src="https://github.com/user-attachments/assets/b4e61dd8-84f8-4c16-924b-da34315d6a25" />


### Relevant link(s)
- [ERA-13417](https://allenai.atlassian.net/browse/ERA-13417)
- [Branch Environment](https://era-13417.dev.pamdas.org)


[ERA-13417]: https://allenai.atlassian.net/browse/ERA-13417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ