### PR TITLE
Enhance ClustersLayer and TimeSlider components with sidebar padding adjustments

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -43,10 +43,11 @@ $map-canvas: '.mapboxgl-canvas';
 
 :root {
   --nav-height: 2.75rem;
+
+  // Keep in sync with VERTICAL_NAV_RAIL_WIDTH_PIXELS.
   --vertical-nav-width: 4.375rem;
 
-  // Make sure to update the SIDEBAR_WIDTH_PIXELS variable in the JS too to add the right padding
-  // when centering something in the map
+  // Keep in sync with SIDEBAR_WIDTH_PIXELS.
   --sidebar-width: calc(100vw);
 
   @media (min-width: $md-layout-width-min) {

--- a/src/ClustersLayer/index.test.js
+++ b/src/ClustersLayer/index.test.js
@@ -505,7 +505,7 @@ describe('ClustersLayer', () => {
       expect(map.easeTo).toHaveBeenCalledWith({
         center: clusterCoordinates,
         zoom: CLUSTER_CLICK_ZOOM_THRESHOLD + 1.1,
-        padding: { left: 592, right: 90, top: 12, bottom: 12 },
+        padding: { left: 582, right: 90, top: 12, bottom: 12 },
       });
     });
 
@@ -537,7 +537,7 @@ describe('ClustersLayer', () => {
     test('pads for the sidebar width when a tab is open', () => {
       getWindowLocation.mockReturnValue({ pathname: '/events' });
 
-      expect(calcClusterZoomPadding()).toEqual({ left: 592, right: 90, top: 12, bottom: 12 });
+      expect(calcClusterZoomPadding()).toEqual({ left: 582, right: 90, top: 12, bottom: 12 });
     });
 
     test('pads for the wider detail view when an item is open', () => {

--- a/src/ClustersLayer/index.test.js
+++ b/src/ClustersLayer/index.test.js
@@ -5,17 +5,19 @@ import { render, waitFor } from '@testing-library/react';
 
 import {
   addNewClusterMarkers,
+  calcClusterZoomPadding,
   createClusterHTMLMarker,
   getClusterIconFeatures,
   getRenderedClustersData,
   onClusterClick,
   removeOldClusterMarkers,
 } from './utils';
+import { BREAKPOINTS, CLUSTER_CLICK_ZOOM_THRESHOLD, SOURCE_IDS } from '../constants';
 import { calcSpriteSvgUrl } from '../utils/img';
 import { calcSvgImageIconId } from '../MapImageFromSvgSpriteRenderer';
-import { CLUSTER_CLICK_ZOOM_THRESHOLD, SOURCE_IDS } from '../constants';
 import ClustersLayer from '.';
 import { createMapMock, createMockInteractionEvent } from '../__test-helpers/mocks';
+import getWindowLocation from '../utils/getWindowLocation';
 import { mockStore } from '../__test-helpers/MockStore';
 import { MapContext } from '../MapContext';
 import {
@@ -67,6 +69,7 @@ jest.mock('../hooks/useTileEventFeatures', () => jest.fn());
 jest.mock('../selectors/events-realtime-overlay', () => ({
   selectRealtimeOverlayFeatureCollection: jest.fn(),
 }));
+jest.mock('../utils/getWindowLocation', () => jest.fn());
 
 
 describe('ClustersLayer', () => {
@@ -78,6 +81,8 @@ describe('ClustersLayer', () => {
 
     selectRealtimeOverlayFeatureCollection.mockReturnValue(featureCollection([]));
     useTileEventFeaturesMock.mockReturnValue(featureCollection([]));
+    getWindowLocation.mockReturnValue({ pathname: '/' });
+    BREAKPOINTS.screenIsMediumLayoutOrLarger.matches = true;
   });
 
   describe('the map layer', () => {
@@ -285,6 +290,7 @@ describe('ClustersLayer', () => {
       expect(map.easeTo).toHaveBeenCalledWith({
         center: [-103.38315141, 20.677884013333337],
         zoom: CLUSTER_CLICK_ZOOM_THRESHOLD + 1.1,
+        padding: { left: 0, right: 90, top: 12, bottom: 12 },
       });
     });
 
@@ -474,7 +480,33 @@ describe('ClustersLayer', () => {
       )(clickEvent);
 
       expect(map.easeTo).toHaveBeenCalledTimes(1);
-      expect(map.easeTo).toHaveBeenCalledWith({ center: clusterCoordinates, zoom: CLUSTER_CLICK_ZOOM_THRESHOLD + 1.1 });
+      expect(map.easeTo).toHaveBeenCalledWith({
+        center: clusterCoordinates,
+        zoom: CLUSTER_CLICK_ZOOM_THRESHOLD + 1.1,
+        padding: { left: 0, right: 90, top: 12, bottom: 12 },
+      });
+    });
+
+    test('centers the zoom on the visible map area, accounting for the sidebar, when it is open', () => {
+      getWindowLocation.mockReturnValue({ pathname: '/events' });
+      map.getSource.mockReturnValue({ getClusterExpansionZoom: getClusterExpansionZoomMock });
+      map.getZoom.mockReturnValue(CLUSTER_CLICK_ZOOM_THRESHOLD - 1);
+
+      onClusterClick(
+        clusterCoordinates,
+        clusterFeatures,
+        clusterHash,
+        clusterMarkerHashMapRef,
+        map,
+        onShowClusterSelectPopup,
+        CLUSTERS_SOURCE_ID
+      )(clickEvent);
+
+      expect(map.easeTo).toHaveBeenCalledWith({
+        center: clusterCoordinates,
+        zoom: CLUSTER_CLICK_ZOOM_THRESHOLD + 1.1,
+        padding: { left: 592, right: 90, top: 12, bottom: 12 },
+      });
     });
 
     test('triggers onShowClusterSelectPopup if the current zoom is equal or greater than the threshold', () => {
@@ -492,6 +524,33 @@ describe('ClustersLayer', () => {
 
       expect(onShowClusterSelectPopup).toHaveBeenCalledTimes(1);
       expect(onShowClusterSelectPopup).toHaveBeenCalledWith(clusterFeatures, clusterCoordinates);
+    });
+  });
+
+  describe('calcClusterZoomPadding', () => {
+    test('pads with a zero left offset when no sidebar tab is open, so a stale padding value never lingers on the map camera', () => {
+      getWindowLocation.mockReturnValue({ pathname: '/' });
+
+      expect(calcClusterZoomPadding()).toEqual({ left: 0, right: 90, top: 12, bottom: 12 });
+    });
+
+    test('pads for the sidebar width when a tab is open', () => {
+      getWindowLocation.mockReturnValue({ pathname: '/events' });
+
+      expect(calcClusterZoomPadding()).toEqual({ left: 592, right: 90, top: 12, bottom: 12 });
+    });
+
+    test('pads for the wider detail view when an item is open', () => {
+      getWindowLocation.mockReturnValue({ pathname: '/events/some-event-id' });
+
+      expect(calcClusterZoomPadding()).toEqual({ left: 736, right: 90, top: 12, bottom: 12 });
+    });
+
+    test('pads with a zero left offset and a narrower right offset below the medium layout breakpoint, since the sidebar covers the full viewport', () => {
+      getWindowLocation.mockReturnValue({ pathname: '/events' });
+      BREAKPOINTS.screenIsMediumLayoutOrLarger.matches = false;
+
+      expect(calcClusterZoomPadding()).toEqual({ left: 0, right: 12, top: 12, bottom: 12 });
     });
   });
 

--- a/src/ClustersLayer/utils.js
+++ b/src/ClustersLayer/utils.js
@@ -2,8 +2,10 @@ import { centroid, featureCollection } from '@turf/turf';
 import mapboxgl from 'mapbox-gl';
 
 import { calcGenericFallbackImageUrl, calcSpriteSvgUrl } from '../utils/img';
-import { CLUSTER_CLICK_ZOOM_THRESHOLD, LAYER_IDS, SUBJECT_FEATURE_CONTENT_TYPE } from '../constants';
+import { BREAKPOINTS, CLUSTER_CLICK_ZOOM_THRESHOLD, LAYER_IDS, SUBJECT_FEATURE_CONTENT_TYPE } from '../constants';
+import { calcSidebarPaddingLeft } from '../utils/map';
 import { calcSvgImageIconId } from '../MapImageFromSvgSpriteRenderer';
+import getWindowLocation from '../utils/getWindowLocation';
 import { subjectIsStatic } from '../utils/subjects';
 import { injectStylesToElement } from '../utils/styles';
 import { hashCode } from '../utils/string';
@@ -130,6 +132,16 @@ export const createClusterHTMLMarker = (
   return clusterHTMLMarkerContainer;
 };
 
+export const calcClusterZoomPadding = () => {
+  const isMediumLayoutOrLarger = BREAKPOINTS.screenIsMediumLayoutOrLarger.matches;
+  const left = calcSidebarPaddingLeft({
+    isMediumLayoutOrLarger,
+    pathname: getWindowLocation().pathname,
+  }) ?? 0;
+
+  return { left, right: isMediumLayoutOrLarger ? 90 : 12, top: 12, bottom: 12 };
+};
+
 export const onClusterClick = (
   clusterCoordinates,
   clusterFeatures,
@@ -148,7 +160,12 @@ export const onClusterClick = (
   if (mapZoom < CLUSTER_CLICK_ZOOM_THRESHOLD) {
     map.getSource(sourceId).getClusterExpansionZoom(
       clusterMarkerHashMapRef.current[clusterHash].id,
-      (error, zoom) => !error && map.easeTo({ center: clusterCoordinates, zoom: zoom + 0.1 })
+      (error, zoom) => {
+        if (!error) {
+          const padding = calcClusterZoomPadding();
+          map.easeTo({ center: clusterCoordinates, zoom: zoom + 0.1, padding });
+        }
+      }
     );
   } else {
     onShowClusterSelectPopup(clusterFeatures, clusterCoordinates);

--- a/src/TimeSlider/index.js
+++ b/src/TimeSlider/index.js
@@ -253,6 +253,14 @@ const TimeSlider = () => {
   }, [isSpeedMenuOpen, playbackSpeed]);
 
   useEffect(() => {
+    if (isCompact) {
+      // The time slider is in compact mode. Close the speed menu.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsSpeedMenuOpen(false);
+    }
+  }, [isCompact]);
+
+  useEffect(() => {
     // Reset the virtual date to the end of the range when the event filter
     // date range is changed.
     setVirtualDateFromSliderValue(1);

--- a/src/TimeSlider/index.js
+++ b/src/TimeSlider/index.js
@@ -5,6 +5,7 @@ import Overlay from 'react-bootstrap/Overlay';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Popover from 'react-bootstrap/Popover';
 import { useDispatch, useSelector } from 'react-redux';
+import { useLocation } from 'react-router';
 import { useTranslation } from 'react-i18next';
 
 import { ReactComponent as CalendarIcon } from '../common/images/icons/calendar.svg';
@@ -14,6 +15,8 @@ import { ReactComponent as CrossIcon } from '../common/images/icons/cross.svg';
 import { ReactComponent as PauseIcon } from '../common/images/icons/pause.svg';
 import { ReactComponent as PlayIcon } from '../common/images/icons/play.svg';
 
+import { BREAKPOINTS } from '../constants';
+import { calcSidebarPaddingLeft } from '../utils/map';
 import {
   clearVirtualDate,
   setVirtualDate,
@@ -32,6 +35,7 @@ import {
   trackEventFactory,
 } from '../utils/analytics';
 import { resetGlobalDateRange } from '../ducks/global-date-range';
+import { useMatchMedia } from '../hooks';
 
 import EventFilterDateRange from '../EventFilter/DateRange';
 
@@ -60,6 +64,9 @@ const isAtEnd = (value) => value >= 0.99999;
 const TimeSlider = () => {
   const dispatch = useDispatch();
   const { i18n, t } = useTranslation('components', { keyPrefix: 'timeSlider' });
+  const location = useLocation();
+
+  const isMediumLayoutOrLarger = useMatchMedia(BREAKPOINTS.screenIsMediumLayoutOrLarger);
 
   const eventFilterLowerDateRange = useSelector((state) => state.data.eventFilter.filter.date_range.lower);
   const eventFilterUpperDateRange = useSelector((state) => state.data.eventFilter.filter.date_range.upper);
@@ -73,6 +80,13 @@ const TimeSlider = () => {
   const [isSpeedMenuOpen, setIsSpeedMenuOpen] = useState(false);
   const [playbackSpeed, setPlaybackSpeed] = useState(DEFAULT_PLAYBACK_SPEED);
   const [speedMenuAnchorEl, setSpeedMenuAnchorEl] = useState();
+
+  const sidebarOffsetPixels = calcSidebarPaddingLeft({
+    isMediumLayoutOrLarger,
+    pathname: location.pathname,
+  }) ?? 0;
+
+  const isCompact = sidebarOffsetPixels > 0;
 
   const debouncedRangeChangeAnalytics = useMemo(() => mapInteractionTracker.debouncedTrack(300), []);
 
@@ -268,7 +282,11 @@ const TimeSlider = () => {
 
   useEffect(() => () => debouncedRangeChangeAnalytics.cancel(), [debouncedRangeChangeAnalytics]);
 
-  return <div className={styles.wrapper}>
+  return <div
+      className={`${styles.wrapper} ${isCompact ? styles.compact : ''}`}
+      data-testid="timeSlider-wrapper"
+      style={{ '--sidebar-offset': `${sidebarOffsetPixels}px` }}
+    >
     <button
       aria-label={isPlaying ? t('stopButtonLabel') : t('playButtonLabel')}
       className={styles.playStopButton}
@@ -279,74 +297,76 @@ const TimeSlider = () => {
       {isPlaying ? <PauseIcon aria-hidden="true" /> : <PlayIcon aria-hidden="true" />}
     </button>
 
-    <button
-      aria-controls={speedMenuPopoverId}
-      aria-expanded={isSpeedMenuOpen}
-      aria-haspopup="menu"
-      aria-label={t('speedButtonLabel')}
-      className={styles.speedButton}
-      onClick={() => setIsSpeedMenuOpen((isOpen) => !isOpen)}
-      ref={setSpeedMenuAnchorEl}
-      title={t('speedButtonLabel')}
-      type="button"
-    >
-      {playbackSpeedOption.label}
-    </button>
+    {!isCompact && <>
+      <button
+        aria-controls={speedMenuPopoverId}
+        aria-expanded={isSpeedMenuOpen}
+        aria-haspopup="menu"
+        aria-label={t('speedButtonLabel')}
+        className={styles.speedButton}
+        onClick={() => setIsSpeedMenuOpen((isOpen) => !isOpen)}
+        ref={setSpeedMenuAnchorEl}
+        title={t('speedButtonLabel')}
+        type="button"
+      >
+        {playbackSpeedOption.label}
+      </button>
 
-    <Overlay
-      onHide={() => setIsSpeedMenuOpen(false)}
-      rootClose
-      show={isSpeedMenuOpen}
-      target={speedMenuAnchorEl}
-    >
-      <Popover className={styles.speedMenuPopover} role="presentation">
-        <div aria-hidden="true" className={styles.speedMenuHeader}>{t('speedMenuHeader')}</div>
+      <Overlay
+        onHide={() => setIsSpeedMenuOpen(false)}
+        rootClose
+        show={isSpeedMenuOpen}
+        target={speedMenuAnchorEl}
+      >
+        <Popover className={styles.speedMenuPopover} role="presentation">
+          <div aria-hidden="true" className={styles.speedMenuHeader}>{t('speedMenuHeader')}</div>
 
-        <ul
-          aria-label={t('speedMenuLabel')}
-          className={styles.speedMenu}
-          id={speedMenuPopoverId}
-          onKeyDown={onSpeedMenuKeyDown}
-          role="menu"
-        >
-          {PLAYBACK_SPEED_OPTIONS.map((option, index) => <li
-            className={styles.speedMenuItem}
-            key={option.value}
-            role="none"
+          <ul
+            aria-label={t('speedMenuLabel')}
+            className={styles.speedMenu}
+            id={speedMenuPopoverId}
+            onKeyDown={onSpeedMenuKeyDown}
+            role="menu"
           >
-            <button
-              aria-checked={playbackSpeed === option.value}
-              aria-label={t('speedMenuOptionLabel', { speed: option.label })}
-              className={styles.speedMenuItemOption}
-              onClick={() => onSpeedMenuOptionClick(option.value)}
-              ref={(element) => {
-                speedMenuItemOptionRefs.current[index] = element;
-              }}
-              role="menuitemradio"
-              tabIndex={-1}
-              title={t('speedMenuOptionLabel', { speed: option.label })}
-              type="button"
+            {PLAYBACK_SPEED_OPTIONS.map((option, index) => <li
+              className={styles.speedMenuItem}
+              key={option.value}
+              role="none"
             >
-              {playbackSpeed === option.value && <CheckIcon className={styles.checkIcon} />}
+              <button
+                aria-checked={playbackSpeed === option.value}
+                aria-label={t('speedMenuOptionLabel', { speed: option.label })}
+                className={styles.speedMenuItemOption}
+                onClick={() => onSpeedMenuOptionClick(option.value)}
+                ref={(element) => {
+                  speedMenuItemOptionRefs.current[index] = element;
+                }}
+                role="menuitemradio"
+                tabIndex={-1}
+                title={t('speedMenuOptionLabel', { speed: option.label })}
+                type="button"
+              >
+                {playbackSpeed === option.value && <CheckIcon className={styles.checkIcon} />}
 
-              {option.label}
-            </button>
-          </li>)}
-        </ul>
-      </Popover>
-    </Overlay>
+                {option.label}
+              </button>
+            </li>)}
+          </ul>
+        </Popover>
+      </Overlay>
 
-    <time className={styles.virtualDateWrapper} dateTime={currentDate.toISOString()}>
-      <span className={styles.virtualTime}>
-        {format(currentDate, SHORT_TIME_FORMAT, { locale: dateLocales[i18n.language] })}
-      </span>
+      <time className={styles.virtualDateWrapper} dateTime={currentDate.toISOString()}>
+        <span className={styles.virtualTime}>
+          {format(currentDate, SHORT_TIME_FORMAT, { locale: dateLocales[i18n.language] })}
+        </span>
 
-      <span className={styles.virtualDate}>
-        {format(currentDate, SHORTENED_DATE_FORMAT, { locale: dateLocales[i18n.language] })}
-      </span>
-    </time>
+        <span className={styles.virtualDate}>
+          {format(currentDate, SHORTENED_DATE_FORMAT, { locale: dateLocales[i18n.language] })}
+        </span>
+      </time>
 
-    <div aria-hidden="true" className={styles.separator} />
+      <div aria-hidden="true" className={styles.separator} />
+    </>}
 
     <div className={styles.track}>
       <input
@@ -376,59 +396,61 @@ const TimeSlider = () => {
       </div>
     </div>
 
-    <OverlayTrigger
-      overlay={
-        <Popover className={styles.popover}>
-          <Popover.Header className={styles.popoverTitle}>
-            <ClockIcon aria-hidden="true" />
+    {!isCompact && <>
+      <OverlayTrigger
+        overlay={
+          <Popover className={styles.popover}>
+            <Popover.Header className={styles.popoverTitle}>
+              <ClockIcon aria-hidden="true" />
 
-            {t('popoverHeader')}
+              {t('popoverHeader')}
 
-            <Button
-              disabled={!isEventFilterDateRangeModified}
-              onClick={onClickReset}
-              size="sm"
-              type="button"
-              variant="light"
-            >
-              {t('popoverResetButton')}
-            </Button>
-          </Popover.Header>
+              <Button
+                disabled={!isEventFilterDateRangeModified}
+                onClick={onClickReset}
+                size="sm"
+                type="button"
+                variant="light"
+              >
+                {t('popoverResetButton')}
+              </Button>
+            </Popover.Header>
 
-          <Popover.Body className={styles.popoverBody}>
-            <EventFilterDateRange
-              endDateLabel=""
-              onEndChange={() => trackDateChange()}
-              onStartChange={() => trackDateChange()}
-              placement="top"
-              popoverClassName={styles.dateRangePopover}
-              startDateLabel=""
-            />
-          </Popover.Body>
-        </Popover>
-      }
-      rootClose
-      trigger="click"
-    >
+            <Popover.Body className={styles.popoverBody}>
+              <EventFilterDateRange
+                endDateLabel=""
+                onEndChange={() => trackDateChange()}
+                onStartChange={() => trackDateChange()}
+                placement="top"
+                popoverClassName={styles.dateRangePopover}
+                startDateLabel=""
+              />
+            </Popover.Body>
+          </Popover>
+        }
+        rootClose
+        trigger="click"
+      >
+        <button
+          aria-label={t('dateRangeButtonLabel')}
+          className={`${styles.dateRangeButton} ${isEventFilterDateRangeModified ? styles.modified : ''}`}
+          title={t('dateRangeButtonLabel')}
+          type="button"
+        >
+          <CalendarIcon aria-hidden="true" />
+        </button>
+      </OverlayTrigger>
+
       <button
-        aria-label={t('dateRangeButtonLabel')}
-        className={`${styles.dateRangeButton} ${isEventFilterDateRangeModified ? styles.modified : ''}`}
-        title={t('dateRangeButtonLabel')}
+        aria-label={t('closeButtonLabel')}
+        className={styles.closeButton}
+        onClick={() => dispatch(setTimeSliderState(false))}
+        title={t('closeButtonLabel')}
         type="button"
       >
-        <CalendarIcon aria-hidden="true" />
+        <CrossIcon aria-hidden="true" />
       </button>
-    </OverlayTrigger>
-
-    <button
-      aria-label={t('closeButtonLabel')}
-      className={styles.closeButton}
-      onClick={() => dispatch(setTimeSliderState(false))}
-      title={t('closeButtonLabel')}
-      type="button"
-    >
-      <CrossIcon aria-hidden="true" />
-    </button>
+    </>}
   </div>;
 };
 

--- a/src/TimeSlider/index.test.js
+++ b/src/TimeSlider/index.test.js
@@ -82,7 +82,7 @@ describe('TimeSlider', () => {
   test('offsets for the sidebar width when a tab is open', () => {
     renderTimeSlider(undefined, { initialEntries: ['/events'] });
 
-    expect(screen.getByTestId('timeSlider-wrapper')).toHaveStyle({ '--sidebar-offset': '592px' });
+    expect(screen.getByTestId('timeSlider-wrapper')).toHaveStyle({ '--sidebar-offset': '582px' });
   });
 
   test('offsets for the wider detail view width when an item is open', () => {
@@ -211,6 +211,27 @@ describe('TimeSlider', () => {
 
     expect(screen.queryByRole('menu', { name: 'Playback speed options' })).toBeNull();
     expect(speedButton).toHaveFocus();
+  });
+
+  test('closes the speed menu when compact mode is entered, so it cannot reappear open once compact mode ends', async () => {
+    BREAKPOINTS.screenIsMediumLayoutOrLarger.matches = false;
+
+    renderTimeSlider(undefined, { initialEntries: ['/events'] });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open playback speed options' }));
+
+    expect(screen.getByRole('menu', { name: 'Playback speed options' })).toBeVisible();
+
+    BREAKPOINTS.screenIsMediumLayoutOrLarger.matches = true;
+    fireEvent(window, new Event('resize'));
+
+    expect(screen.queryByRole('button', { name: 'Open playback speed options' })).toBeNull();
+
+    BREAKPOINTS.screenIsMediumLayoutOrLarger.matches = false;
+    fireEvent(window, new Event('resize'));
+
+    expect(screen.getByRole('button', { name: 'Open playback speed options' })).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('menu', { name: 'Playback speed options' })).toBeNull();
   });
 
   test('shows the speed menu header', async () => {

--- a/src/TimeSlider/index.test.js
+++ b/src/TimeSlider/index.test.js
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux';
 import userEvent from '@testing-library/user-event';
 
 import { act, fireEvent, render, screen, waitFor } from '../test-utils';
+import { BREAKPOINTS } from '../constants';
 import {
   clearVirtualDate,
   setVirtualDate,
@@ -39,6 +40,8 @@ describe('TimeSlider', () => {
     setVirtualDate.mockImplementation(() => () => {});
     resetGlobalDateRange.mockImplementation(() => () => {});
 
+    BREAKPOINTS.screenIsMediumLayoutOrLarger.matches = true;
+
     store = {
       data: {
         eventFilter: {
@@ -63,11 +66,73 @@ describe('TimeSlider', () => {
     jest.useRealTimers();
   });
 
-  const renderTimeSlider = (props) => render(
+  const renderTimeSlider = (props, { initialEntries } = {}) => render(
     <Provider store={mockStore(store)}>
       <TimeSlider {...props} />
-    </Provider>
+    </Provider>,
+    { initialEntries }
   );
+
+  test('has no sidebar offset when no sidebar tab is open', () => {
+    renderTimeSlider(undefined, { initialEntries: ['/'] });
+
+    expect(screen.getByTestId('timeSlider-wrapper')).toHaveStyle({ '--sidebar-offset': '0px' });
+  });
+
+  test('offsets for the sidebar width when a tab is open', () => {
+    renderTimeSlider(undefined, { initialEntries: ['/events'] });
+
+    expect(screen.getByTestId('timeSlider-wrapper')).toHaveStyle({ '--sidebar-offset': '592px' });
+  });
+
+  test('offsets for the wider detail view width when an item is open', () => {
+    renderTimeSlider(undefined, { initialEntries: ['/events/some-event-id'] });
+
+    expect(screen.getByTestId('timeSlider-wrapper')).toHaveStyle({ '--sidebar-offset': '736px' });
+  });
+
+  test('has no sidebar offset below the medium layout breakpoint, regardless of the URL', () => {
+    BREAKPOINTS.screenIsMediumLayoutOrLarger.matches = false;
+
+    renderTimeSlider(undefined, { initialEntries: ['/events/some-event-id'] });
+
+    expect(screen.getByTestId('timeSlider-wrapper')).toHaveStyle({ '--sidebar-offset': '0px' });
+  });
+
+  test('hides the other controls, leaving only the slider and the play button, when a sidebar tab is open', () => {
+    renderTimeSlider(undefined, { initialEntries: ['/events'] });
+
+    expect(screen.getByRole('slider', { name: 'Timeslider' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Play timeslider' })).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'Open playback speed options' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Change date range' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Close timeslider' })).toBeNull();
+    expect(screen.queryByRole('time')).toBeNull();
+  });
+
+  test('hides the other controls when a sidebar detail view is open, but keeps the play button', () => {
+    renderTimeSlider(undefined, { initialEntries: ['/events/some-event-id'] });
+
+    expect(screen.getByRole('slider', { name: 'Timeslider' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Play timeslider' })).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'Open playback speed options' })).toBeNull();
+  });
+
+  test('keeps showing the other controls when no sidebar tab is open', () => {
+    renderTimeSlider(undefined, { initialEntries: ['/'] });
+
+    expect(screen.getByRole('button', { name: 'Play timeslider' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Close timeslider' })).toBeVisible();
+  });
+
+  test('keeps showing the other controls when a sidebar tab is open below the medium layout breakpoint, since the CSS media queries already hide them there', () => {
+    BREAKPOINTS.screenIsMediumLayoutOrLarger.matches = false;
+
+    renderTimeSlider(undefined, { initialEntries: ['/events'] });
+
+    expect(screen.getByRole('button', { name: 'Play timeslider' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Close timeslider' })).toBeVisible();
+  });
 
   test('shows the play button', async () => {
     renderTimeSlider();

--- a/src/TimeSlider/styles.module.scss
+++ b/src/TimeSlider/styles.module.scss
@@ -29,6 +29,14 @@
   padding: 0 0.5rem;
   position: absolute;
 
+  &.compact {
+    padding-right: 1.5rem;
+
+    .track {
+      margin-left: 0.5rem;
+    }
+  }
+
   .playStopButton {
     align-items: center;
     background: colors.$bright-blue;
@@ -250,10 +258,10 @@
   }
 
   @media (min-width: layout.$md-layout-width-min) {
-    left: 50%;
+    left: calc(50vw + (var(--sidebar-offset, 0px) / 2));
     transform: translateX(-50%);
-    transition: left 0.3s ease-in-out;
-    width: 66%;
+    transition: left 0.3s ease-in-out, width 0.3s ease-in-out;
+    width: calc((100vw - var(--sidebar-offset, 0px)) * 0.66);
   }
 
   @media print {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -86,6 +86,9 @@ export const BREAKPOINTS = {
   screenIsExtraLargeWidth: window.matchMedia(xlLayoutWidthMin),
 };
 
+export const SIDEBAR_WIDTH_PIXELS = 512;
+export const SIDEBAR_DETAIL_VIEW_WIDTH_PIXELS = 736;
+
 export const LAYER_IDS = {
   ANALYZER_LINES_CRITICAL: 'analyzer-line-critical',
   ANALYZER_LINES_WARNING: 'analyzer-line-warning',

--- a/src/hooks/useJumpToLocation/index.js
+++ b/src/hooks/useJumpToLocation/index.js
@@ -1,39 +1,17 @@
-import { useContext, useMemo } from 'react';
+import { useContext } from 'react';
 import { LngLatBounds } from 'mapbox-gl';
 import { useLocation as useRouterLocation } from 'react-router';
 
 import { BREAKPOINTS } from '../../constants';
-import { getCurrentTabFromURL, getCurrentIdFromURL } from '../../utils/navigation';
+import { calcSidebarPaddingLeft } from '../../utils/map';
 import { MapContext } from '../../MapContext';
 import { useMatchMedia } from '../';
-
-const SIDEBAR_WIDTH_PIXELS = 512;
-const SIDEBAR_DETAIL_VIEW_WIDTH_PIXELS = 736;
 
 const DEFAULT_LOCATION_JUMP_PADDING = {
   left: 12,
   top: 12,
   bottom: 12,
   right: 12,
-};
-
-const calcPadding = (currentTab, isArray, itemId, isMediumLayoutOrLarger) => {
-  const padding = { ...DEFAULT_LOCATION_JUMP_PADDING };
-  const polygonPadding = 350;
-
-  if (isMediumLayoutOrLarger) {
-    if (itemId) {
-      padding.left = isArray
-        ? ( SIDEBAR_DETAIL_VIEW_WIDTH_PIXELS - polygonPadding )
-        : SIDEBAR_DETAIL_VIEW_WIDTH_PIXELS;
-    } else if (currentTab) {
-      padding.left = isArray
-        ? ( SIDEBAR_WIDTH_PIXELS - polygonPadding )
-        : SIDEBAR_WIDTH_PIXELS + 80;
-    }
-    padding.right = 90;
-  }
-  return padding;
 };
 
 const extendBoundsForMultiDimensionalCoords = (coords, mapBounds) => {
@@ -51,15 +29,20 @@ const useJumpToLocation = () => {
   const map = useContext(MapContext);
   const isMediumLayoutOrLarger = useMatchMedia(BREAKPOINTS.screenIsMediumLayoutOrLarger);
 
-  const { currentTab, itemId } = useMemo(() => ({
-    currentTab: getCurrentTabFromURL(routerLocation.pathname),
-    itemId: getCurrentIdFromURL(routerLocation.pathname),
-  }), [routerLocation.pathname]);
-
   return (coords, zoom = 15) => {
     const isArrayCoords = Array.isArray(coords[0]);
 
-    const padding = calcPadding(currentTab, isArrayCoords, itemId, isMediumLayoutOrLarger);
+    const sidebarPaddingLeft = calcSidebarPaddingLeft({
+      isMediumLayoutOrLarger,
+      isPolygon: isArrayCoords,
+      pathname: routerLocation.pathname,
+    });
+
+    const padding = {
+      ...DEFAULT_LOCATION_JUMP_PADDING,
+      ...(sidebarPaddingLeft !== undefined && { left: sidebarPaddingLeft }),
+      ...(isMediumLayoutOrLarger && { right: 90 }),
+    };
 
     if (isArrayCoords && coords.length > 1) {
       const mapBoundaries = coords.reduce(buildLocationJumpBounds, new LngLatBounds());

--- a/src/hooks/useJumpToLocation/index.test.js
+++ b/src/hooks/useJumpToLocation/index.test.js
@@ -142,7 +142,7 @@ describe('useJumpToLocation', () => {
       expect(map.easeTo).toHaveBeenCalledTimes(1);
       expect(map.easeTo).toHaveBeenCalledWith({
         center: [-104.19557197413907, 20.75709101172957],
-        padding: { top: 12, right: 90, bottom: 12, left: 592 },
+        padding: { top: 12, right: 90, bottom: 12, left: 582 },
         speed: 200,
         zoom: 12,
       });

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -8,8 +8,8 @@ import { getCurrentIdFromURL, getCurrentTabFromURL } from './navigation';
 import { imgElFromSrc, calcUrlForImage, calcImgIdFromUrlForMapImages } from './img';
 
 // Extra allowance for the fixed vertical icon nav rail that sits between the
-// sidebar panel and the map.
-const VERTICAL_NAV_RAIL_WIDTH_PIXELS = 80;
+// sidebar panel and the map. Keep in sync with --vertical-nav-width.
+const VERTICAL_NAV_RAIL_WIDTH_PIXELS = 70;
 const POLYGON_PADDING_REDUCTION_PIXELS = 350;
 
 export const calcSidebarPaddingLeft = ({ pathname, isMediumLayoutOrLarger, isPolygon = false }) => {

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -2,9 +2,30 @@ import { featureCollection } from '@turf/turf';
 
 import store from '../store';
 import { addImageToMapIfNecessary } from '../ducks/map-images';
-import { MAP_ICON_SIZE, MAP_ICON_SCALE } from '../constants';
+import { MAP_ICON_SIZE, MAP_ICON_SCALE, SIDEBAR_DETAIL_VIEW_WIDTH_PIXELS, SIDEBAR_WIDTH_PIXELS } from '../constants';
 import { format, formatEventSymbolDate } from './datetime';
+import { getCurrentIdFromURL, getCurrentTabFromURL } from './navigation';
 import { imgElFromSrc, calcUrlForImage, calcImgIdFromUrlForMapImages } from './img';
+
+// Extra allowance for the fixed vertical icon nav rail that sits between the
+// sidebar panel and the map.
+const VERTICAL_NAV_RAIL_WIDTH_PIXELS = 80;
+const POLYGON_PADDING_REDUCTION_PIXELS = 350;
+
+export const calcSidebarPaddingLeft = ({ pathname, isMediumLayoutOrLarger, isPolygon = false }) => {
+  if (isMediumLayoutOrLarger) {
+    const currentTab = getCurrentTabFromURL(pathname);
+    const itemId = getCurrentIdFromURL(pathname);
+
+    if (currentTab || itemId) {
+      return itemId
+        ? SIDEBAR_DETAIL_VIEW_WIDTH_PIXELS - (isPolygon ? POLYGON_PADDING_REDUCTION_PIXELS : 0)
+        : SIDEBAR_WIDTH_PIXELS + (isPolygon ? -POLYGON_PADDING_REDUCTION_PIXELS : VERTICAL_NAV_RAIL_WIDTH_PIXELS);
+    }
+  }
+
+  return undefined;
+};
 
 const addItemPropsToFeatureByKey = (item, feature, key) => {
   const toDelete = ['geojson', 'location', 'geometry', key];

--- a/src/utils/map.test.js
+++ b/src/utils/map.test.js
@@ -2,6 +2,7 @@ import { createMapMock } from '../__test-helpers/mocks';
 
 import {
   buildGeoSpanFilter,
+  calcSidebarPaddingLeft,
   calculatePopoverPlacement,
   safeRemoveMapLayer,
   safeRemoveMapSource,
@@ -216,5 +217,40 @@ describe('safeRemoveMapLayer / safeRemoveMapSource', () => {
     map.getSource.mockReturnValue({});
     safeRemoveMapSource(map, 'source-a');
     expect(map.removeSource).toHaveBeenCalledWith('source-a');
+  });
+});
+
+describe('calcSidebarPaddingLeft', () => {
+  test('returns undefined below the medium layout breakpoint, regardless of the URL', () => {
+    expect(calcSidebarPaddingLeft({ pathname: '/events', isMediumLayoutOrLarger: false })).toBeUndefined();
+    expect(calcSidebarPaddingLeft({ pathname: '/events/some-id', isMediumLayoutOrLarger: false })).toBeUndefined();
+  });
+
+  test('returns undefined when no sidebar tab is open', () => {
+    expect(calcSidebarPaddingLeft({ pathname: '/', isMediumLayoutOrLarger: true })).toBeUndefined();
+  });
+
+  test('pads for the sidebar width, plus the vertical nav rail, when a tab is open', () => {
+    expect(calcSidebarPaddingLeft({ pathname: '/events', isMediumLayoutOrLarger: true })).toBe(592);
+  });
+
+  test('pads for the wider detail view when an item is open', () => {
+    expect(calcSidebarPaddingLeft({ pathname: '/events/some-event-id', isMediumLayoutOrLarger: true })).toBe(736);
+  });
+
+  test('reduces the sidebar padding for a polygon/bounds fit, since it already hugs its own shape', () => {
+    expect(calcSidebarPaddingLeft({
+      pathname: '/events', isMediumLayoutOrLarger: true, isPolygon: true,
+    })).toBe(162);
+  });
+
+  test('reduces the detail-view padding for a polygon/bounds fit', () => {
+    expect(calcSidebarPaddingLeft({
+      pathname: '/events/some-event-id', isMediumLayoutOrLarger: true, isPolygon: true,
+    })).toBe(386);
+  });
+
+  test('prioritizes the detail-view width over the tab width when both are present', () => {
+    expect(calcSidebarPaddingLeft({ pathname: '/patrols/some-patrol-id', isMediumLayoutOrLarger: true })).toBe(736);
   });
 });

--- a/src/utils/map.test.js
+++ b/src/utils/map.test.js
@@ -231,7 +231,7 @@ describe('calcSidebarPaddingLeft', () => {
   });
 
   test('pads for the sidebar width, plus the vertical nav rail, when a tab is open', () => {
-    expect(calcSidebarPaddingLeft({ pathname: '/events', isMediumLayoutOrLarger: true })).toBe(592);
+    expect(calcSidebarPaddingLeft({ pathname: '/events', isMediumLayoutOrLarger: true })).toBe(582);
   });
 
   test('pads for the wider detail view when an item is open', () => {


### PR DESCRIPTION
## What does this PR do?
- Introduced `calcClusterZoomPadding` utility to dynamically calculate zoom padding based on sidebar visibility.
- Updated `onClusterClick` to utilize the new padding logic for smoother map interactions.
- Refactored `TimeSlider` to adjust its layout based on sidebar state, improving user experience on different screen sizes.
- Added tests to verify sidebar offset behavior in `TimeSlider` and ensure correct padding calculations in various scenarios.
- Enhanced styles for compact mode in `TimeSlider` to accommodate layout changes.

## Evidence
**Clusters**
<img width="756" height="431" alt="Kapture 2026-07-09 at 15 32 26" src="https://github.com/user-attachments/assets/7af7516d-04fe-454c-aee1-708e35b32108" />

**Time Slider**
<img width="756" height="431" alt="Kapture 2026-07-09 at 15 34 37" src="https://github.com/user-attachments/assets/e83c47a5-3f32-4637-b5e3-f5d830dbdaf8" />


### Relevant link(s)
- [Branch Environment](https://sidebar-fixes.dev.pamdas.org)

## Notes
The time slider buttons are dropped in "compact mode". We do the same for small (mobile) devices, otherwise its content overflows and becomes hard to use.
<img width="309" height="674" alt="image" src="https://github.com/user-attachments/assets/fad9bef8-6f4b-42e3-bf3a-12a06b664b53" />
