### PR TITLE
ERA-13539: adopt Auth0 refresh-token rotation for ER Web token renewal

### DIFF
--- a/src/Auth0TokenManager/index.js
+++ b/src/Auth0TokenManager/index.js
@@ -5,7 +5,7 @@ import { useLocation } from 'react-router';
 
 import appConfig from '../config';
 import { REACT_APP_ROUTE_PREFIX } from '../constants';
-import { clearAuth, POST_AUTH_SUCCESS } from '../ducks/auth';
+import { applyAccessToken, clearAuth } from '../ducks/auth';
 import useNavigate from '../hooks/useNavigate';
 import { checkAccountLinked, GATE_RESULT } from '../utils/account-linking';
 import {
@@ -81,8 +81,7 @@ const Auth0TokenManager = () => {
             // A LINKED result returns no early exit and falls through to the sign-in below.
           }
 
-          document.cookie = `token=${safe};path=/`;
-          dispatch({ type: POST_AUTH_SUCCESS, payload: { data: { access_token: safe } } });
+          dispatch(applyAccessToken(safe));
 
           // Return route survives the Auth0 redirect in localStorage.
           const intendedRoute = getIntendedPostAuth0SuccessRoute();

--- a/src/Auth0TokenManager/index.test.js
+++ b/src/Auth0TokenManager/index.test.js
@@ -8,7 +8,7 @@ import { hasAuth0CallbackParams } from '../utils/auth0';
 import { isValidTokenFormat } from '../utils/auth';
 import useNavigate from '../hooks/useNavigate';
 import { GATE_RESULT, checkAccountLinked } from '../utils/account-linking';
-import { POST_AUTH_SUCCESS } from '../ducks/auth';
+import { applyAccessToken } from '../ducks/auth';
 import { redirectToExternalUrl } from '../utils/navigation';
 
 jest.mock('@auth0/auth0-react');
@@ -24,6 +24,11 @@ jest.mock('../utils/account-linking', () => {
 jest.mock('../utils/navigation', () => ({
   ...jest.requireActual('../utils/navigation'),
   redirectToExternalUrl: jest.fn(),
+}));
+jest.mock('../ducks/auth', () => ({
+  __esModule: true,
+  ...jest.requireActual('../ducks/auth'),
+  applyAccessToken: jest.fn(() => ({ type: 'APPLY_ACCESS_TOKEN' })),
 }));
 
 describe('Auth0TokenManager', () => {
@@ -185,7 +190,7 @@ describe('Auth0TokenManager', () => {
       renderAfterCallback();
 
       await waitFor(() => {
-        expect(mockDispatch).toHaveBeenCalledWith(expect.objectContaining({ type: POST_AUTH_SUCCESS }));
+        expect(applyAccessToken).toHaveBeenCalledWith(VALID_TOKEN);
       });
       expect(checkAccountLinked).toHaveBeenCalledWith(VALID_TOKEN);
     });
@@ -202,7 +207,7 @@ describe('Auth0TokenManager', () => {
         expect(redirectToExternalUrl).toHaveBeenCalledWith('https://site.example/auth/link-accounts/');
       });
       // No authenticated-state transition, no SPA navigation, no token teardown.
-      expect(mockDispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: POST_AUTH_SUCCESS }));
+      expect(applyAccessToken).not.toHaveBeenCalled();
       expect(mockNavigate).not.toHaveBeenCalled();
       expect(mockLogout).not.toHaveBeenCalled();
     });
@@ -216,7 +221,7 @@ describe('Auth0TokenManager', () => {
         expect(mockLogout).toHaveBeenCalledWith({ openUrl: false });
       });
       expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('login'), { replace: true });
-      expect(mockDispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: POST_AUTH_SUCCESS }));
+      expect(applyAccessToken).not.toHaveBeenCalled();
     });
 
     test('transient failure: leaves the user at login with a retryable error and no token teardown', async () => {
@@ -231,7 +236,7 @@ describe('Auth0TokenManager', () => {
         );
       });
       expect(mockLogout).not.toHaveBeenCalled();
-      expect(mockDispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: POST_AUTH_SUCCESS }));
+      expect(applyAccessToken).not.toHaveBeenCalled();
     });
 
     test('org-scoped (idp_org_id set): skips the gate and authenticates', async () => {
@@ -243,7 +248,7 @@ describe('Auth0TokenManager', () => {
       renderAfterCallback();
 
       await waitFor(() => {
-        expect(mockDispatch).toHaveBeenCalledWith(expect.objectContaining({ type: POST_AUTH_SUCCESS }));
+        expect(applyAccessToken).toHaveBeenCalledWith(VALID_TOKEN);
       });
       expect(checkAccountLinked).not.toHaveBeenCalled();
     });

--- a/src/RequestConfigManager/index.js
+++ b/src/RequestConfigManager/index.js
@@ -1,10 +1,11 @@
 import { memo, useCallback, useEffect } from 'react';
 import axios from 'axios';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import { useLocation } from 'react-router';
+import { useAuth0 } from '@auth0/auth0-react';
 import { toast } from 'react-toastify';
 
-import { clearAuth, resetMasterCancelToken } from '../ducks/auth';
+import { clearAuth, POST_AUTH_SUCCESS, resetMasterCancelToken } from '../ducks/auth';
 
 import { REACT_APP_ROUTE_PREFIX } from '../constants';
 import { showToast } from '../utils/toast';
@@ -58,17 +59,38 @@ const RequestConfigManager = ({
   token,
   user,
 }) => {
-  const location = useLocation();
+  const { search } = useLocation();
   const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const { getAccessTokenSilently } = useAuth0();
 
-  const handle401Errors = useCallback((error) => {
-    if (error && error.toString().includes('401') && !error.config?.skipAuth) {
+  const handle401Errors = useCallback(async (error) => {
+    const isAuthError = error?.response?.status === 401 && !error.config?.skipAuth;
+    const request = error?.config;
+
+    if (isAuthError && request && !request.retriedAfterRefresh) {
+      try {
+        const accessToken = await getAccessTokenSilently();
+        document.cookie = `token=${accessToken};path=/`;
+        dispatch({ type: POST_AUTH_SUCCESS, payload: { data: { access_token: accessToken } } });
+        return axios({
+          ...request,
+          retriedAfterRefresh: true,
+          headers: { ...request.headers, Authorization: `Bearer ${accessToken}` },
+        });
+      } catch (renewalError) {
+        console.warn('Token renewal failed; signing out', renewalError);
+      }
+    }
+
+    if (isAuthError) {
       resetMasterCancelToken();
       clearAuth().then(() => {
-        navigate({ pathname: `${REACT_APP_ROUTE_PREFIX}login`, search: location.search });
+        navigate({ pathname: `${REACT_APP_ROUTE_PREFIX}login`, search });
       });
     }
-  }, [clearAuth, location?.search, navigate, resetMasterCancelToken]);
+    return Promise.reject(error);
+  }, [clearAuth, dispatch, getAccessTokenSilently, navigate, resetMasterCancelToken, search]);
 
   const addMasterCancelTokenToRequests = useCallback((config) => {
     config.cancelToken = config.cancelToken || (masterRequestCancelToken && masterRequestCancelToken.token);
@@ -114,10 +136,7 @@ const RequestConfigManager = ({
         handleGeoPermWarningHeader(response, userLocationAccessGranted);
         return response;
       },
-      (error) => {
-        handle401Errors(error);
-        return Promise.reject(error);
-      }
+      (error) => handle401Errors(error)
     ];
 
     const interceptorId = axios.interceptors.response.use(...interceptorConfig);

--- a/src/RequestConfigManager/index.js
+++ b/src/RequestConfigManager/index.js
@@ -1,11 +1,11 @@
 import { memo, useCallback, useEffect } from 'react';
 import axios from 'axios';
-import { connect, useDispatch } from 'react-redux';
+import { connect } from 'react-redux';
 import { useLocation } from 'react-router';
 import { useAuth0 } from '@auth0/auth0-react';
 import { toast } from 'react-toastify';
 
-import { clearAuth, POST_AUTH_SUCCESS, resetMasterCancelToken } from '../ducks/auth';
+import { applyAccessToken, clearAuth, resetMasterCancelToken } from '../ducks/auth';
 
 import { REACT_APP_ROUTE_PREFIX } from '../constants';
 import { showToast } from '../utils/toast';
@@ -51,6 +51,7 @@ const handleGeoPermWarningHeader = (response, userLocationAccessGranted) => {
 
 
 const RequestConfigManager = ({
+  applyAccessToken,
   clearAuth,
   userLocationAccessGranted,
   masterRequestCancelToken,
@@ -61,7 +62,6 @@ const RequestConfigManager = ({
 }) => {
   const { search } = useLocation();
   const navigate = useNavigate();
-  const dispatch = useDispatch();
   const { getAccessTokenSilently } = useAuth0();
 
   const handle401Errors = useCallback(async (error) => {
@@ -71,8 +71,7 @@ const RequestConfigManager = ({
     if (isAuthError && request && !request.retriedAfterRefresh) {
       try {
         const accessToken = await getAccessTokenSilently();
-        document.cookie = `token=${accessToken};path=/`;
-        dispatch({ type: POST_AUTH_SUCCESS, payload: { data: { access_token: accessToken } } });
+        applyAccessToken(accessToken);
         return axios({
           ...request,
           retriedAfterRefresh: true,
@@ -90,7 +89,7 @@ const RequestConfigManager = ({
       });
     }
     return Promise.reject(error);
-  }, [clearAuth, dispatch, getAccessTokenSilently, navigate, resetMasterCancelToken, search]);
+  }, [applyAccessToken, clearAuth, getAccessTokenSilently, navigate, resetMasterCancelToken, search]);
 
   const addMasterCancelTokenToRequests = useCallback((config) => {
     config.cancelToken = config.cancelToken || (masterRequestCancelToken && masterRequestCancelToken.token);
@@ -181,4 +180,4 @@ const mapStateToProps = ({ data: { selectedUserProfile, user, masterRequestCance
 });
 
 
-export default connect(mapStateToProps, { clearAuth, resetMasterCancelToken })(memo(RequestConfigManager));
+export default connect(mapStateToProps, { applyAccessToken, clearAuth, resetMasterCancelToken })(memo(RequestConfigManager));

--- a/src/RequestConfigManager/index.test.js
+++ b/src/RequestConfigManager/index.test.js
@@ -1,0 +1,179 @@
+import { render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import axios from 'axios';
+import { useAuth0 } from '@auth0/auth0-react';
+import { useLocation } from 'react-router';
+
+import RequestConfigManager from './';
+import useNavigate from '../hooks/useNavigate';
+import { mockStore } from '../__test-helpers/MockStore';
+import { POST_AUTH_SUCCESS } from '../ducks/auth';
+
+jest.mock('axios', () => {
+  const axiosFn = jest.fn();
+  axiosFn.interceptors = {
+    request: { use: jest.fn(() => 1), eject: jest.fn() },
+    response: { use: jest.fn(() => 2), eject: jest.fn() },
+  };
+  axiosFn.defaults = { headers: { common: {} } };
+  const CancelToken = { source: () => ({ token: {}, cancel: jest.fn() }) };
+  axiosFn.CancelToken = CancelToken;
+  return { __esModule: true, default: axiosFn, CancelToken };
+});
+
+jest.mock('@auth0/auth0-react');
+jest.mock('react-router', () => ({ __esModule: true, useLocation: jest.fn() }));
+jest.mock('../hooks/useNavigate');
+
+const renderManager = () => {
+  const store = mockStore({
+    data: {
+      selectedUserProfile: null,
+      user: { id: 'u1' },
+      masterRequestCancelToken: { token: {} },
+      token: { access_token: 'existing.jwt.token' },
+    },
+    view: { userLocationAccessGranted: { granted: false } },
+  });
+
+  render(<Provider store={store}><RequestConfigManager /></Provider>);
+
+  const calls = axios.interceptors.response.use.mock.calls;
+  const [, rejected] = calls[calls.length - 1];
+  return { store, rejected };
+};
+
+const make401 = (configOverrides = {}) => ({
+  response: { status: 401 },
+  config: { headers: {}, url: '/api/v1.0/events', ...configOverrides },
+});
+
+describe('RequestConfigManager 401 handling', () => {
+  let navigate;
+
+  beforeEach(() => {
+    navigate = jest.fn();
+    useLocation.mockReturnValue({ search: '' });
+    useNavigate.mockReturnValue(navigate);
+    useAuth0.mockReturnValue({ getAccessTokenSilently: jest.fn() });
+
+    axios.mockReset();
+    axios.interceptors.request.use.mockClear();
+    axios.interceptors.response.use.mockClear();
+    axios.defaults.headers.common = {};
+    document.cookie = `token=;path=/;expires=${new Date(0).toUTCString()}`;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renews, persists the token, and replays preserving other headers', async () => {
+    const getAccessTokenSilently = jest.fn().mockResolvedValue('new.jwt.token');
+    useAuth0.mockReturnValue({ getAccessTokenSilently });
+    axios.mockResolvedValue({ status: 200, data: 'ok' });
+
+    const { store, rejected } = renderManager();
+    const error = make401({ headers: { 'USER-PROFILE': 'p1', Authorization: 'Bearer old.jwt.token' } });
+    const result = await rejected(error);
+
+    expect(getAccessTokenSilently).toHaveBeenCalledTimes(1);
+    expect(axios).toHaveBeenCalledWith(expect.objectContaining({
+      retriedAfterRefresh: true,
+      headers: expect.objectContaining({
+        'USER-PROFILE': 'p1',
+        Authorization: 'Bearer new.jwt.token',
+      }),
+    }));
+    expect(result).toEqual({ status: 200, data: 'ok' });
+    expect(document.cookie).toContain('token=new.jwt.token');
+    expect(store.getActions()).toContainEqual(
+      expect.objectContaining({
+        type: POST_AUTH_SUCCESS,
+        payload: { data: { access_token: 'new.jwt.token' } },
+      })
+    );
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  test('renews once, replays once, and signs out (no loop) when the replay 401s again', async () => {
+    const getAccessTokenSilently = jest.fn().mockResolvedValue('new.jwt.token');
+    useAuth0.mockReturnValue({ getAccessTokenSilently });
+    axios.mockRejectedValue({ response: { status: 401 } });
+
+    const { rejected } = renderManager();
+
+    await expect(rejected(make401())).rejects.toMatchObject({ response: { status: 401 } });
+    expect(getAccessTokenSilently).toHaveBeenCalledTimes(1);
+    expect(axios).toHaveBeenCalledTimes(1);
+    const replayConfig = axios.mock.calls[0][0];
+    expect(replayConfig.retriedAfterRefresh).toBe(true);
+    expect(navigate).not.toHaveBeenCalled();
+
+    // Re-enter as the interceptor would on the replay's 401: the marker is read,
+    // so there is no second renewal — sign out.
+    await expect(rejected({ response: { status: 401 }, config: replayConfig })).rejects.toBeDefined();
+    expect(getAccessTokenSilently).toHaveBeenCalledTimes(1);
+    expect(axios).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: expect.stringContaining('login') })
+    ));
+  });
+
+  test('signs out and logs when the refresh grant fails', async () => {
+    const renewalError = new Error('login_required');
+    const getAccessTokenSilently = jest.fn().mockRejectedValue(renewalError);
+    useAuth0.mockReturnValue({ getAccessTokenSilently });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { rejected } = renderManager();
+    const error = make401();
+
+    await expect(rejected(error)).rejects.toBe(error);
+    expect(axios).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.any(String), renewalError);
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: expect.stringContaining('login') })
+    ));
+
+    warnSpy.mockRestore();
+  });
+
+  test('a 401 with no config signs out without attempting renewal', async () => {
+    const getAccessTokenSilently = jest.fn();
+    useAuth0.mockReturnValue({ getAccessTokenSilently });
+
+    const { rejected } = renderManager();
+    const error = { response: { status: 401 } };
+
+    await expect(rejected(error)).rejects.toBe(error);
+    expect(getAccessTokenSilently).not.toHaveBeenCalled();
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: expect.stringContaining('login') })
+    ));
+  });
+
+  test('skipAuth requests bypass renewal and sign-out', async () => {
+    const getAccessTokenSilently = jest.fn();
+    useAuth0.mockReturnValue({ getAccessTokenSilently });
+
+    const { rejected } = renderManager();
+    const error = make401({ skipAuth: true });
+
+    await expect(rejected(error)).rejects.toBe(error);
+    expect(getAccessTokenSilently).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  test('non-401 errors pass through untouched', async () => {
+    const getAccessTokenSilently = jest.fn();
+    useAuth0.mockReturnValue({ getAccessTokenSilently });
+
+    const { rejected } = renderManager();
+    const error = { response: { status: 500 }, config: { headers: {} } };
+
+    await expect(rejected(error)).rejects.toBe(error);
+    expect(getAccessTokenSilently).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/ducks/auth.js
+++ b/src/ducks/auth.js
@@ -29,13 +29,15 @@ export const postAuth = (userData) => (dispatch) => {
     });
 };
 
-const postAuthSuccess = response => (dispatch) => {
-  document.cookie = `token=${response.data.access_token};path=/`;
+export const applyAccessToken = accessToken => (dispatch) => {
+  document.cookie = `token=${accessToken};path=/`;
   dispatch({
     type: POST_AUTH_SUCCESS,
-    payload: response,
+    payload: { data: { access_token: accessToken } },
   });
 };
+
+const postAuthSuccess = response => applyAccessToken(response.data.access_token);
 
 export const clearAuth = () => (dispatch) => {
 

--- a/src/index.js
+++ b/src/index.js
@@ -140,6 +140,7 @@ root.render(
           redirect_uri: `${window.location.origin}${REACT_APP_ROUTE_PREFIX}`,
         }}
         cacheLocation="localstorage"
+        useRefreshTokens={true}
       >
         <BrowserRouter>
           <NavigationContextProvider>


### PR DESCRIPTION
**Jira:** https://allenai.atlassian.net/browse/ERA-13539

## What
ER Web (Auth0 / `require_idp` sites) renews access tokens via the rotating `refresh_token` grant instead of silent-iframe auth. Two commits:
- Enable `useRefreshTokens` on `Auth0Provider` (auto-requests `offline_access` → Auth0 issues a rotating refresh token).
- Renew on 401 in `RequestConfigManager`: on a retriable 401, `getAccessTokenSilently()` → persist (cookie + Redux) → replay the request once; on renewal failure or a repeat 401, sign out as before.

## Why
Prerequisite for server-side MFA enforcement (ERA-13387): once Server validates the MFA mirror claims on every access token, the client must renew silently (the mirror claims survive the refresh — verified orgless) rather than force a full re-login every ~2 days. Also cookie-independent / more robust than silent-iframe. Mirrors the mobile fix (EM-2286).

## Scope
Auth0 / `require_idp` deployments only. Legacy `grant_type=password` sites are unaffected (they never use Auth0 renewal; `getAccessTokenSilently` throws → same sign-out as today).

## Verification
- `/oauth/token` now returns a `refresh_token` (auth-test-harness recon / DevTools).
- Org-enforced-MFA refresh path unblocked by PADAS/auth0-platform-management#117 (merged) — the `security-policies` Action now no-ops on `oauth2-refresh-token` grants (without it, org refresh returned `403 mfa_required`).
- 6 `RequestConfigManager` unit tests (renew+replay, loop-guard round-trip, renewal-failure→sign-out, no-config, skipAuth, non-401). Full suite green.

## Reviewer notes (context intentionally kept out of the code)
- **Loop guard:** the replay carries a private, client-only `retriedAfterRefresh` config marker so a repeat 401 can't recurse into another refresh. It rides axios's `mergeConfig` — the same mechanism the existing `skipAuth` flag uses (verified in axios 1.17.0).
- **Don't hand-roll the refresh:** concurrent 401s are safe because `getAccessTokenSilently` is serialized/deduped inside auth0-spa-js (one rotation; others use the cached token). A manual mutex or a direct `/oauth/token` call would risk refresh-token reuse-detection revoking the family.
- **cancelToken:** the replay reuses the master cancel token; a concurrent sign-out could cancel an in-flight replay — benign (we're navigating to login anyway).
- **Storage:** the refresh token lives in localStorage (standard `auth0-spa-js` pattern; consistent with existing token storage).
- **`useRefreshTokensFallback` left `false`** deliberately — a failed refresh surfaces as a clean login redirect, not a silent iframe retry.

## Out of scope / follow-ups
- `mfa_max_age` vs the 2-day access-token lifetime (ERA-13387) — future work.
- Test hardening: an MSW real-axios integration test for the loop-guard round-trip + extracting `handle401Errors` into a pure function — follow-up (not filed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
