### PR TITLE
Bump docker/setup-buildx-action to v4

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -17,8 +17,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
       - name: Install dependencies
@@ -32,9 +32,9 @@ jobs:
       build-args: ${{ steps.env-vars.outputs.build-args }}
       image-tag: ${{ steps.tag.outputs.value }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
       - run: |
@@ -52,7 +52,7 @@ jobs:
           BRANCH_SAFE=$(echo "${GITHUB_REF_NAME}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
           echo "value=${BRANCH_SAFE}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: npm-config
           path: package.json
@@ -61,9 +61,9 @@ jobs:
     needs: config
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: npm-config
           path: .
@@ -84,7 +84,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             europe-west3-docker.pkg.dev/serca-artifact-registry/earthranger/das-web-react
@@ -96,7 +96,7 @@ jobs:
         run: echo "value=$(cat .node-version)" >> $GITHUB_OUTPUT
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Configure Docker
         run: gcloud auth configure-docker europe-west3-docker.pkg.dev
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
         with:
           driver-opts: |
             image=europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/moby/buildkit:buildx-stable-1

--- a/.github/workflows/pr-envs.yml
+++ b/.github/workflows/pr-envs.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Configure Docker
         run: gcloud auth configure-docker europe-west3-docker.pkg.dev
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
         with:
           driver-opts: |
             image=europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/moby/buildkit:buildx-stable-1

--- a/.github/workflows/pr-envs.yml
+++ b/.github/workflows/pr-envs.yml
@@ -21,8 +21,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
       - name: Install dependencies
@@ -59,14 +59,14 @@ jobs:
   config:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
       - run: |
           npm pkg set "buildbranch"="${{ github.event.pull_request.head.sha }}"
           npm pkg set "buildnum"="${{ github.run_number }}"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: npm-config
           path: package.json
@@ -75,9 +75,9 @@ jobs:
     needs: [prepare, config]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: npm-config
           path: .
@@ -98,7 +98,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: >
             europe-west3-docker.pkg.dev/serca-artifact-registry/earthranger/das-web-react
@@ -111,7 +111,7 @@ jobs:
         run: echo "value=$(cat .node-version)" >> $GITHUB_OUTPUT
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
       - name: Install dependencies
@@ -33,9 +33,9 @@ jobs:
       build-args: ${{ steps.env-vars.outputs.build-args }}
       image-tag: ${{ steps.tag.outputs.value }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
       - run: |
@@ -53,7 +53,7 @@ jobs:
           BRANCH_SAFE=$(echo "${GITHUB_REF_NAME}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
           echo "value=${BRANCH_SAFE}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: npm-config
           path: package.json
@@ -62,9 +62,9 @@ jobs:
     needs: config
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: npm-config
           path: .
@@ -85,7 +85,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             europe-west3-docker.pkg.dev/serca-artifact-registry/earthranger/das-web-react
@@ -97,7 +97,7 @@ jobs:
         run: echo "value=$(cat .node-version)" >> $GITHUB_OUTPUT
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Configure Docker
         run: gcloud auth configure-docker europe-west3-docker.pkg.dev
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
         with:
           driver-opts: |
             image=europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/moby/buildkit:buildx-stable-1


### PR DESCRIPTION
## Summary
Resolves the Node 20 deprecation warnings surfaced in CI builds by bumping every pinned GitHub Action in these workflows to a major version that runs on Node 24.

## Changes
- `docker/setup-buildx-action@v3` → `@v4`
- `actions/checkout@v4` → `@v7`
- `actions/setup-node@v4` → `@v6`
- `actions/upload-artifact@v4` → `@v7`
- `actions/download-artifact@v4` → `@v8`
- `docker/metadata-action@v5` → `@v6`
- `docker/build-push-action@v6` → `@v7`

Applied across `develop.yml`, `release.yml`, and `pr-envs.yml`.

## Technical Details
Checked each action's changelog for breaking changes against this repo's actual usage:
- `setup-node@v6` restricts automatic package-manager caching to `npm` only, so it has no effect here (this repo pins `packageManager: yarn@4.16.0`).
- `download-artifact@v5`'s path-behavior fix only affects downloads by `artifact-ids`; these workflows download by `name`, unaffected.
- `build-push-action@v7` removes deprecated `DOCKER_BUILD_NO_SUMMARY`/`DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs — not used here.
- `docker/metadata-action@v6`'s only behavioral change (preserving `#` in list values) doesn't affect the plain `type=raw` tags used here.

Verified in CI: the buildx step runs clean with no deprecation warning attached to it.