### PR TITLE
ERA-13728: V1 dropdown fields cant be updated to empty fields

### DIFF
--- a/src/ReportManager/DetailsSection/index.test.js
+++ b/src/ReportManager/DetailsSection/index.test.js
@@ -463,6 +463,58 @@ describe('ReportManager - DetailsSection', () => {
     expect(onLegacyFormChange).toHaveBeenCalled();
   });
 
+  const legacyEventSchemaWithDropdown = {
+    ...eventSchemas.accident_rep.base,
+    schema: {
+      ...eventSchemas.accident_rep.base.schema,
+      properties: {
+        ...eventSchemas.accident_rep.base.schema.properties,
+        severity: {
+          type: 'string',
+          title: 'Severity',
+          enum: ['minor', 'major'],
+          enumNames: ['Minor', 'Major'],
+          key: 'severity',
+        },
+      },
+    },
+    uiSchema: {
+      ...eventSchemas.accident_rep.base.uiSchema,
+      'ui:groups': [{
+        origin: 'inferred',
+        items: ['type_accident', 'number_people_involved', 'animals_involved', 'severity'],
+      }],
+    },
+  };
+
+  test('drops the key of a cleared dropdown from the legacy form change data', async () => {
+    renderDetailsSection({
+      eventSchema: legacyEventSchemaWithDropdown,
+      reportForm: { ...report, event_details: { severity: 'minor', type_accident: 'Truck crash' } },
+    });
+
+    await userEvent.selectOptions(screen.getByLabelText('Severity'), '');
+
+    const { formData } = onLegacyFormChange.mock.calls.at(-1)[0];
+    expect(formData.severity).toBeUndefined();
+    expect(formData.type_accident).toBe('Truck crash');
+  });
+
+  test('keeps event details keys that are not in the schema in the legacy form change data', async () => {
+    renderDetailsSection({
+      eventSchema: legacyEventSchemaWithDropdown,
+      reportForm: {
+        ...report,
+        event_details: { severity: 'minor', stashed_hidden_field: 'stashed value', type_accident: 'Truck crash' },
+      },
+    });
+
+    await userEvent.selectOptions(screen.getByLabelText('Severity'), '');
+
+    const { formData } = onLegacyFormChange.mock.calls.at(-1)[0];
+    expect(formData.stashed_hidden_field).toBe('stashed value');
+  });
+
   test('submits the form for legacy schemas', async () => {
     renderDetailsSection();
 

--- a/src/ReportManager/ReportDetailView/index.js
+++ b/src/ReportManager/ReportDetailView/index.js
@@ -443,13 +443,16 @@ const ReportDetailView = ({
   }, [reportForm, reportTracker]);
 
   const onLegacyFormChange = useCallback((event) => {
-    const formData = Object.entries(event.formData).reduce((acc, [formKey, formData]) => ({
+    const eventDetails = reportForm.event_details ?? {};
+    const eventDetailsKeys = new Set([...Object.keys(eventDetails), ...Object.keys(event.formData)]);
+    // rjsf unsets a cleared leaf field's key, so a key missing from
+    // event.formData means the field was cleared.
+    const updatedEventDetails = [...eventDetailsKeys].reduce((acc, key) => ({
       ...acc,
-      [formKey]: formData === undefined ? '' : formData
+      [key]: key in event.formData ? event.formData[key] : ''
     }), {});
 
-    setReportForm({ ...reportForm, event_details: { ...reportForm.event_details, ...formData } });
-
+    setReportForm({ ...reportForm, event_details: updatedEventDetails });
   }, [reportForm]);
 
   const onFormError = useCallback((errors) => {

--- a/src/ReportManager/ReportDetailView/index.js
+++ b/src/ReportManager/ReportDetailView/index.js
@@ -445,14 +445,14 @@ const ReportDetailView = ({
   const onLegacyFormChange = useCallback((event) => {
     const eventDetails = reportForm.event_details ?? {};
     const eventDetailsKeys = new Set([...Object.keys(eventDetails), ...Object.keys(event.formData)]);
-    // rjsf unsets a cleared leaf field's key, so a key missing from
-    // event.formData means the field was cleared.
-    const updatedEventDetails = [...eventDetailsKeys].reduce((acc, key) => ({
-      ...acc,
-      [key]: key in event.formData ? event.formData[key] : ''
+    // rjsf unsets (deletes) or sets to undefined a cleared leaf field's key,
+    // so a missing or undefined value in event.formData means the field was cleared.
+    const nextEventDetails = [...eventDetailsKeys].reduce((accumulator, eventDetailKey) => ({
+      ...accumulator,
+      [eventDetailKey]: event.formData[eventDetailKey] === undefined ? '' : event.formData[eventDetailKey]
     }), {});
 
-    setReportForm({ ...reportForm, event_details: updatedEventDetails });
+    setReportForm({ ...reportForm, event_details: nextEventDetails });
   }, [reportForm]);
 
   const onFormError = useCallback((errors) => {

--- a/src/ReportManager/ReportDetailView/index.test.js
+++ b/src/ReportManager/ReportDetailView/index.test.js
@@ -318,6 +318,63 @@ describe('ReportManager - ReportDetailView', () => {
     expect((await screen.findByDisplayValue('Truck crash'))).toBeDefined();
   });
 
+  test('sends an empty value for a cleared legacy dropdown and keeps out-of-schema event details when saving', async () => {
+    const accidentSchema = eventSchemas.accident_rep.base;
+    state.data.eventSchemas = {
+      ...eventSchemas,
+      accident_rep: {
+        ...eventSchemas.accident_rep,
+        789: {
+          ...accidentSchema,
+          schema: {
+            ...accidentSchema.schema,
+            properties: {
+              ...accidentSchema.schema.properties,
+              severity: {
+                type: 'string',
+                title: 'Severity',
+                enum: ['minor', 'major'],
+                enumNames: ['Minor', 'Major'],
+                key: 'severity',
+              },
+            },
+          },
+          uiSchema: {
+            ...accidentSchema.uiSchema,
+            'ui:groups': [{
+              origin: 'inferred',
+              items: ['type_accident', 'number_people_involved', 'animals_involved', 'severity'],
+            }],
+          },
+        },
+      },
+    };
+    state.data.eventStore = {
+      ...state.data.eventStore,
+      789: {
+        ...mockReport,
+        event_type: 'accident_rep',
+        event_details: { severity: 'minor', stashed_hidden_field: 'stashed value', type_accident: 'Truck crash' },
+        id: '789',
+      },
+    };
+
+    renderWithWrapper(<ReportDetailView isNewReport={false} reportId="789" />);
+
+    await userEvent.selectOptions(await screen.findByLabelText('Severity'), '');
+
+    await userEvent.click(await screen.findByText('Save'));
+
+    await waitFor(() => {
+      expect(generateSaveActionsForReportLikeObject).toHaveBeenCalledTimes(1);
+    });
+    expect(generateSaveActionsForReportLikeObject.mock.calls[0][0].event_details).toEqual({
+      severity: '',
+      stashed_hidden_field: 'stashed value',
+      type_accident: 'Truck crash',
+    });
+  });
+
   test('sets the state when user changes it', async () => {
     renderWithWrapper(
       <ReportDetailView


### PR DESCRIPTION
## What does this PR do?
Refactor legacy form change handling to correctly update event details.
- Improved the logic for updating event details in the report form to handle cleared fields appropriately.
- Ensured that missing keys in the form data are set to an empty string, enhancing data integrity.

### Relevant link(s)
- [ERA-13728](https://allenai.atlassian.net/browse/ERA-13728)


[ERA-13728]: https://allenai.atlassian.net/browse/ERA-13728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ