### PR TITLE
ERA-13575: Icons in event cluster show a broken image even if the event icon is visible in the map

### DIFF
--- a/src/LayerSelectorPopup/index.js
+++ b/src/LayerSelectorPopup/index.js
@@ -3,10 +3,11 @@ import { center } from '@turf/turf';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
-import { calcImgIdFromUrlForMapImages, calcUrlForImage } from '../utils/img';
+import { calcImgIdFromUrlForMapImages, calcSpriteSvgUrl, calcUrlForImage } from '../utils/img';
+import { calcSvgImageIconId } from '../MapImageFromSvgSpriteRenderer';
 import { createFeatureCollectionFromEvents } from '../utils/map';
-import { hidePopup } from '../ducks/popup';
 import { GEAR_FEATURE_CONTENT_TYPE, SUBJECT_FEATURE_CONTENT_TYPE } from '../constants';
+import { hidePopup } from '../ducks/popup';
 import { subjectIsStatic } from '../utils/subjects';
 
 import SearchBar from '../SearchBar';
@@ -26,14 +27,24 @@ const LayerSelectorPopup = ({ data, id }) => {
   const { layers: layerList, onSelectEvent, onSelectGear, onSelectSubject } = data;
   const showFilterInput = layerList.length > 5;
 
-  // Event features from the vector tile lack the flattened props this popup
-  // needs, so hydrate them from the event store.
+  // Event features from the vector tile carry an unreliable image/image_url,
+  // so always prefer the event store's flattened props when the event is
+  // loaded there.
   const hydratedLayerList = useMemo(() => layerList.map((layer) => {
     const eventId = layer.properties?.id;
     const storeEvent = eventId && eventStore?.[eventId];
-    if (!layer.properties?.display_title && storeEvent) {
-      const [hydrated] = createFeatureCollectionFromEvents([storeEvent], eventTypes ?? []).features;
-      return hydrated ?? layer;
+    const [hydrated] = storeEvent
+      ? createFeatureCollectionFromEvents([storeEvent], eventTypes ?? []).features
+      : [];
+    if (hydrated) {
+      return hydrated;
+    }
+
+    if (layer.properties?.icon_id && layer.properties?.event_type) {
+      return {
+        ...layer,
+        properties: { ...layer.properties, image: calcSpriteSvgUrl(layer.properties.icon_id) },
+      };
     }
     return layer;
   }), [layerList, eventStore, eventTypes]);
@@ -76,9 +87,12 @@ const LayerSelectorPopup = ({ data, id }) => {
 
     return filteredLayerList.map((layer) => {
       const isGearLayerItem = layer.properties?.content_type === GEAR_FEATURE_CONTENT_TYPE;
-      const imageinStore = !isGearLayerItem && mapImages[
-        calcImgIdFromUrlForMapImages(layer.properties.image, layer.properties.height, layer.properties.width)
-      ];
+      const isEventLayerItem = !!layer.properties?.icon_id && !!layer.properties?.event_type;
+
+      const mapImagesKey = isEventLayerItem
+        ? calcSvgImageIconId(layer.properties)
+        : calcImgIdFromUrlForMapImages(layer.properties.image, layer.properties.height, layer.properties.width);
+      const imageinStore = !isGearLayerItem && mapImages[mapImagesKey];
       const imgSrc = imageinStore
         ? imageinStore.image.src
         : calcUrlForImage(layer.properties.image || layer.properties.image_url);

--- a/src/LayerSelectorPopup/index.test.js
+++ b/src/LayerSelectorPopup/index.test.js
@@ -153,4 +153,221 @@ describe('LayerSelectorPopup', () => {
     expect(onSelectEvent).toHaveBeenCalledTimes(1);
     expect(onSelectEvent.mock.calls[0][0].layer.properties.id).toBe('60e98094-4f5d-4e91-8b7c-1cef1775109d');
   });
+
+  test('hydrates the icon for vector-tile event features from the event store, overriding the tile\'s own bogus image', async () => {
+    const eventId = 'tile-event-id';
+    const imageUrl = 'https://develop.pamdas.org/static/sprite-src/jenaeonefield.svg';
+
+    const tileEventLayer = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [0, 0] },
+      properties: {
+        id: eventId,
+        display_title: 'k6_event_24231\nJul 03, 08:59 UTC',
+        event_type: 'jenaeonefield',
+        icon_id: 'jenaeonefield',
+        // The vector tile's own image/image_url is not a fetchable icon URL
+        // (e.g. a bogus "icon-rep-amber.svg" slug) and must not be trusted.
+        image: 'https://develop.pamdas.org/static/sprite-src/jenaeonefield-rep-amber.svg',
+      },
+    };
+
+    const storeEvent = {
+      id: eventId,
+      title: 'k6_event_24231',
+      event_type: 'jenaeonefield',
+      geojson: {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [0, 0] },
+        properties: { image: imageUrl },
+      },
+    };
+
+    const tileStore = mockStore({
+      view: { mapImages: [] },
+      data: { eventStore: { [eventId]: storeEvent }, eventTypes: [] },
+    });
+
+    const data = {
+      layers: [tileEventLayer],
+      onSelectSubject,
+      onSelectEvent,
+      onSelectPoint,
+    };
+    render(
+      <Provider store={tileStore}>
+        <LayerSelectorPopup data={data} id={uuid()} />
+      </Provider>
+    );
+
+    const image = await screen.findByRole('img');
+    expect(image.getAttribute('src')).toBe(imageUrl);
+  });
+
+  test('falls back to the icon sprite source URL for vector-tile event features not yet in the event store', async () => {
+    const eventId = 'tile-only-event-id';
+
+    const tileEventLayer = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [0, 0] },
+      properties: {
+        id: eventId,
+        display_title: 'k6_event_99999\nJul 03, 08:59 UTC',
+        event_type: 'jenaeonefield',
+        icon_id: 'jenaeonefield',
+        image: 'https://develop.pamdas.org/static/sprite-src/jenaeonefield-rep-amber.svg',
+      },
+    };
+
+    const tileStore = mockStore({
+      view: { mapImages: [] },
+      data: { eventStore: {}, eventTypes: [] },
+    });
+
+    const data = {
+      layers: [tileEventLayer],
+      onSelectSubject,
+      onSelectEvent,
+      onSelectPoint,
+    };
+    render(
+      <Provider store={tileStore}>
+        <LayerSelectorPopup data={data} id={uuid()} />
+      </Provider>
+    );
+
+    const image = await screen.findByRole('img');
+    expect(image.getAttribute('src')).toContain('/static/sprite-src/jenaeonefield.svg');
+  });
+
+  test('uses the priority-colored icon already cached by MapImageFromSvgSpriteRenderer, when available', async () => {
+    const eventId = 'tile-only-event-id';
+    const coloredIconSrc = 'data:image/svg+xml;charset=utf-8,colored-icon';
+
+    const tileEventLayer = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [0, 0] },
+      properties: {
+        id: eventId,
+        display_title: 'k6_event_99999\nJul 03, 08:59 UTC',
+        event_type: 'jenaeonefield',
+        icon_id: 'jenaeonefield',
+        priority: 200,
+        image: 'https://develop.pamdas.org/static/sprite-src/jenaeonefield-rep-amber.svg',
+      },
+    };
+
+    const tileStore = mockStore({
+      view: { mapImages: { 'jenaeonefield-200': { image: { src: coloredIconSrc } } } },
+      data: { eventStore: {}, eventTypes: [] },
+    });
+
+    const data = {
+      layers: [tileEventLayer],
+      onSelectSubject,
+      onSelectEvent,
+      onSelectPoint,
+    };
+    render(
+      <Provider store={tileStore}>
+        <LayerSelectorPopup data={data} id={uuid()} />
+      </Provider>
+    );
+
+    const image = await screen.findByRole('img');
+    expect(image.getAttribute('src')).toBe(coloredIconSrc);
+  });
+
+  test('falls back to the icon sprite source URL when the matching store event has no geojson yet', async () => {
+    const eventId = 'store-event-without-geojson';
+
+    const tileEventLayer = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [0, 0] },
+      properties: {
+        id: eventId,
+        display_title: 'k6_event_11111\nJul 03, 08:59 UTC',
+        event_type: 'jenaeonefield',
+        icon_id: 'jenaeonefield',
+        image: 'https://develop.pamdas.org/static/sprite-src/jenaeonefield-rep-amber.svg',
+      },
+    };
+
+    // A store event without a `geojson` property is filtered out by
+    // createFeatureCollectionFromEvents, so hydration yields nothing here.
+    const storeEvent = { id: eventId, title: 'k6_event_11111', event_type: 'jenaeonefield' };
+
+    const tileStore = mockStore({
+      view: { mapImages: [] },
+      data: { eventStore: { [eventId]: storeEvent }, eventTypes: [] },
+    });
+
+    const data = {
+      layers: [tileEventLayer],
+      onSelectSubject,
+      onSelectEvent,
+      onSelectPoint,
+    };
+    render(
+      <Provider store={tileStore}>
+        <LayerSelectorPopup data={data} id={uuid()} />
+      </Provider>
+    );
+
+    const image = await screen.findByRole('img');
+    expect(image.getAttribute('src')).toContain('/static/sprite-src/jenaeonefield.svg');
+  });
+
+  test('uses the cached colored icon for a hydrated store event that carries icon_id/event_type', async () => {
+    const eventId = 'hydrated-event-with-icon-id';
+    const coloredIconSrc = 'data:image/svg+xml;charset=utf-8,colored-icon';
+
+    const tileEventLayer = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [0, 0] },
+      properties: {
+        id: eventId,
+        display_title: 'k6_event_22222\nJul 03, 08:59 UTC',
+        event_type: 'jenaeonefield',
+        icon_id: 'jenaeonefield',
+        image: 'https://develop.pamdas.org/static/sprite-src/jenaeonefield-rep-amber.svg',
+      },
+    };
+
+    // Real events returned by the API carry icon_id/priority at the top
+    // level, which addPropsToGeoJsonByKey flattens onto the hydrated
+    // feature's properties alongside event_type.
+    const storeEvent = {
+      id: eventId,
+      title: 'k6_event_22222',
+      event_type: 'jenaeonefield',
+      icon_id: 'jenaeonefield',
+      priority: 200,
+      geojson: {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [0, 0] },
+        properties: {},
+      },
+    };
+
+    const tileStore = mockStore({
+      view: { mapImages: { 'jenaeonefield-200': { image: { src: coloredIconSrc } } } },
+      data: { eventStore: { [eventId]: storeEvent }, eventTypes: [] },
+    });
+
+    const data = {
+      layers: [tileEventLayer],
+      onSelectSubject,
+      onSelectEvent,
+      onSelectPoint,
+    };
+    render(
+      <Provider store={tileStore}>
+        <LayerSelectorPopup data={data} id={uuid()} />
+      </Provider>
+    );
+
+    const image = await screen.findByRole('img');
+    expect(image.getAttribute('src')).toBe(coloredIconSrc);
+  });
 });

--- a/src/MapImageFromSvgSpriteRenderer/index.js
+++ b/src/MapImageFromSvgSpriteRenderer/index.js
@@ -4,8 +4,8 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { addImageToMapIfNecessary } from '../ducks/map-images';
 import { calcIconColorByPriority } from '../utils/event-types';
-import { calcUrlForImage, imgElFromSrc } from '../utils/img';
-import { DAS_HOST, MAP_ICON_SIZE, MAP_ICON_SCALE } from '../constants';
+import { calcSpriteSvgUrl, calcUrlForImage, imgElFromSrc } from '../utils/img';
+import { MAP_ICON_SIZE, MAP_ICON_SCALE } from '../constants';
 
 const EMPTY_FEATURE_COLLECTION = { features: [] };
 
@@ -19,7 +19,7 @@ export const calcSvgImageIconId = ({ icon_id, priority, width, height }) => {
 };
 
 const fetchSpriteSvgMarkup = async (spriteIconId) => {
-  const response = await axios.get(`${DAS_HOST}/static/sprite-src/${spriteIconId}.svg`, {
+  const response = await axios.get(calcSpriteSvgUrl(spriteIconId), {
     headers: {
       Accept: 'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8',
     },

--- a/src/utils/img.js
+++ b/src/utils/img.js
@@ -176,6 +176,8 @@ export const calcImgIdFromUrlForMapImages = (src, width = null, height = null) =
   return `${path}-${width ? width : 'x'}-${height ? height : 'x'}`;
 };
 
+export const calcSpriteSvgUrl = (iconId) => `${DAS_HOST}/static/sprite-src/${iconId}.svg`;
+
 export const calcUrlForImage = imagePath => {
   if (!imagePath) {
     return null;

--- a/src/utils/patrols.js
+++ b/src/utils/patrols.js
@@ -14,8 +14,10 @@ import cloneDeep from 'lodash/cloneDeep';
 import isUndefined from 'lodash/isUndefined';
 import isNil from 'lodash/isNil';
 
-import { DAS_HOST, PATROL_UI_STATES, PATROL_API_STATES } from '../constants';
+import { calcSpriteSvgUrl } from './img';
 import { format, getCurrentLocale, SHORT_TIME_FORMAT } from './datetime';
+import { PATROL_UI_STATES, PATROL_API_STATES } from '../constants';
+
 import TimeAgo from '../TimeAgo';
 
 import store from '../store';
@@ -495,7 +497,7 @@ export const makePatrolPointFromFeature = (label, coordinates, icon_id, stroke, 
 
   const properties = {
     stroke,
-    image: `${DAS_HOST}/static/sprite-src/${icon_id}.svg`,
+    image: calcSpriteSvgUrl(icon_id),
     name: label,
     title: label,
     time: time,


### PR DESCRIPTION
## What does this PR do?
Enhance `LayerSelectorPopup` to hydrate vector-tile event features with reliable image sources

- Updated `LayerSelectorPopup` to prefer event store properties over vector tile properties for event features.
- Introduced `calcSpriteSvgUrl` utility for consistent sprite URL generation.
- Added tests to verify hydration of event features and fallback mechanisms for icon sources.

### Relevant link(s)
- [ERA-13575](https://allenai.atlassian.net/browse/ERA-13575)


[ERA-13575]: https://allenai.atlassian.net/browse/ERA-13575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ