### PR TITLE
ERA-13684: Fix clustered subject grey-dot icons and hasImage empty-id error

### DIFF
--- a/src/ClustersLayer/index.test.js
+++ b/src/ClustersLayer/index.test.js
@@ -152,12 +152,12 @@ describe('ClustersLayer', () => {
       });
     });
 
-    test('withholds a cluster marker until all its displayed icons resolve in mapImages, rather than showing a guessed placeholder', async () => {
+    test('renders every cluster marker immediately even before its icons resolve, then upgrades to the resolved sprite', async () => {
       unmount();
       mapMarkers.length = 0;
 
       const fullMapImages = buildMapImagesForFeatures([...mockClusterLeaves[0], ...mockClusterLeaves[1]]);
-      // Simulates the initial-page-load race.
+      // Simulates the initial-page-load race where an icon hasn't been generated yet.
       const { 'jenaeonefield-200': omitted, ...incompleteMapImages } = fullMapImages;
       expect(omitted).toBeDefined();
 
@@ -170,12 +170,14 @@ describe('ClustersLayer', () => {
       ));
       map.__test__.fireHandlers('sourcedata', { sourceId: CLUSTERS_SOURCE_ID });
 
-      // Only the cluster whose icons are already resolved gets a marker.
+      // Both clusters render immediately — the not-yet-generated icon falls back
+      // to the feature's own image rather than the marker being withheld.
       await waitFor(() => {
-        expect(mapMarkers).toHaveLength(1);
+        expect(mapMarkers).toHaveLength(2);
       });
 
-      // The missing icon resolves and mapImages updates.
+      // Once the missing icon resolves, the marker upgrades to the resolved
+      // sprite (a data URI).
       renderWithMapImages(fullMapImages);
 
       await waitFor(() => {
@@ -184,17 +186,14 @@ describe('ClustersLayer', () => {
       });
     });
 
-    test('does not create a marker for a still-not-ready cluster on unrelated mapImages updates', async () => {
+    test('does not duplicate markers on unrelated mapImages updates', async () => {
       unmount();
       mapMarkers.length = 0;
 
       const fullMapImages = buildMapImagesForFeatures([...mockClusterLeaves[0], ...mockClusterLeaves[1]]);
-      // Simulates the initial-page-load race, same as the previous test.
-      const { 'jenaeonefield-200': omitted, ...incompleteMapImages } = fullMapImages;
-      expect(omitted).toBeDefined();
 
       ({ rerender } = render(
-        <Provider store={buildStore(incompleteMapImages)}>
+        <Provider store={buildStore(fullMapImages)}>
           <MapContext.Provider value={map}>
             <ClustersLayer onShowClusterSelectPopup={onShowClusterSelectPopup} />
           </MapContext.Provider>
@@ -203,16 +202,14 @@ describe('ClustersLayer', () => {
       map.__test__.fireHandlers('sourcedata', { sourceId: CLUSTERS_SOURCE_ID });
 
       await waitFor(() => {
-        expect(mapMarkers).toHaveLength(1);
+        expect(mapMarkers).toHaveLength(2);
       });
 
-      // An unrelated icon resolves elsewhere on the map — the cluster's own
-      // missing icon ('jenaeonefield-200') is still not present, so no marker
-      // should be created for it yet.
-      renderWithMapImages({ ...incompleteMapImages, 'unrelated_icon-100': { image: document.createElement('img') } });
+      // An unrelated icon resolves elsewhere on the map.
+      renderWithMapImages({ ...fullMapImages, 'unrelated_icon-100': { image: document.createElement('img') } });
 
       await waitFor(() => {
-        expect(mapMarkers).toHaveLength(1);
+        expect(mapMarkers).toHaveLength(2);
       });
     });
 
@@ -390,12 +387,12 @@ describe('ClustersLayer', () => {
     let clusterHTMLMarker;
     beforeEach(() => {
       const clusterFeatures = [
-        { properties: { id: '1', content_type: 'observations.subject', is_static: true, subject_type: 'stationary-subject' } },
-        { properties: { id: '2', event_type: 'jenaeonefield' } },
-        { properties: { id: '3' } },
-        { properties: { id: '4', content_type: 'observations.subject' } },
-        { properties: { id: '5', event_type: 'jenaeonefield' } },
-        { properties: { id: '6' } },
+        { properties: { id: '1', content_type: 'observations.subject', is_static: true, subject_type: 'stationary-subject', image_url: 'https://develop.pamdas.org/static/ranger-black.svg' } },
+        { properties: { id: '2', event_type: 'jenaeonefield', image: 'https://develop.pamdas.org/static/fire_rep.svg' } },
+        { properties: { id: '3', image: 'https://develop.pamdas.org/static/fire_rep.svg' } },
+        { properties: { id: '4', content_type: 'observations.subject', image_url: 'https://develop.pamdas.org/static/ranger-black.svg' } },
+        { properties: { id: '5', event_type: 'jenaeonefield', image: 'https://develop.pamdas.org/static/fire_rep.svg' } },
+        { properties: { id: '6', image: 'https://develop.pamdas.org/static/fire_rep.svg' } },
       ];
       clusterHTMLMarker = createClusterHTMLMarker(
         clusterFeatures,
@@ -434,6 +431,72 @@ describe('ClustersLayer', () => {
       expect(clusterHTMLMarker.childNodes[1].tagName).toBe('IMG');
       expect(clusterHTMLMarker.childNodes[2].tagName).toBe('IMG');
       expect(clusterHTMLMarker.childNodes[3].tagName).toBe('P');
+    });
+  });
+
+  describe('createClusterHTMLMarker icon resolution', () => {
+    const noop = jest.fn();
+    const buildMarker = (feature, mapImages = {}) => createClusterHTMLMarker([feature], mapImages, noop, noop, noop);
+
+    const imgWithSrc = (src) => {
+      const image = document.createElement('img');
+      image.src = src;
+      return image;
+    };
+
+    test('resolves an event icon from its generated sprite in mapImages', () => {
+      const feature = { properties: { id: 'e1', event_type: 'fire', icon_id: 'fire_rep', priority: 200 } };
+      const spriteSrc = 'data:image/svg+xml,recolored-sprite';
+      const mapImages = { [calcSvgImageIconId(feature.properties)]: { image: imgWithSrc(spriteSrc) } };
+
+      const marker = buildMarker(feature, mapImages);
+
+      expect(marker.childNodes[0].getAttribute('src')).toBe(spriteSrc);
+    });
+
+    test('falls back to an event\'s own pre-colored image URL when its sprite is not yet generated', () => {
+      const image = 'https://develop.pamdas.org/static/generic-amber.svg';
+      const feature = { properties: { id: 'e1', event_type: 'fire', icon_id: 'fire_rep', priority: 200, image } };
+
+      const marker = buildMarker(feature, {});
+
+      expect(marker.childNodes[0].getAttribute('src')).toBe(image);
+    });
+
+    test('skips a raw sprite-src fallback (rather than flashing a broken image) until the recolored sprite resolves', () => {
+      // Vector-tile events carry the raw, uncolored sprite template, which is
+      // not display-ready and 404s for generic icons. It must be omitted, not
+      // rendered as a broken <img>, until MapImageFromSvgSpriteRenderer registers
+      // the recolored sprite and the repaint fills the slot.
+      const image = 'https://develop.pamdas.org/static/sprite-src/generic.svg';
+      const feature = { properties: { id: 'e1', event_type: 'fire', icon_id: 'generic', priority: 200, image } };
+
+      const marker = buildMarker(feature, {});
+
+      expect(marker.childNodes).toHaveLength(0);
+    });
+
+    test('skips the icon (rather than rendering a broken image) when a vector-tile event has no sprite yet and no image URL', () => {
+      // Vector-tile events carry an icon_id but may have no image/image_url;
+      // before the sprite resolves there is nothing valid to show, so the slot
+      // must be omitted instead of rendering an <img> with a null src.
+      const feature = { properties: { id: 'e1', event_type: 'fire', icon_id: 'fire_rep', priority: 200 } };
+
+      const marker = buildMarker(feature, {});
+
+      expect(marker.childNodes).toHaveLength(0);
+    });
+
+    test('renders a subject from its own image URL and never resolves it from the shared generic key', () => {
+      const imageUrl = 'https://develop.pamdas.org/static/ranger-black.svg';
+      const subject = { properties: { id: 's1', content_type: 'observations.subject', image_url: imageUrl } };
+      // A generic icon sitting under the empty-icon_id key ('generic') must not
+      // leak into subjects, which is what caused clustered subjects to show generic.
+      const mapImages = { [calcSvgImageIconId(subject.properties)]: { image: imgWithSrc('GENERIC-LEAK') } };
+
+      const marker = buildMarker(subject, mapImages);
+
+      expect(marker.childNodes[0].getAttribute('src')).toBe(imageUrl);
     });
   });
 

--- a/src/ClustersLayer/utils.js
+++ b/src/ClustersLayer/utils.js
@@ -1,7 +1,7 @@
 import { centroid, featureCollection } from '@turf/turf';
 import mapboxgl from 'mapbox-gl';
 
-import { calcGenericFallbackImageUrl, calcSpriteSvgUrl } from '../utils/img';
+import { calcUrlForImage } from '../utils/img';
 import { CLUSTER_CLICK_ZOOM_THRESHOLD, LAYER_IDS, SUBJECT_FEATURE_CONTENT_TYPE } from '../constants';
 import { calcSvgImageIconId } from '../MapImageFromSvgSpriteRenderer';
 import { subjectIsStatic } from '../utils/subjects';
@@ -26,7 +26,7 @@ const FEATURE_SS_ICON_HTML_STYLES = { filter: 'brightness(0)' };
 const FEATURE_COUNT_HTML_STYLES = { fontSize: '16px', fontWeight: '500', paddingLeft: '4px', margin: '0' };
 
 const getFeatureIcon = (feature, mapImages) =>
-  mapImages[calcSvgImageIconId(feature.properties)]?.image;
+  feature.properties.icon_id ? mapImages[calcSvgImageIconId(feature.properties)]?.image : undefined;
 
 export const getClusterIconFeatures = (clusterFeatures) => {
   const { eventFeatures, subjectFeatures } = clusterFeatures.reduce((accumulator, feature) => {
@@ -77,20 +77,15 @@ const populateClusterIconChildren = (clusterHTMLMarkerContainer, clusterIconFeat
   clusterIconFeatures.forEach((feature) => {
     let featureImageHTML = getFeatureIcon(feature, mapImages)?.cloneNode(true);
     if (!featureImageHTML) {
-      featureImageHTML = document.createElement('img');
-      // Event features' own image/image_url from the vector tile is unreliable
-      // so fall back to the uncolored sprite master until mapImages resolves.
-      // That master doesn't exist for every icon_id either, so if it also
-      // fails to load, drop to the generic per-color icon.
-      if (feature.properties.icon_id) {
-        featureImageHTML.src = calcSpriteSvgUrl(feature.properties.icon_id);
-        featureImageHTML.onerror = () => {
-          featureImageHTML.onerror = null;
-          featureImageHTML.src = calcGenericFallbackImageUrl(feature.properties);
-        };
-      } else {
-        featureImageHTML.src = feature.properties.image || feature.properties.image_url;
+      // The recolored sprite isn't in mapImages yet. Fall back to the feature's
+      // own icon URL only when it's a display-ready image.
+      const fallbackSrc = calcUrlForImage(feature.properties.image || feature.properties.image_url);
+      if (!fallbackSrc || fallbackSrc.includes('/sprite-src/')) {
+        return;
       }
+
+      featureImageHTML = document.createElement('img');
+      featureImageHTML.src = fallbackSrc;
     }
     injectStylesToElement(featureImageHTML, FEATURE_ICON_HTML_STYLES);
     if (subjectIsStatic(feature)) {
@@ -215,9 +210,7 @@ export const addNewClusterMarkers = (
     const clusterIconFeatures = wasReady ? null : getClusterIconFeatures(clusterFeatures);
     const iconsReady = wasReady || clusterIconFeatures
       .every((feature) => !feature.properties.icon_id || !!getFeatureIcon(feature, mapImages));
-
-    // Wait for every displayed icon to resolve before creating the marker.
-    if (!marker && iconsReady) {
+    if (!marker) {
       const clusterFeatureCollection = featureCollection(clusterFeatures);
       const clusterPoint = centroid(clusterFeatureCollection);
       const onClick = onClusterClick(
@@ -244,6 +237,8 @@ export const addNewClusterMarkers = (
         .setLngLat(clusterPoint.geometry.coordinates)
         .addTo(map);
     } else if (!wasReady && iconsReady) {
+      // Marker already exists but was built with image-URL fallbacks; repaint
+      // its icons in place.
       populateClusterIconChildren(marker.getElement(), clusterIconFeatures, clusterFeatures.length, mapImages);
     }
 
@@ -252,4 +247,3 @@ export const addNewClusterMarkers = (
 
   return renderedClusterMarkersHashMap;
 };
-

--- a/src/EventsLayer/index.js
+++ b/src/EventsLayer/index.js
@@ -16,7 +16,7 @@ import {
 import { getMapEventSymbolPointsWithVirtualDate } from '../selectors/events';
 import { selectShouldEventsBeClustered } from '../selectors/clusters';
 import { MapContext } from '../MapContext';
-import MapImageFromSvgSpriteRenderer, { calcSvgImageIconId } from '../MapImageFromSvgSpriteRenderer';
+import MapImageFromSvgSpriteRenderer from '../MapImageFromSvgSpriteRenderer';
 import useMapSources from '../hooks/useMapSources';
 import { withMultiLayerHandlerAwareness } from '../utils/map-handlers';
 
@@ -61,7 +61,6 @@ const SYMBOL_LAYER_FILTER = [
 
 const EventsLayer = ({
   bounceEventIDs = [],
-  mapImages = {},
   mapUserLayoutConfig,
   mapUserLayoutConfigByLayerId,
   minZoom,
@@ -80,7 +79,6 @@ const EventsLayer = ({
   const [bounceIDs, setBounceIDs] = useState([]);
   const [eventLayerIds, setEventLayerIds] = useState([]);
   const [eventsWithBounce, setEventsWithBounce] = useState(featureCollection([]));
-  const [mapEventFeatures, setMapEventFeatures] = useState(featureCollection([]));
 
   const onLayerInit = useCallback(() => setEventLayerIds([
     EVENT_SYMBOLS,
@@ -220,13 +218,6 @@ const EventsLayer = ({
   }, [bounceEventIDs]);
 
   useEffect(() => {
-    setMapEventFeatures({
-      ...eventsWithBounce,
-      features: eventsWithBounce.features.filter(feature => !map.hasImage(calcSvgImageIconId(feature))),
-    });
-  }, [eventsWithBounce, map, mapImages]);
-
-  useEffect(() => {
     const addClusterIconToMap = () => {
       if (!map.hasImage('event-cluster-icon')) {
         addMapImage({ src: ClusterIcon, id: 'event-cluster-icon' });
@@ -237,8 +228,8 @@ const EventsLayer = ({
   }, [map]);
 
   const geoJson = {
-    ...mapEventFeatures,
-    features: !shouldEventsBeClustered && !!showReportsOnMap ? mapEventFeatures.features : [],
+    ...eventsWithBounce,
+    features: !shouldEventsBeClustered && !!showReportsOnMap ? eventsWithBounce.features : [],
   };
   useMapSources([{ id: UNCLUSTERED_EVENTS_SOURCE, data: geoJson }]);
 

--- a/src/Map/index.js
+++ b/src/Map/index.js
@@ -724,7 +724,6 @@ const Map = ({ children, onMapLoad, socket }) => {
       {eventsEnabled && (eventVectorTilesEnabled
         ? <EventsTileLayers onEventClick={onSelectEvent} />
         : <EventsLayer
-          mapImages={mapImages}
           onEventClick={onSelectEvent}
           bounceEventIDs={bounceEventIDs}
         />)}

--- a/src/MapImageFromSvgSpriteRenderer/index.js
+++ b/src/MapImageFromSvgSpriteRenderer/index.js
@@ -17,7 +17,7 @@ const REP_SUFFIX = '_rep';
 // used by the Mapbox icon-image expressions (icon_id-priority-width-height).
 export const calcSvgImageIconId = ({ icon_id, priority, width, height }) => {
   const variantSuffixParts = [priority, width, height].filter((value) => value === 0 || Boolean(value));
-  return [icon_id, ...variantSuffixParts].join('-');
+  return [icon_id || 'generic', ...variantSuffixParts].join('-');
 };
 
 const fetchSpriteSvgMarkup = async (spriteIconId) => {

--- a/src/MapImageFromSvgSpriteRenderer/index.test.js
+++ b/src/MapImageFromSvgSpriteRenderer/index.test.js
@@ -40,6 +40,11 @@ describe('calcSvgImageIconId', () => {
   it('appends width and height when provided, alongside priority, matching the icon-image expression order', () => {
     expect(calcSvgImageIconId({ icon_id: 'fire', priority: 200, height: 32, width: 24 })).toBe('fire-200-24-32');
   });
+
+  it('falls back to the "generic" key when icon_id is absent, so the map-image id is never empty', () => {
+    expect(calcSvgImageIconId({})).toBe('generic');
+    expect(calcSvgImageIconId({ priority: 200 })).toBe('generic-200');
+  });
 });
 
 describe('MapImageFromSvgSpriteRenderer', () => {

--- a/src/MapImagesLayer/index.js
+++ b/src/MapImagesLayer/index.js
@@ -10,7 +10,7 @@ const MapImagesLayer = () => {
 
   useEffect(() => {
     Object.entries(mapImages).forEach(([mapImageId, mapImageData]) => {
-      if (!map.hasImage(mapImageId)) {
+      if (mapImageId && !map.hasImage(mapImageId)) {
         map.addImage(mapImageId, mapImageData.image, mapImageData.options);
       }
     });

--- a/src/MapImagesLayer/index.test.js
+++ b/src/MapImagesLayer/index.test.js
@@ -80,4 +80,27 @@ describe('adding images to the map', () => {
     expect(map.addImage).toHaveBeenCalledWith('id2', state.view.mapImages.id2.image, state.view.mapImages.id2.options);
     expect(map.addImage).not.toHaveBeenCalledWith(EXISTING_IMG_ID, state.view.mapImages[EXISTING_IMG_ID].image, state.view.mapImages[EXISTING_IMG_ID].options);
   });
+
+  test('skips a falsy/empty image id instead of passing it to mapbox (which would raise "Missing required image id")', () => {
+    map.hasImage.mockImplementation(() => false);
+
+    const state = {
+      view: {
+        mapImages: {
+          '': { image: 'i_have_no_id', options: {} },
+          id2: { image: 'i_am_fine', options: {} },
+        },
+      }
+    };
+
+    render(<Provider store={mockStore(() => state)}>
+      <MapContext.Provider value={map}>
+        <MapImagesLayer />
+      </MapContext.Provider>
+    </Provider>);
+
+    expect(map.hasImage).not.toHaveBeenCalledWith('');
+    expect(map.addImage).not.toHaveBeenCalledWith('', expect.anything(), expect.anything());
+    expect(map.addImage).toHaveBeenCalledWith('id2', 'i_am_fine', {});
+  });
 });

--- a/src/selectors/events.js
+++ b/src/selectors/events.js
@@ -47,7 +47,7 @@ export const getMapEventFeatureCollectionByTypeWithVirtualDate = createSelector(
     if (mappedByType[VALID_EVENT_GEOMETRY_TYPES.POLYGON]) {
       mappedByType.PolygonCentersOfMass = featureCollection(
         mappedByType[VALID_EVENT_GEOMETRY_TYPES.POLYGON].features
-          .map(feature => centerOfMass(feature, feature.properties ))
+          .map(feature => centerOfMass(feature, { properties: feature.properties }))
       );
     }
     return mappedByType;

--- a/src/selectors/events.test.js
+++ b/src/selectors/events.test.js
@@ -65,7 +65,7 @@ describe('#getMapEventFeatureCollectionByTypeWithVirtualDate', () => {
       featureCollection([
         centerOfMass(
           polygonFeature,
-          polygonFeature.properties,
+          { properties: polygonFeature.properties },
         ),
       ])
     );


### PR DESCRIPTION
## What does this PR do?
Refactor cluster marker tests and improve icon resolution handling.

- Updated test descriptions in ClustersLayer to clarify the rendering behavior of cluster markers based on icon readiness.
- Cluster markers now render immediately and each icon progressively upgrades to its recolored sprite as soon as that sprite is registered in `mapImages`, rather than withholding the whole marker until every icon resolves.
- Improved fallback strategies for icon rendering: display-ready images (subjects' and flag-off events' pre-colored URLs) are shown right away, while non-display-ready fallbacks (raw `/sprite-src/` templates that 404 for generic icons) are skipped to avoid a broken-image flash until the recolored sprite resolves.
- Prevented clustered subjects (which have no `icon_id`) from resolving against the shared generic map-image key, fixing the grey-dot icon, and guarded `map.addImage` against empty ids.
- Added tests to verify the new behavior for icon resolution and marker rendering under various conditions.

## Evidence
Vector tiles off:
<img width="1512" height="859" alt="image" src="https://github.com/user-attachments/assets/f1343b06-6153-4856-b472-b38253a8733d" />

Vector tiles on:
<img width="1512" height="859" alt="image" src="https://github.com/user-attachments/assets/7785d6cb-f2f9-43ca-a564-9eaa2473373c" />


### Relevant link(s)
- [ERA-13684](https://allenai.atlassian.net/browse/ERA-13684)


[ERA-13684]: https://allenai.atlassian.net/browse/ERA-13684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ