### PR TITLE
Refactor cluster marker tests and enhance icon resolution logic

### DIFF
--- a/src/ClustersLayer/index.test.js
+++ b/src/ClustersLayer/index.test.js
@@ -152,7 +152,7 @@ describe('ClustersLayer', () => {
       });
     });
 
-    test('refreshes a cluster marker\'s icon in place once a missing member icon becomes available in mapImages, with no new sourcedata event', async () => {
+    test('withholds a cluster marker until all its displayed icons resolve in mapImages, rather than showing a guessed placeholder', async () => {
       unmount();
       mapMarkers.length = 0;
 
@@ -170,26 +170,21 @@ describe('ClustersLayer', () => {
       ));
       map.__test__.fireHandlers('sourcedata', { sourceId: CLUSTERS_SOURCE_ID });
 
-      let clusterMarkerBuiltWhileIncomplete;
+      // Only the cluster whose icons are already resolved gets a marker.
       await waitFor(() => {
-        expect(mapMarkers).toHaveLength(2);
-        clusterMarkerBuiltWhileIncomplete = mapMarkers[1];
+        expect(mapMarkers).toHaveLength(1);
       });
 
-      // The icon resolves and mapImages updates.
+      // The missing icon resolves and mapImages updates.
       renderWithMapImages(fullMapImages);
 
       await waitFor(() => {
-        // The marker is refreshed in place rather than torn down and rebuilt —
-        // rebuilding would drop any hover listener bound to the old element
-        // and could leave a cluster highlight polygon stuck on the map.
         expect(mapMarkers).toHaveLength(2);
-        expect(mapMarkers[1]).toBe(clusterMarkerBuiltWhileIncomplete);
         expect(mapMarkers[1].innerHTML).not.toContain(calcSpriteSvgUrl('jenaeonefield'));
       });
     });
 
-    test('does not rebuild a not-yet-ready cluster marker on unrelated mapImages updates', async () => {
+    test('does not create a marker for a still-not-ready cluster on unrelated mapImages updates', async () => {
       unmount();
       mapMarkers.length = 0;
 
@@ -207,20 +202,17 @@ describe('ClustersLayer', () => {
       ));
       map.__test__.fireHandlers('sourcedata', { sourceId: CLUSTERS_SOURCE_ID });
 
-      let notReadyClusterMarker;
       await waitFor(() => {
-        expect(mapMarkers).toHaveLength(2);
-        notReadyClusterMarker = mapMarkers[1];
+        expect(mapMarkers).toHaveLength(1);
       });
 
       // An unrelated icon resolves elsewhere on the map — the cluster's own
-      // missing icon ('jenaeonefield-200') is still not present, so its
-      // marker must not be torn down and rebuilt on this change.
+      // missing icon ('jenaeonefield-200') is still not present, so no marker
+      // should be created for it yet.
       renderWithMapImages({ ...incompleteMapImages, 'unrelated_icon-100': { image: document.createElement('img') } });
 
       await waitFor(() => {
-        expect(mapMarkers).toHaveLength(2);
-        expect(mapMarkers[1]).toBe(notReadyClusterMarker);
+        expect(mapMarkers).toHaveLength(1);
       });
     });
 

--- a/src/ClustersLayer/utils.js
+++ b/src/ClustersLayer/utils.js
@@ -184,7 +184,7 @@ export const removeOldClusterMarkers = (clusterMarkerHashMapRef, removeClusterPo
   const prevClusterHashes = Object.keys(clusterMarkerHashMapRef.current).map((clusterHash) => parseInt(clusterHash));
   prevClusterHashes.forEach((prevClusterHash) => {
     if (!renderedClusterHashesSet.has(prevClusterHash)) {
-      clusterMarkerHashMapRef.current[prevClusterHash].marker.remove();
+      clusterMarkerHashMapRef.current[prevClusterHash].marker?.remove();
       removeClusterPolygon();
     }
   });
@@ -216,7 +216,8 @@ export const addNewClusterMarkers = (
     const iconsReady = wasReady || clusterIconFeatures
       .every((feature) => !feature.properties.icon_id || !!getFeatureIcon(feature, mapImages));
 
-    if (!marker) {
+    // Wait for every displayed icon to resolve before creating the marker.
+    if (!marker && iconsReady) {
       const clusterFeatureCollection = featureCollection(clusterFeatures);
       const clusterPoint = centroid(clusterFeatureCollection);
       const onClick = onClusterClick(

--- a/src/MapImageFromSvgSpriteRenderer/index.js
+++ b/src/MapImageFromSvgSpriteRenderer/index.js
@@ -11,6 +11,8 @@ const EMPTY_FEATURE_COLLECTION = { features: [] };
 
 const isClientError = (status) => typeof status === 'number' && status >= 400 && status < 500;
 
+const REP_SUFFIX = '_rep';
+
 // Builds the map-image cache key for an event's icon. Must match the suffix order
 // used by the Mapbox icon-image expressions (icon_id-priority-width-height).
 export const calcSvgImageIconId = ({ icon_id, priority, width, height }) => {
@@ -27,6 +29,17 @@ const fetchSpriteSvgMarkup = async (spriteIconId) => {
   });
 
   return response.data;
+};
+
+const fetchSpriteSvgMarkupWithRepFallback = async (spriteIconId) => {
+  try {
+    return await fetchSpriteSvgMarkup(spriteIconId);
+  } catch (error) {
+    if (isClientError(error?.response?.status) && !spriteIconId.endsWith(REP_SUFFIX)) {
+      return fetchSpriteSvgMarkup(`${spriteIconId}${REP_SUFFIX}`);
+    }
+    throw error;
+  }
 };
 
 const calcScaledIconDimensions = ({ height, width = MAP_ICON_SIZE }) => [
@@ -79,7 +92,7 @@ const MapImageFromSvgSpriteRenderer = ({ eventFeatureCollection = EMPTY_FEATURE_
       if (!spriteFetchesInFlight.current[spriteIconId]) {
         spriteFetchesInFlight.current[spriteIconId] = (async () => {
           try {
-            const svgMarkup = await fetchSpriteSvgMarkup(spriteIconId);
+            const svgMarkup = await fetchSpriteSvgMarkupWithRepFallback(spriteIconId);
             spriteMarkupCache.current[spriteIconId] = svgMarkup;
             return svgMarkup;
           } finally {

--- a/src/MapImageFromSvgSpriteRenderer/index.test.js
+++ b/src/MapImageFromSvgSpriteRenderer/index.test.js
@@ -228,8 +228,59 @@ describe('MapImageFromSvgSpriteRenderer', () => {
     expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/generic.svg'), expect.anything());
   });
 
+  it('retries with a "_rep" suffix when the bare icon_id has no sprite entry, rendering the real icon ' +
+    'instead of falling back to generic (mirrors DasIcon\'s header/sidebar icon resolution)', async () => {
+    axios.get
+      .mockRejectedValueOnce({ response: { status: 404 } })
+      .mockResolvedValueOnce({ data: SVG_MARKUP });
+
+    const event = { icon_id: 'geofence_break', priority: 200 };
+    const store = mockStore({ view: { mapImages: {} } });
+
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <MapImageFromSvgSpriteRenderer eventFeatureCollection={featureCollectionFromEvents([event])} />
+        </Provider>
+      );
+      await flushPromises();
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenNthCalledWith(1, expect.stringContaining('/geofence_break.svg'), expect.anything());
+    expect(axios.get).toHaveBeenNthCalledWith(2, expect.stringContaining('/geofence_break_rep.svg'), expect.anything());
+
+    await act(async () => {
+      loadCallbacks.forEach((callback) => callback());
+      await flushPromises();
+    });
+
+    expect(global.Image.mock.results[0].value.src).toMatch(/^data:image\/svg\+xml/);
+    expect(dispatchedIconIdsFrom(store)).toEqual([calcSvgImageIconId(event)]);
+  });
+
+  it('does not retry with a doubled "_rep" suffix when the icon_id already ends in "_rep"', async () => {
+    axios.get.mockRejectedValue({ response: { status: 404 } });
+
+    const event = { icon_id: 'snare_rep', priority: 200, image: 'snare.png' };
+    const store = mockStore({ view: { mapImages: {} } });
+
+    await act(async () => {
+      render(
+        <Provider store={store}>
+          <MapImageFromSvgSpriteRenderer eventFeatureCollection={featureCollectionFromEvents([event])} />
+        </Provider>
+      );
+      await flushPromises();
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+
   it('falls back to the event\'s own image when the event type has no sprite entry', async () => {
-    axios.get.mockRejectedValueOnce({ response: { status: 404 } });
+    // Rejects both the bare icon_id attempt and the "_rep" suffix retry, simulating an icon_id with
+    // no sprite entry under either name.
+    axios.get.mockRejectedValue({ response: { status: 404 } });
 
     const event = { icon_id: 'custom-marker', priority: 100, image: 'custom-marker.png' };
     const store = mockStore({ view: { mapImages: {} } });
@@ -317,7 +368,9 @@ describe('MapImageFromSvgSpriteRenderer', () => {
   });
 
   it('uses the vector-tile image path as-is for the fallback, without guessing at a different path', async () => {
-    axios.get.mockRejectedValueOnce({ response: { status: 404 } });
+    // Rejects both the bare icon_id attempt and the "_rep" suffix retry, simulating an icon_id with
+    // no sprite entry under either name.
+    axios.get.mockRejectedValue({ response: { status: 404 } });
 
     const event = {
       icon_id: 'hydrophone_detection',
@@ -340,7 +393,9 @@ describe('MapImageFromSvgSpriteRenderer', () => {
   });
 
   it('falls back to the generic per-color icon when the event\'s own fallback image also fails to load, so the map is never left with a permanently broken icon', async () => {
-    axios.get.mockRejectedValueOnce({ response: { status: 404 } });
+    // Rejects both the bare icon_id attempt and the "_rep" suffix retry, simulating an icon_id with
+    // no sprite entry under either name.
+    axios.get.mockRejectedValue({ response: { status: 404 } });
 
     const event = { icon_id: 'custom-marker', priority: 100, image: 'custom-marker.png' };
     const store = mockStore({ view: { mapImages: {} } });
@@ -373,7 +428,9 @@ describe('MapImageFromSvgSpriteRenderer', () => {
   });
 
   it('uses the tile-provided color for the generic fallback when the event carries one', async () => {
-    axios.get.mockRejectedValueOnce({ response: { status: 404 } });
+    // Rejects both the bare icon_id attempt and the "_rep" suffix retry, simulating an icon_id with
+    // no sprite entry under either name.
+    axios.get.mockRejectedValue({ response: { status: 404 } });
 
     const event = { icon_id: 'custom-marker', priority: 100, color: 'lt_gray', image: 'custom-marker.png' };
     const store = mockStore({ view: { mapImages: {} } });
@@ -397,7 +454,9 @@ describe('MapImageFromSvgSpriteRenderer', () => {
   });
 
   it('logs a warning when the event\'s own fallback image and the generic per-color fallback both fail to load', async () => {
-    axios.get.mockRejectedValueOnce({ response: { status: 404 } });
+    // Rejects both the bare icon_id attempt and the "_rep" suffix retry, simulating an icon_id with
+    // no sprite entry under either name.
+    axios.get.mockRejectedValue({ response: { status: 404 } });
 
     const event = { icon_id: 'custom-marker', priority: 100, image: 'custom-marker.png' };
     const store = mockStore({ view: { mapImages: {} } });


### PR DESCRIPTION
- Updated test descriptions in ClustersLayer to clarify behavior regarding cluster marker visibility based on icon readiness.
- Improved logic in the ClustersLayer utility functions to ensure markers are only created when all displayed icons are resolved.
- Enhanced error handling in MapImageFromSvgSpriteRenderer to retry fetching icons with a "_rep" suffix when the initial fetch fails.
- Added tests to verify the new retry behavior and ensure that markers are not created for clusters with unresolved icons.
