### PR TITLE
ERA-13550: playground.staging turns barely unusable when focusing on a high load of events area

### DIFF
--- a/src/EventsLayer/index.js
+++ b/src/EventsLayer/index.js
@@ -280,7 +280,7 @@ const EventsLayer = ({
     </>}
 
     {!!eventPointFeatureCollection?.features?.length && <MapImageFromSvgSpriteRenderer
-      reportFeatureCollection={eventPointFeatureCollection}
+      eventFeatureCollection={eventPointFeatureCollection}
     />}
   </>;
 };

--- a/src/EventsTileLayers/index.js
+++ b/src/EventsTileLayers/index.js
@@ -31,7 +31,7 @@ const EventsTileLayers = ({ onEventClick }) => {
     <EventsClusterSymbolsLayer onEventClick={onEventClick} />
 
     {!!spriteFeatureCollection.features.length && <MapImageFromSvgSpriteRenderer
-      reportFeatureCollection={spriteFeatureCollection}
+      eventFeatureCollection={spriteFeatureCollection}
     />}
   </>;
 };

--- a/src/EventsTileLayers/index.test.js
+++ b/src/EventsTileLayers/index.test.js
@@ -42,7 +42,7 @@ describe('EventsTileLayers', () => {
       overlayFC: featureCollection([point([2, 2], { id: 'overlay-1', icon_id: 'snare', priority: 300 })]),
     });
 
-    const ids = spriteProps.reportFeatureCollection.features.map((f) => f.properties.id);
+    const ids = spriteProps.eventFeatureCollection.features.map((f) => f.properties.id);
     expect(ids).toEqual(expect.arrayContaining(['tile-1', 'overlay-1']));
   });
 

--- a/src/MapImageFromSvgSpriteRenderer/index.js
+++ b/src/MapImageFromSvgSpriteRenderer/index.js
@@ -1,156 +1,143 @@
-import React, { memo, useRef } from 'react';
+import React, { memo, useEffect, useRef } from 'react';
 import axios from 'axios';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { addImageToMapIfNecessary } from '../ducks/map-images';
 import { calcIconColorByPriority } from '../utils/event-types';
 import { calcUrlForImage, imgElFromSrc } from '../utils/img';
-import { addImageToMapIfNecessary } from '../ducks/map-images';
-
 import { DAS_HOST, MAP_ICON_SIZE, MAP_ICON_SCALE } from '../constants';
 
+const EMPTY_FEATURE_COLLECTION = { features: [] };
+
+const isClientError = (status) => typeof status === 'number' && status >= 400 && status < 500;
+
+// Builds the map-image cache key for an event's icon.
 export const calcSvgImageIconId = ({ icon_id, priority, height, width }) => {
-  let string = `${icon_id}`;
-
-  [priority, height, width]
-    .filter(item => item === 0 || !!item)
-    .forEach((item) => {
-      string+=`-${item}`;
-    });
-
-  return string;
+  const variantSuffixParts = [priority, height, width].filter((value) => value === 0 || Boolean(value));
+  return [icon_id, ...variantSuffixParts].join('-');
 };
 
-const fetchSpriteImage = (icon_id) => axios.get(`${DAS_HOST}/static/sprite-src/${icon_id}.svg`,
-  {
+const fetchSpriteSvgMarkup = async (spriteIconId) => {
+  const response = await axios.get(`${DAS_HOST}/static/sprite-src/${spriteIconId}.svg`, {
     headers: {
       Accept: 'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8',
     },
     responseType: 'text',
-  }
-);
+  });
 
-const imageElFromSvgString = (svgString, report) => {
+  return response.data;
+};
 
-  const { height, priority, width = MAP_ICON_SIZE } = report;
-  const color = calcIconColorByPriority(priority);
+const calcScaledIconDimensions = ({ height, width = MAP_ICON_SIZE }) => [
+  width * MAP_ICON_SCALE,
+  height ? height * MAP_ICON_SCALE : undefined,
+];
 
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(svgString, 'image/svg+xml');
-  const svgEl = doc.documentElement;
+// Recolors an event icon's SVG markup for the event's priority and rasterizes
+// it into an <img> element via a data URI.
+const renderColoredIconImage = (svgMarkup, event) => {
+  const color = calcIconColorByPriority(event.priority);
+
+  const svgEl = new DOMParser().parseFromString(svgMarkup, 'image/svg+xml').documentElement;
 
   svgEl.style.fill = `${color} !important`;
   svgEl.setAttribute('fill', color);
 
-  const svgContent = svgEl.querySelectorAll('*');
-
-  svgContent.forEach((item) => {
-    const attributesToRemove = ['class', 'style', 'fill', 'stroke'];
-    attributesToRemove.forEach(attr => item.removeAttribute(attr));
+  svgEl.querySelectorAll('*').forEach((node) => {
+    ['class', 'style', 'fill', 'stroke'].forEach((attribute) => node.removeAttribute(attribute));
   });
 
-  var xml = (new XMLSerializer()).serializeToString(svgEl);
-  const withStyleElRemoved = xml.replace(/<style>.*?<\/style>/g, '');
+  const serializedSvg = new XMLSerializer()
+    .serializeToString(svgEl)
+    .replace(/<style>.*?<\/style>/g, '');
 
-  const blob = new Blob([withStyleElRemoved], { type: 'image/svg+xml' });
-  const url = URL.createObjectURL(blob);
+  const dataUri = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(serializedSvg)}`;
 
-  return imgElFromSrc(
-    url,
-    width * MAP_ICON_SCALE,
-    (height ? (height * MAP_ICON_SCALE) : undefined),
-  );
+  return imgElFromSrc(dataUri, ...calcScaledIconDimensions(event));
 };
 
-const getImageAssemblyDataFromReport = (report) => {
-  const reportTypeIconId = report.icon_id || 'generic';
-  const icon_id = calcSvgImageIconId(report);
-  const color = calcIconColorByPriority(report.priority);
+const renderFallbackEventImage = (event) => imgElFromSrc(calcUrlForImage(event.image), ...calcScaledIconDimensions(event));
 
-  return { color, report, icon_id, reportTypeIconId };
-};
+const MapImageFromSvgSpriteRenderer = ({ eventFeatureCollection = EMPTY_FEATURE_COLLECTION }) => {
+  const dispatch = useDispatch();
+  const mapImages = useSelector((state) => state.view.mapImages);
 
-const MapImageFromSvgSpriteRenderer = (props) => {
-  const { addImageToMapIfNecessary, mapImages, reportFeatureCollection = { features: [] } } = props;
+  const spriteMarkupCache = useRef({});
+  const spriteFetchesInFlight = useRef({});
+  const iconsBeingGenerated = useRef(new Set());
 
-  const reports = reportFeatureCollection.features.map(({ properties }) => properties);
-  const spriteCache = useRef({});
-  const ongoingRequests = useRef({});
+  useEffect(() => {
+    const getSpriteSvgMarkup = (spriteIconId) => {
+      if (spriteMarkupCache.current[spriteIconId]) {
+        return Promise.resolve(spriteMarkupCache.current[spriteIconId]);
+      }
 
-  const reportImageAssemblyData = reports
-    .map(getImageAssemblyDataFromReport)
-    .filter(({ icon_id }) => !mapImages[icon_id]);
+      if (!spriteFetchesInFlight.current[spriteIconId]) {
+        spriteFetchesInFlight.current[spriteIconId] = (async () => {
+          try {
+            const svgMarkup = await fetchSpriteSvgMarkup(spriteIconId);
+            spriteMarkupCache.current[spriteIconId] = svgMarkup;
+            return svgMarkup;
+          } finally {
+            delete spriteFetchesInFlight.current[spriteIconId];
+          }
+        })();
+      }
 
-  const toRequest = reportImageAssemblyData
-    .filter(({ reportTypeIconId }) =>
-      !spriteCache.current[reportTypeIconId]
-    );
+      return spriteFetchesInFlight.current[spriteIconId];
+    };
 
-  const toGenerateFromCache = reportImageAssemblyData
-    .filter(({ reportTypeIconId }) =>
-      !!spriteCache.current[reportTypeIconId]
-    );
-
-  toRequest.forEach(({ report, icon_id, reportTypeIconId }) => {
-    if (!ongoingRequests.current[reportTypeIconId]) {
-      ongoingRequests.current[reportTypeIconId] = fetchSpriteImage(reportTypeIconId);
-    }
-
-    ongoingRequests.current[reportTypeIconId]
-      .then((response) => {
-        spriteCache.current[reportTypeIconId] = response.data;
-
-        return imageElFromSvgString(response.data, report);
-      })
-      .then((image) => {
-        addImageToMapIfNecessary({ icon_id, image });
-      })
-      .catch((error) => {
-        if (/4[0-9][0-9]/.test(error?.response?.status)) {
-          /* not in the sprite, fetch from the url instead */
-          const iconSrc = calcUrlForImage(report.image);
-
-          const { height, width = MAP_ICON_SIZE } = report;
-
-          imgElFromSrc(
-            iconSrc,
-            width * MAP_ICON_SCALE,
-            (height ? (height * MAP_ICON_SCALE) : undefined),
-          )
-            .then((image) => {
-              addImageToMapIfNecessary({ icon_id, image });
-            })
-            .catch((error) => {
-              console.warn('imgElFromSrc error', error);
-            });
-
-
+    const resolveAndRegisterIcon = async ({ event, iconVariantId, spriteIconId }) => {
+      try {
+        const svgMarkup = await getSpriteSvgMarkup(spriteIconId);
+        const image = await renderColoredIconImage(svgMarkup, event);
+        dispatch(addImageToMapIfNecessary({ icon_id: iconVariantId, image }));
+      } catch (error) {
+        if (isClientError(error?.response?.status)) {
+          try {
+            const image = await renderFallbackEventImage(event);
+            dispatch(addImageToMapIfNecessary({ icon_id: iconVariantId, image }));
+          } catch (fallbackError) {
+            console.warn('map icon fallback image failed to load', fallbackError);
+          }
         } else {
-          delete spriteCache.current[reportTypeIconId];
-          console.warn('error generating image for report', error);
+          // the fetched markup itself may be what's causing generation to
+          // fail. Drop it so the next attempt re-fetches from the server
+          // instead of repeating the same failure.
+          delete spriteMarkupCache.current[spriteIconId];
+          console.warn('failed to generate map icon from sprite', error);
         }
-      })
-      .finally(() => {
-        delete ongoingRequests.current[reportTypeIconId];
-      });
+      } finally {
+        iconsBeingGenerated.current.delete(iconVariantId);
+      }
+    };
 
-  });
+    // Many events share the same icon variant (event type + priority + size),
+    // so only one generation task is queued per distinct variant.
+    const iconTasksByVariantId = new Map();
 
-  toGenerateFromCache.forEach(({ icon_id, reportTypeIconId, report }) => {
-    imageElFromSvgString(spriteCache.current[reportTypeIconId], report)
-      .then((image) => {
-        addImageToMapIfNecessary({ icon_id, image });
-      })
-      .catch((error) => {
-        console.warn('error generating image from cache', error);
-      });
-  });
+    eventFeatureCollection.features.forEach(({ properties: event }) => {
+      const iconVariantId = calcSvgImageIconId(event);
+      const alreadyHandled = mapImages[iconVariantId]
+        || iconsBeingGenerated.current.has(iconVariantId)
+        || iconTasksByVariantId.has(iconVariantId);
+
+      if (!alreadyHandled) {
+        iconTasksByVariantId.set(iconVariantId, {
+          event,
+          iconVariantId,
+          spriteIconId: event.icon_id || 'generic',
+        });
+      }
+    });
+
+    iconTasksByVariantId.forEach((task) => {
+      iconsBeingGenerated.current.add(task.iconVariantId);
+      resolveAndRegisterIcon(task);
+    });
+  }, [eventFeatureCollection, mapImages, dispatch]);
 
   return null;
-
 };
 
-const mapStateToProps = ({ view: { mapImages } }) => ({
-  mapImages,
-});
-
-
-export default connect(mapStateToProps, { addImageToMapIfNecessary })(memo(MapImageFromSvgSpriteRenderer));
+export default memo(MapImageFromSvgSpriteRenderer);

--- a/src/MapImageFromSvgSpriteRenderer/index.js
+++ b/src/MapImageFromSvgSpriteRenderer/index.js
@@ -11,9 +11,10 @@ const EMPTY_FEATURE_COLLECTION = { features: [] };
 
 const isClientError = (status) => typeof status === 'number' && status >= 400 && status < 500;
 
-// Builds the map-image cache key for an event's icon.
-export const calcSvgImageIconId = ({ icon_id, priority, height, width }) => {
-  const variantSuffixParts = [priority, height, width].filter((value) => value === 0 || Boolean(value));
+// Builds the map-image cache key for an event's icon. Must match the suffix order
+// used by the Mapbox icon-image expressions (icon_id-priority-width-height).
+export const calcSvgImageIconId = ({ icon_id, priority, width, height }) => {
+  const variantSuffixParts = [priority, width, height].filter((value) => value === 0 || Boolean(value));
   return [icon_id, ...variantSuffixParts].join('-');
 };
 

--- a/src/MapImageFromSvgSpriteRenderer/index.test.js
+++ b/src/MapImageFromSvgSpriteRenderer/index.test.js
@@ -37,8 +37,8 @@ describe('calcSvgImageIconId', () => {
     expect(calcSvgImageIconId({ icon_id: 'fire', priority: 0 })).toBe('fire-0');
   });
 
-  it('appends height and width when provided, alongside priority', () => {
-    expect(calcSvgImageIconId({ icon_id: 'fire', priority: 200, height: 32, width: 24 })).toBe('fire-200-32-24');
+  it('appends width and height when provided, alongside priority, matching the icon-image expression order', () => {
+    expect(calcSvgImageIconId({ icon_id: 'fire', priority: 200, height: 32, width: 24 })).toBe('fire-200-24-32');
   });
 });
 

--- a/src/MapImageFromSvgSpriteRenderer/index.test.js
+++ b/src/MapImageFromSvgSpriteRenderer/index.test.js
@@ -1,0 +1,300 @@
+import React from 'react';
+import axios from 'axios';
+import { act, render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { featureCollection, point } from '@turf/turf';
+
+import { mockStore } from '../__test-helpers/MockStore';
+import { calcUrlForImage, ImageCache } from '../utils/img';
+
+import MapImageFromSvgSpriteRenderer, { calcSvgImageIconId } from './';
+
+jest.mock('axios');
+
+const SVG_MARKUP = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>';
+
+const featureCollectionFromEvents = (events) =>
+  featureCollection(events.map((event, index) => point([index, index], event)));
+
+// Real-timer flush (rather than a fixed number of `await Promise.resolve()` chains) so tests
+// don't need to hand-count microtask hops through nested async/await + reject/fallback paths.
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const dispatchedIconIdsFrom = (store) => store.getActions()
+  .filter((action) => action.type === 'ADD_IMAGE_TO_MAP_IF_NECESSARY')
+  .map((action) => action.payload.data.icon_id);
+
+describe('calcSvgImageIconId', () => {
+  it('returns the base icon_id when no priority, height, or width are provided', () => {
+    expect(calcSvgImageIconId({ icon_id: 'fire' })).toBe('fire');
+  });
+
+  it('appends priority to the base icon_id', () => {
+    expect(calcSvgImageIconId({ icon_id: 'fire', priority: 200 })).toBe('fire-200');
+  });
+
+  it('treats a priority of 0 as a meaningful value rather than omitting it', () => {
+    expect(calcSvgImageIconId({ icon_id: 'fire', priority: 0 })).toBe('fire-0');
+  });
+
+  it('appends height and width when provided, alongside priority', () => {
+    expect(calcSvgImageIconId({ icon_id: 'fire', priority: 200, height: 32, width: 24 })).toBe('fire-200-32-24');
+  });
+});
+
+describe('MapImageFromSvgSpriteRenderer', () => {
+  let loadCallbacks;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    ImageCache.instance = null;
+
+    loadCallbacks = [];
+
+    global.URL.createObjectURL = jest.fn();
+    global.URL.revokeObjectURL = jest.fn();
+
+    global.Image = jest.fn(() => {
+      const img = {
+        setAttribute: jest.fn(),
+        addEventListener: jest.fn((event, callback) => {
+          if (event === 'load') loadCallbacks.push(callback);
+        }),
+        onerror: null,
+        naturalWidth: 24,
+        naturalHeight: 24,
+        width: 0,
+        height: 0,
+        src: '',
+      };
+      return img;
+    });
+
+    axios.get.mockResolvedValue({ data: SVG_MARKUP });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('generates one icon per unique icon_id instead of one per event', async () => {
+    const sharedEvent = { icon_id: 'fire', priority: 200, height: 32 };
+    const store = mockStore({ view: { mapImages: {} } });
+
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <MapImageFromSvgSpriteRenderer
+            eventFeatureCollection={featureCollectionFromEvents([sharedEvent, sharedEvent, sharedEvent])}
+          />
+        </Provider>
+      );
+      await flushPromises();
+    });
+
+    // three events share one icon_id, so the sprite should be fetched and rendered only once
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    expect(global.Image).toHaveBeenCalledTimes(1);
+
+    // icons are generated as deterministic data URIs, not Blob object URLs that would need revoking
+    expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+    expect(global.Image.mock.results[0].value.src).toMatch(/^data:image\/svg\+xml/);
+
+    await act(async () => {
+      loadCallbacks.forEach((callback) => callback());
+      await flushPromises();
+    });
+
+    expect(dispatchedIconIdsFrom(store)).toEqual([calcSvgImageIconId(sharedEvent)]);
+  });
+
+  it('does not regenerate an icon that is already present in the mapImages store', async () => {
+    const event = { icon_id: 'fire', priority: 200 };
+    const iconId = calcSvgImageIconId(event);
+    const store = mockStore({ view: { mapImages: { [iconId]: { image: 'cached', options: {} } } } });
+
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <MapImageFromSvgSpriteRenderer eventFeatureCollection={featureCollectionFromEvents([event])} />
+        </Provider>
+      );
+      await flushPromises();
+    });
+
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(global.Image).not.toHaveBeenCalled();
+  });
+
+  it('reuses cached sprite markup across renders for a new priority variant of the same icon type', async () => {
+    const store = mockStore({ view: { mapImages: {} } });
+    const firstEvent = { icon_id: 'fire', priority: 200 };
+    const secondEvent = { icon_id: 'fire', priority: 300 };
+
+    const { rerender } = render(
+      <Provider store={store}>
+        <MapImageFromSvgSpriteRenderer eventFeatureCollection={featureCollectionFromEvents([firstEvent])} />
+      </Provider>
+    );
+
+    await act(async () => {
+      await flushPromises();
+      loadCallbacks.forEach((callback) => callback());
+      await flushPromises();
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      rerender(
+        <Provider store={store}>
+          <MapImageFromSvgSpriteRenderer eventFeatureCollection={featureCollectionFromEvents([secondEvent])} />
+        </Provider>
+      );
+      await flushPromises();
+    });
+
+    // the new priority variant shares its base icon with the already-resolved one, so its sprite
+    // markup is served from spriteMarkupCache instead of triggering a second sprite fetch
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    expect(global.Image).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares one in-flight sprite fetch across different priority variants of the same icon type', async () => {
+    let resolveAxiosGet;
+    axios.get.mockReturnValueOnce(new Promise((resolve) => {
+      resolveAxiosGet = resolve;
+    }));
+
+    const lowPriorityEvent = { icon_id: 'fire', priority: 100 };
+    const highPriorityEvent = { icon_id: 'fire', priority: 300 };
+    const store = mockStore({ view: { mapImages: {} } });
+
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <MapImageFromSvgSpriteRenderer
+            eventFeatureCollection={featureCollectionFromEvents([lowPriorityEvent, highPriorityEvent])}
+          />
+        </Provider>
+      );
+      await flushPromises();
+    });
+
+    // both variants requested the sprite before it resolved, so only one request should exist
+    expect(axios.get).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveAxiosGet({ data: SVG_MARKUP });
+      await flushPromises();
+    });
+
+    // each variant still gets its own rendered (differently colored) icon from the shared markup
+    expect(global.Image).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders nothing and fetches nothing when no eventFeatureCollection prop is given', async () => {
+    const store = mockStore({ view: { mapImages: {} } });
+
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <MapImageFromSvgSpriteRenderer />
+        </Provider>
+      );
+      await flushPromises();
+    });
+
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(global.Image).not.toHaveBeenCalled();
+  });
+
+  it('looks up the "generic" sprite for events with no icon_id of their own', async () => {
+    const event = { priority: 200 };
+    const store = mockStore({ view: { mapImages: {} } });
+
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <MapImageFromSvgSpriteRenderer eventFeatureCollection={featureCollectionFromEvents([event])} />
+        </Provider>
+      );
+      await flushPromises();
+    });
+
+    expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/generic.svg'), expect.anything());
+  });
+
+  it('falls back to the event\'s own image when the event type has no sprite entry', async () => {
+    axios.get.mockRejectedValueOnce({ response: { status: 404 } });
+
+    const event = { icon_id: 'custom-marker', priority: 100, image: 'custom-marker.png' };
+    const store = mockStore({ view: { mapImages: {} } });
+
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <MapImageFromSvgSpriteRenderer eventFeatureCollection={featureCollectionFromEvents([event])} />
+        </Provider>
+      );
+      await flushPromises();
+    });
+
+    await act(async () => {
+      loadCallbacks.forEach((callback) => callback());
+      await flushPromises();
+    });
+
+    expect(global.Image).toHaveBeenCalledTimes(1);
+    expect(global.Image.mock.results[0].value.src).toBe(calcUrlForImage(event.image));
+    expect(dispatchedIconIdsFrom(store)).toEqual([calcSvgImageIconId(event)]);
+  });
+
+  it('logs a warning and drops the sprite cache entry when the sprite fetch fails for a non-4xx reason', async () => {
+    axios.get.mockRejectedValueOnce(new Error('network error'));
+
+    const event = { icon_id: 'fire', priority: 200 };
+    const store = mockStore({ view: { mapImages: {} } });
+
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <MapImageFromSvgSpriteRenderer eventFeatureCollection={featureCollectionFromEvents([event])} />
+        </Provider>
+      );
+      await flushPromises();
+    });
+
+    expect(console.warn).toHaveBeenCalledWith('failed to generate map icon from sprite', expect.any(Error));
+    expect(global.Image).not.toHaveBeenCalled();
+    expect(dispatchedIconIdsFrom(store)).toEqual([]);
+  });
+
+  it('logs a warning when the fallback event image also fails to load', async () => {
+    axios.get.mockRejectedValueOnce({ response: { status: 404 } });
+
+    const event = { icon_id: 'custom-marker', priority: 100, image: 'custom-marker.png' };
+    const store = mockStore({ view: { mapImages: {} } });
+
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <MapImageFromSvgSpriteRenderer eventFeatureCollection={featureCollectionFromEvents([event])} />
+        </Provider>
+      );
+      await flushPromises();
+    });
+
+    await act(async () => {
+      const [fallbackImage] = global.Image.mock.results.map((result) => result.value);
+      fallbackImage.onerror(new Error('fallback image failed'));
+      await flushPromises();
+    });
+
+    expect(console.warn).toHaveBeenCalledWith('map icon fallback image failed to load', expect.any(String));
+    expect(dispatchedIconIdsFrom(store)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What does this PR do?
Optimize `MapImageFromSvgSpriteRenderer` to avoid one object URL per each event icon and instead keep in memory each icon only once.

### Relevant link(s)
- [ERA-13550](https://allenai.atlassian.net/browse/ERA-13550)


[ERA-13550]: https://allenai.atlassian.net/browse/ERA-13550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ