### PR TITLE
ERA-13076: Follow-ups to sprite-icon removal (subject icon URLs + generic id default)

### DIFF
--- a/src/ClustersLayer/index.test.js
+++ b/src/ClustersLayer/index.test.js
@@ -13,7 +13,7 @@ import {
   removeOldClusterMarkers,
 } from './utils';
 import { BREAKPOINTS, CLUSTER_CLICK_ZOOM_THRESHOLD, SOURCE_IDS } from '../constants';
-import { calcSpriteSvgUrl } from '../utils/img';
+import { calcSpriteSvgUrl, calcUrlForImage } from '../utils/img';
 import { calcSvgImageIconId } from '../utils/mapImages';
 import * as eventMapIcons from '../utils/eventMapIcons';
 import ClustersLayer from '.';
@@ -464,6 +464,21 @@ describe('ClustersLayer', () => {
       expect(clusterHTMLMarker.childNodes[1].tagName).toBe('IMG');
       expect(clusterHTMLMarker.childNodes[2].tagName).toBe('IMG');
       expect(clusterHTMLMarker.childNodes[3].tagName).toBe('P');
+    });
+
+    test('resolves a subject feature\'s backend-relative image against DAS_HOST via calcUrlForImage', () => {
+      const relativeImage = '/static/ranger-black.svg';
+      const subjectMarker = createClusterHTMLMarker(
+        [{ properties: { id: '1', content_type: 'observations.subject', image_url: relativeImage } }],
+        onClusterClick,
+        onClusterMouseEnter,
+        onClusterMouseLeave
+      );
+
+      const img = subjectMarker.querySelector('img');
+      expect(img.getAttribute('src')).toBe(calcUrlForImage(relativeImage));
+      // The raw backend-relative path must not be used unresolved.
+      expect(img.getAttribute('src')).not.toBe(relativeImage);
     });
   });
 

--- a/src/ClustersLayer/utils.js
+++ b/src/ClustersLayer/utils.js
@@ -1,7 +1,7 @@
 import { centroid, featureCollection } from '@turf/turf';
 import mapboxgl from 'mapbox-gl';
 
-import { calcGenericFallbackImageUrl, calcSpriteSvgUrl } from '../utils/img';
+import { calcGenericFallbackImageUrl, calcSpriteSvgUrl, calcUrlForImage } from '../utils/img';
 import { BREAKPOINTS, CLUSTER_CLICK_ZOOM_THRESHOLD, LAYER_IDS, SUBJECT_FEATURE_CONTENT_TYPE } from '../constants';
 import { calcSidebarPaddingLeft } from '../utils/map';
 import { calcSvgImageIconId } from '../utils/mapImages';
@@ -115,7 +115,7 @@ const populateClusterIconChildren = (
           featureImageHTML.src = calcGenericFallbackImageUrl(feature.properties);
         };
       } else {
-        featureImageHTML.src = feature.properties.image || feature.properties.image_url;
+        featureImageHTML.src = calcUrlForImage(feature.properties.image || feature.properties.image_url);
       }
     }
     injectStylesToElement(featureImageHTML, FEATURE_ICON_HTML_STYLES);

--- a/src/utils/mapImages.js
+++ b/src/utils/mapImages.js
@@ -6,11 +6,12 @@ export const EVENT_ICON_ID_PREFIX = 'event-icon|';
 
 // Builds the map-image cache key for an event's icon. Must match the format
 // emitted by the Mapbox icon-image expressions: the `event-icon|` prefix
-// followed by icon_id, priority, width, and height, pipe-separated, with absent
-// parts omitted (e.g. "event-icon|fire|200|24|32").
-// The icon_id slot defaults to `'generic'` when absent (mirroring the same
-// default in generateEventIconImage) so the leading slot is always present and
-// the key stays reversible, rather than relying on callers to guard first.
+// followed by icon_id, priority, width, and height, pipe-separated
+// (e.g. "event-icon|fire|200|24|32").
+// The leading icon_id slot is always present: it defaults to `'generic'` when
+// absent (mirroring the same default in generateEventIconImage), so the key
+// stays reversible rather than relying on callers to guard first. Only the
+// trailing numeric slots (priority, width, height) are omitted when absent.
 export const calcSvgImageIconId = ({ icon_id, priority, width, height }) => {
   const parts = [icon_id || 'generic', priority, width, height].filter((value) => value === 0 || Boolean(value));
   return `${EVENT_ICON_ID_PREFIX}${parts.join('|')}`;

--- a/src/utils/mapImages.js
+++ b/src/utils/mapImages.js
@@ -8,10 +8,10 @@ export const EVENT_ICON_ID_PREFIX = 'event-icon|';
 // emitted by the Mapbox icon-image expressions: the `event-icon|` prefix
 // followed by icon_id, priority, width, and height, pipe-separated, with absent
 // parts omitted (e.g. "event-icon|fire|200|24|32").
-// Invariant: callers must pass an `icon_id` (or guard before calling) — absent
-// leading parts make the pipe-format non-reversible, and the GL icon-image
-// expressions always emit the icon_id slot.
+// The icon_id slot defaults to `'generic'` when absent (mirroring the same
+// default in generateEventIconImage) so the leading slot is always present and
+// the key stays reversible, rather than relying on callers to guard first.
 export const calcSvgImageIconId = ({ icon_id, priority, width, height }) => {
-  const parts = [icon_id, priority, width, height].filter((value) => value === 0 || Boolean(value));
+  const parts = [icon_id || 'generic', priority, width, height].filter((value) => value === 0 || Boolean(value));
   return `${EVENT_ICON_ID_PREFIX}${parts.join('|')}`;
 };

--- a/src/utils/mapImages.test.js
+++ b/src/utils/mapImages.test.js
@@ -13,6 +13,10 @@ describe('calcSvgImageIconId', () => {
     expect(calcSvgImageIconId({ icon_id: 'fire', priority: 200 })).toBe('event-icon|fire|200');
   });
 
+  it('defaults the icon_id slot to "generic" when absent so the leading slot stays present and reversible', () => {
+    expect(calcSvgImageIconId({ priority: 200 })).toBe('event-icon|generic|200');
+  });
+
   it('treats a priority of 0 as a meaningful value rather than omitting it', () => {
     expect(calcSvgImageIconId({ icon_id: 'fire', priority: 0 })).toBe('event-icon|fire|0');
   });


### PR DESCRIPTION
## What does this PR do?

Two small follow-ups to #1529 (sprite-icon removal), surfaced by Copilot's review of that PR and by developer feedback:

1. **Resolve subject cluster-icon URLs against `DAS_HOST`.** Cluster markers for subjects (no `icon_id`) set their `<img>` src straight from `feature.properties.image`/`image_url`, so backend-relative paths like `/static/ranger-black.svg` resolved against the SPA origin and 404'd. Wrapped the fallback in `calcUrlForImage`, consistent with other subject-icon usages.

2. **Default the event icon-id slot to `'generic'` in `calcSvgImageIconId`.** An absent `icon_id` previously dropped the slot entirely, yielding a non-reversible key (`event-icon|200`) that the `styleimagemissing` reverse-parse could misassign. Defaulting the slot to `'generic'` keeps the pipe key always reversible, matching `generateEventIconImage`'s existing fallback. Only the icon_id-absent branch changes; icon_id-present keys are byte-identical.

## Testing

- `yarn lint` clean on all changed files.
- `yarn test src/ClustersLayer src/utils/mapImages src/utils/eventMapIcons` → all green (added a subject-URL wrapping test and a `calcSvgImageIconId({ priority: 200 })` → `event-icon|generic|200` case).

## Notes

Two other review points were considered and **intentionally not actioned here**:

- **Cluster markers are withheld until their icons resolve** (was: mount immediately, upgrade later). Confirmed real via the `iconsReady` gate in `addNewClusterMarkers` — subjects don't block, but event-bearing clusters wait one sprite fetch per distinct `icon_id` on a cold cache. This is a deliberate design choice from #1529 and a potential UX regression on throttled connections; flagging for a throttled-network spot-check rather than changing the gating unilaterally.
- **Module-level icon caches not scoped by community** — not a reachable path: `SvgIcon`'s `svgCache` is keyed by the full (community-inclusive) URL, and the map's `eventMapIcons` caches are single-tenant (`DAS_HOST`, no community segment) and never mounted by `CommunityPage` (a sibling route to the authenticated app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
