### PR TITLE
ERA-13684: Fix clustered subject grey-dot icons and hasImage empty-id error

### DIFF
--- a/src/ClustersLayer/index.test.js
+++ b/src/ClustersLayer/index.test.js
@@ -435,6 +435,23 @@ describe('ClustersLayer', () => {
       expect(clusterHTMLMarker.childNodes[2].tagName).toBe('IMG');
       expect(clusterHTMLMarker.childNodes[3].tagName).toBe('P');
     });
+
+    test('renders a subject\'s own image rather than the event sprite/generic fallback, even when it carries an icon_id', () => {
+      const subjectImage = 'https://example.com/ranger.svg';
+      const marker = createClusterHTMLMarker(
+        [{ properties: { id: '1', content_type: 'observations.subject', icon_id: 'ranger', image: subjectImage } }],
+        {},
+        onClusterClick,
+        onClusterMouseEnter,
+        onClusterMouseLeave
+      );
+
+      const subjectIcon = marker.querySelector('img');
+      expect(subjectIcon.src).toBe(subjectImage);
+      expect(subjectIcon.src).not.toContain('sprite-src');
+      expect(subjectIcon.src).not.toContain('generic-');
+      expect(subjectIcon.onerror).toBeNull();
+    });
   });
 
   describe('onClusterClick', () => {
@@ -712,6 +729,29 @@ describe('ClustersLayer', () => {
       expect(renderedClusterMarkersHashMap.pending.marker).toBe(staleMarker);
       expect(renderedClusterMarkersHashMap.pending.iconsReady).toBe(true);
       expect(staleMarkerElement.querySelector('img')).toBeTruthy();
+    });
+
+    test('treats a subject cluster as icons-ready even though the subject icon_id is never in mapImages', () => {
+      const subjectClusterFeatures = [[{
+        geometry: { type: 'Point', coordinates: [0, 0] },
+        properties: { id: '20', content_type: 'observations.subject', icon_id: 'ranger', image: 'https://example.com/ranger.svg' },
+        type: 'Feature',
+      }]];
+
+      const renderedClusterMarkersHashMap = addNewClusterMarkers(
+        onClusterMouseEnter,
+        { current: {} },
+        clustersSource,
+        map,
+        {},
+        onClusterMouseLeave,
+        subjectClusterFeatures,
+        ['subject-cluster'],
+        ['mnop'],
+        onShowClusterSelectPopup
+      );
+
+      expect(renderedClusterMarkersHashMap['subject-cluster'].iconsReady).toBe(true);
     });
   });
 

--- a/src/ClustersLayer/utils.js
+++ b/src/ClustersLayer/utils.js
@@ -25,8 +25,18 @@ const FEATURE_ICON_HTML_STYLES = { maxWidth: '24px', minWidth: '18px', height: '
 const FEATURE_SS_ICON_HTML_STYLES = { filter: 'brightness(0)' };
 const FEATURE_COUNT_HTML_STYLES = { fontSize: '16px', fontWeight: '500', paddingLeft: '4px', margin: '0' };
 
+// Subject icons are served as ready-to-use image URLs and are never registered
+// in `mapImages` under a sprite/icon_id key, nor do they live in the event
+// sprite sheet. Only event features go through the sprite -> generic fallback
+// chain; subjects keep using their own image source directly.
+const featureIsSubject = (feature) => feature.properties?.content_type === SUBJECT_FEATURE_CONTENT_TYPE;
+
+// Only resolve event features from the sprite `mapImages` cache. Subjects have
+// no `icon_id`, so their event-shaped key can collapse to an empty/generic
+// entry and resolve to a grey dot; return undefined so they fall through to
+// their own `image` URL instead.
 const getFeatureIcon = (feature, mapImages) =>
-  mapImages[calcSvgImageIconId(feature.properties)]?.image;
+  featureIsSubject(feature) ? undefined : mapImages[calcSvgImageIconId(feature.properties)]?.image;
 
 export const getClusterIconFeatures = (clusterFeatures) => {
   const { eventFeatures, subjectFeatures } = clusterFeatures.reduce((accumulator, feature) => {
@@ -81,8 +91,9 @@ const populateClusterIconChildren = (clusterHTMLMarkerContainer, clusterIconFeat
       // Event features' own image/image_url from the vector tile is unreliable
       // so fall back to the uncolored sprite master until mapImages resolves.
       // That master doesn't exist for every icon_id either, so if it also
-      // fails to load, drop to the generic per-color icon.
-      if (feature.properties.icon_id) {
+      // fails to load, drop to the generic per-color icon. Subjects aren't in
+      // the event sprite sheet and carry a reliable image, so they skip this.
+      if (feature.properties.icon_id && !featureIsSubject(feature)) {
         featureImageHTML.src = calcSpriteSvgUrl(feature.properties.icon_id);
         featureImageHTML.onerror = () => {
           featureImageHTML.onerror = null;
@@ -214,7 +225,7 @@ export const addNewClusterMarkers = (
 
     const clusterIconFeatures = wasReady ? null : getClusterIconFeatures(clusterFeatures);
     const iconsReady = wasReady || clusterIconFeatures
-      .every((feature) => !feature.properties.icon_id || !!getFeatureIcon(feature, mapImages));
+      .every((feature) => featureIsSubject(feature) || !feature.properties.icon_id || !!getFeatureIcon(feature, mapImages));
 
     // Wait for every displayed icon to resolve before creating the marker.
     if (!marker && iconsReady) {

--- a/src/EventsLayer/index.js
+++ b/src/EventsLayer/index.js
@@ -222,7 +222,7 @@ const EventsLayer = ({
   useEffect(() => {
     setMapEventFeatures({
       ...eventsWithBounce,
-      features: eventsWithBounce.features.filter(feature => !map.hasImage(calcSvgImageIconId(feature))),
+      features: eventsWithBounce.features.filter(feature => !map.hasImage(calcSvgImageIconId(feature.properties))),
     });
   }, [eventsWithBounce, map, mapImages]);
 


### PR DESCRIPTION
## Summary

Hotfix for [ERA-13684](https://allenai.atlassian.net/browse/ERA-13684) against `release-2.143.1`.

- **Clustered subjects rendered as a generic grey dot.** `getFeatureIcon` looked subjects up in the event sprite `mapImages` cache, but subjects have no `icon_id`, so their event-shaped key (`calcSvgImageIconId`) collapsed to an empty/generic entry that resolved to the grey generic image. Subjects now skip the sprite cache and fall through to their own `feature.properties.image` URL — the same icon they use as a standalone pin.
- **`Error: Missing required image id` flooding the console.** `EventsLayer` passed the whole `feature` (not `feature.properties`) into `calcSvgImageIconId`, producing an empty-string id; `map.hasImage('')` throws on every render, which also silently no-op'd the unclustered-events filter. Fixed to pass `feature.properties`.
- **Removed** the temporary `[cluster-icon-debug]` logging in `ClustersLayer/utils.js`.

## Testing

- `ClustersLayer` unit tests pass (33/33).
- ESLint clean on `ClustersLayer/utils.js`. The `react-hooks` lint errors reported on `EventsLayer/index.js` pre-exist on the release branch and are unrelated to the one-token change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ERA-13684]: https://allenai.atlassian.net/browse/ERA-13684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ