### PR TITLE
ERA-13544: update the Ecoscope Downloader link in the sidebar to point to the migration guide that applies post-Downloader sunset (June 30, 2026).

### DIFF
--- a/public/locales/en-US/menu-drawer.json
+++ b/public/locales/en-US/menu-drawer.json
@@ -35,8 +35,8 @@
     },
     "ecoscopeAnalysisLinkAriaLabel": "Ecoscope Analysis",
     "ecoscopeAnalysisLink": "Analysis",
-    "ecoscopeDownloaderLinkAriaLabel": "Ecoscope Downloader",
-    "ecoscopeDownloaderLink": "Downloader",
+    "ecoscopeDownloaderMigrationGuideLinkAriaLabel": "Ecoscope Downloader",
+    "ecoscopeDownloaderMigrationGuideLink": "Downloader",
     "ecoscopeHeading": "ECOSCOPE",
     "footer": {
       "clientVersion": "Web client version: {{version}}",

--- a/public/locales/es/menu-drawer.json
+++ b/public/locales/es/menu-drawer.json
@@ -33,8 +33,8 @@
     },
     "ecoscopeAnalysisLinkAriaLabel": "Análisis con Ecoscope",
     "ecoscopeAnalysisLink": "Análisis",
-    "ecoscopeDownloaderLinkAriaLabel": "Descargador de Ecoscope",
-    "ecoscopeDownloaderLink": "Descargar",
+    "ecoscopeDownloaderMigrationGuideLinkAriaLabel": "Descargador de Ecoscope",
+    "ecoscopeDownloaderMigrationGuideLink": "Descargar",
     "ecoscopeHeading": "ECOSCOPE",
     "footer": {
       "clientVersion": "Versión del cliente web: {{version}}",

--- a/public/locales/fr/menu-drawer.json
+++ b/public/locales/fr/menu-drawer.json
@@ -33,8 +33,8 @@
     },
     "ecoscopeAnalysisLinkAriaLabel": "Analyse avec Ecoscope",
     "ecoscopeAnalysisLink": "Analyse",
-    "ecoscopeDownloaderLinkAriaLabel": "Téléchargeur d’Ecoscope",
-    "ecoscopeDownloaderLink": "Télécharger",
+    "ecoscopeDownloaderMigrationGuideLinkAriaLabel": "Téléchargeur d’Ecoscope",
+    "ecoscopeDownloaderMigrationGuideLink": "Télécharger",
     "ecoscopeHeading": "ECOSCOPE",
     "footer": {
       "clientVersion": "Version du client web: {{version}}",

--- a/public/locales/ne-NP/menu-drawer.json
+++ b/public/locales/ne-NP/menu-drawer.json
@@ -33,8 +33,8 @@
     },
     "ecoscopeAnalysisLinkAriaLabel": "Ecoscope सँग विश्लेषण",
     "ecoscopeAnalysisLink": "विश्लेषण",
-    "ecoscopeDownloaderLinkAriaLabel": "Ecoscope डाउनलोडर",
-    "ecoscopeDownloaderLink": "डाउनलोड",
+    "ecoscopeDownloaderMigrationGuideLinkAriaLabel": "Ecoscope डाउनलोडर",
+    "ecoscopeDownloaderMigrationGuideLink": "डाउनलोड",
     "ecoscopeHeading": "ECOSCOPE",
     "footer": {
       "clientVersion": "वेब ग्राहक संस्करण: {{version}}",

--- a/public/locales/pt/menu-drawer.json
+++ b/public/locales/pt/menu-drawer.json
@@ -33,8 +33,8 @@
     },
     "ecoscopeAnalysisLinkAriaLabel": "Análise com Ecoscope",
     "ecoscopeAnalysisLink": "Análise",
-    "ecoscopeDownloaderLinkAriaLabel": "Baixador do Ecoscope",
-    "ecoscopeDownloaderLink": "Baixar",
+    "ecoscopeDownloaderMigrationGuideLinkAriaLabel": "Baixador do Ecoscope",
+    "ecoscopeDownloaderMigrationGuideLink": "Baixar",
     "ecoscopeHeading": "ECOSCOPE",
     "footer": {
       "clientVersion": "Versão do cliente web: {{version}}",

--- a/public/locales/sw/menu-drawer.json
+++ b/public/locales/sw/menu-drawer.json
@@ -35,8 +35,8 @@
     },
     "ecoscopeAnalysisLinkAriaLabel": "Uchambuzi na Ecoscope",
     "ecoscopeAnalysisLink": "Uchambuzi",
-    "ecoscopeDownloaderLinkAriaLabel": "Upakuaji wa Ecoscope",
-    "ecoscopeDownloaderLink": "Pakua",
+    "ecoscopeDownloaderMigrationGuideLinkAriaLabel": "Upakuaji wa Ecoscope",
+    "ecoscopeDownloaderMigrationGuideLink": "Pakua",
     "ecoscopeHeading": "ECOSCOPE",
     "footer": {
       "clientVersion": "Toleo la Wavuti: {{version}}",

--- a/src/GlobalMenuDrawer/index.js
+++ b/src/GlobalMenuDrawer/index.js
@@ -48,7 +48,7 @@ export const COMMUNITY_SITE_URL = 'https://Community.EarthRanger.com';
 export const CONTACT_SUPPORT_EMAIL_ADDRESS = 'support@pamdas.org';
 export const DATA_PRIVACY_POLICY_URL = 'https://assets-global.website-files.com/61a93c4da07e4e6975c3f2b2/61eaeb2ccd0b65595bd4d387_EarthRanger_PP_ver2021-10-01.pdf';
 export const ECOSCOPE_ANALYSIS_URL = 'https://app.ecoscope.io/login';
-export const ECOSCOPE_DOWNLOADER_URL = 'https://ecoscope.io/en/latest/ecoscope_gui.html#downloads';
+export const ECOSCOPE_DOWNLOADER_MIGRATION_GUIDE_URL = 'https://support.earthranger.com/en_US/ecoscope-getting-help/ecoscope-migration-guide';
 export const EULA_URL = 'https://assets.website-files.com/61a93c4da07e4e6975c3f2b2/61d7274b9ba24a5d8bac44b2_EarthRanger_EULA_ver2021-10-01.pdf';
 export const HELP_CENTER_SITE_URL = 'https://support.earthranger.com/';
 export const USERS_GUIDE_SITE_URL = 'https://support.earthranger.com/en_US/earthranger-web';
@@ -345,7 +345,7 @@ const GlobalMenuDrawer = () => {
           <li>
             <a
               aria-label={t('ecoscopeDownloaderLinkAriaLabel')}
-              href={ECOSCOPE_DOWNLOADER_URL}
+              href={ECOSCOPE_DOWNLOADER_MIGRATION_GUIDE_URL}
               onClick={() => mainToolbarTracker.track('Click \'Ecoscope Downloader\' menu item')}
               rel="noopener noreferrer"
               target="_blank"

--- a/src/GlobalMenuDrawer/index.js
+++ b/src/GlobalMenuDrawer/index.js
@@ -344,13 +344,13 @@ const GlobalMenuDrawer = () => {
         <ul>
           <li>
             <a
-              aria-label={t('ecoscopeDownloaderLinkAriaLabel')}
+              aria-label={t('ecoscopeDownloaderMigrationGuideLinkAriaLabel')}
               href={ECOSCOPE_DOWNLOADER_MIGRATION_GUIDE_URL}
               onClick={() => mainToolbarTracker.track('Click \'Ecoscope Downloader\' menu item')}
               rel="noopener noreferrer"
               target="_blank"
             >
-              {t('ecoscopeDownloaderLink')}
+              {t('ecoscopeDownloaderMigrationGuideLink')}
             </a>
           </li>
 


### PR DESCRIPTION
## What does this PR do?
Updates the Downloader link in the sidebar to point to the migration guide that applies post-Downloader sunset (June 30, 2026).

Closes ERA-13544.

## Evidence
N/A.

### Relevant link(s)
- [ERA-13544](https://allenai.atlassian.net/browse/ERA-13544)
- [Branch Environment](https://era-13544.dev.pamdas.org)

## Notes
Just a simple URL tweak. 

[ERA-13544]: https://allenai.atlassian.net/browse/ERA-13544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ