### PR TITLE
ERA-13735 Replace patrol track download with GeoJSON/CSV patrol exports

### DIFF
--- a/public/locales/en-US/patrols.json
+++ b/public/locales/en-US/patrols.json
@@ -64,8 +64,9 @@
     "endPatrol": "End Patrol",
     "label": "View Patrol Options",
     "title": "Patrol Options",
-    "downloadTrackButton": "Download Patrol Track",
-    "noTrackDataTooltip": "No data to download",
+    "exportPatrolGeoJsonButton": "Export Patrol GeoJson",
+    "exportPatrolCsvButton": "Export Patrol CSV",
+    "noDataToExportTooltip": "No data to export",
     "printPatrolButton": "Print Patrol",
     "restorePatrol": "Restore Patrol",
     "startPatrol": "Start Patrol"

--- a/public/locales/en-US/patrols.json
+++ b/public/locales/en-US/patrols.json
@@ -67,6 +67,7 @@
     "exportPatrolGeoJsonButton": "Export Patrol GeoJson",
     "exportPatrolCsvButton": "Export Patrol CSV",
     "noDataToExportTooltip": "No data to export",
+    "exportErrorToast": "Unable to export patrol data",
     "printPatrolButton": "Print Patrol",
     "restorePatrol": "Restore Patrol",
     "startPatrol": "Start Patrol"

--- a/public/locales/es/patrols.json
+++ b/public/locales/es/patrols.json
@@ -67,7 +67,8 @@
     "printPatrolButton": "Imprimir patrulla",
     "restorePatrol": "Restaurar Patrulla",
     "startPatrol": "Iniciar Patrullaje",
-    "noDataToExportTooltip": "No hay datos para exportar"
+    "noDataToExportTooltip": "No hay datos para exportar",
+    "exportErrorToast": "No se pudo exportar los datos de la patrulla"
   },
   "patrolList": {
     "emptyPatrolList": "No hay más patrullas que mostrar."

--- a/public/locales/es/patrols.json
+++ b/public/locales/es/patrols.json
@@ -62,11 +62,12 @@
     "copyButton": "Copiar link del patrulla",
     "copyButtonMessage": "Link copiado",
     "endPatrol": "Finalizar Patrullaje",
-    "downloadTrackButton": "Descargar ruta de patrulla",
+    "exportPatrolGeoJsonButton": "Exportar patrulla en GeoJson",
+    "exportPatrolCsvButton": "Exportar patrulla en CSV",
     "printPatrolButton": "Imprimir patrulla",
     "restorePatrol": "Restaurar Patrulla",
     "startPatrol": "Iniciar Patrullaje",
-    "noTrackDataTooltip": "No hay datos para descargar"
+    "noDataToExportTooltip": "No hay datos para exportar"
   },
   "patrolList": {
     "emptyPatrolList": "No hay más patrullas que mostrar."

--- a/public/locales/fr/patrols.json
+++ b/public/locales/fr/patrols.json
@@ -67,7 +67,8 @@
     "printPatrolButton": "Imprimer la Patrouille",
     "restorePatrol": "Restaurer la Patrouille",
     "startPatrol": "Commencer la Patrouille",
-    "noDataToExportTooltip": "Aucune donnée à exporter"
+    "noDataToExportTooltip": "Aucune donnée à exporter",
+    "exportErrorToast": "Impossible d'exporter les données de la patrouille"
   },
   "patrolList": {
     "emptyPatrolList": "Aucune patrouille à afficher."

--- a/public/locales/fr/patrols.json
+++ b/public/locales/fr/patrols.json
@@ -62,11 +62,12 @@
     "copyButton": "Copier le lien de la patrouille",
     "copyButtonMessage": "Lien copié avec succès",
     "endPatrol": "Terminer la Patrouille",
-    "downloadTrackButton": "Télécharger la Piste de la Patrouille",
+    "exportPatrolGeoJsonButton": "Exporter la patrouille en GeoJson",
+    "exportPatrolCsvButton": "Exporter la patrouille en CSV",
     "printPatrolButton": "Imprimer la Patrouille",
     "restorePatrol": "Restaurer la Patrouille",
     "startPatrol": "Commencer la Patrouille",
-    "noTrackDataTooltip": "Aucune donnée à télécharger"
+    "noDataToExportTooltip": "Aucune donnée à exporter"
   },
   "patrolList": {
     "emptyPatrolList": "Aucune patrouille à afficher."

--- a/public/locales/ne-NP/patrols.json
+++ b/public/locales/ne-NP/patrols.json
@@ -69,7 +69,8 @@
     "startPatrol": "गस्ती सुरु गर्नुहोस्",
     "label": "गस्तीका विकल्पहरु हेर्नुहोस्",
     "title": "गस्तीका विकल्पहरु",
-    "noDataToExportTooltip": "निर्यात गर्न कुनै डेटा छैन"
+    "noDataToExportTooltip": "निर्यात गर्न कुनै डेटा छैन",
+    "exportErrorToast": "गस्तीको डेटा निर्यात गर्न सकिएन"
   },
   "patrolList": {
     "emptyPatrolList": "प्रदर्शनीका लागि कुनै गस्ती छैन ।"

--- a/public/locales/ne-NP/patrols.json
+++ b/public/locales/ne-NP/patrols.json
@@ -62,13 +62,14 @@
     "copyButton": "गस्तीको लिकं कपि गर्नुहोस्",
     "copyButtonMessage": "लिकं कपि भयो",
     "endPatrol": "गस्ती अन्त्य गर्नुहोस्",
-    "downloadTrackButton": "गस्तीको ट्र्याक डाउनलोड गर्नुहोस्",
+    "exportPatrolGeoJsonButton": "गस्ती GeoJson निर्यात गर्नुहोस्",
+    "exportPatrolCsvButton": "गस्ती CSV निर्यात गर्नुहोस्",
     "printPatrolButton": "गस्ती प्रिन्ट गर्नुहोस्",
     "restorePatrol": "गस्ती पुर्नस्थापना गर्नुहोस्",
     "startPatrol": "गस्ती सुरु गर्नुहोस्",
     "label": "गस्तीका विकल्पहरु हेर्नुहोस्",
     "title": "गस्तीका विकल्पहरु",
-    "noTrackDataTooltip": "डाउनलोड गर्न कुनै डेटा छैन"
+    "noDataToExportTooltip": "निर्यात गर्न कुनै डेटा छैन"
   },
   "patrolList": {
     "emptyPatrolList": "प्रदर्शनीका लागि कुनै गस्ती छैन ।"

--- a/public/locales/pt/patrols.json
+++ b/public/locales/pt/patrols.json
@@ -62,11 +62,12 @@
     "copyButton": "Copiar link de patrulha",
     "copyButtonMessage": "Link copiado",
     "endPatrol": "Finalizar patrulha",
-    "downloadTrackButton": "Baixar trilha da patrulha",
+    "exportPatrolGeoJsonButton": "Exportar patrulha em GeoJson",
+    "exportPatrolCsvButton": "Exportar patrulha em CSV",
     "printPatrolButton": "Imprimir patrulha",
     "restorePatrol": "Restaurar patrulha",
     "startPatrol": "Iniciar patrulha",
-    "noTrackDataTooltip": "Nenhum dado para baixar"
+    "noDataToExportTooltip": "Nenhum dado para exportar"
   },
   "patrolList": {
     "emptyPatrolList": "Não há patrulhas para mostrar"

--- a/public/locales/pt/patrols.json
+++ b/public/locales/pt/patrols.json
@@ -67,7 +67,8 @@
     "printPatrolButton": "Imprimir patrulha",
     "restorePatrol": "Restaurar patrulha",
     "startPatrol": "Iniciar patrulha",
-    "noDataToExportTooltip": "Nenhum dado para exportar"
+    "noDataToExportTooltip": "Nenhum dado para exportar",
+    "exportErrorToast": "Não foi possível exportar os dados da patrulha"
   },
   "patrolList": {
     "emptyPatrolList": "Não há patrulhas para mostrar"

--- a/public/locales/sw/patrols.json
+++ b/public/locales/sw/patrols.json
@@ -64,12 +64,13 @@
     "endPatrol": "Maliza Doria",
     "label": "Angalia Chaguzi za Doria",
     "title": "Chaguzi za Doria",
-    "exportPatrolGeoJsonButton": "Nakili Doria kama GeoJson",
-    "exportPatrolCsvButton": "Nakili Doria kama CSV",
+    "exportPatrolGeoJsonButton": "Hamisha GeoJson ya Doria",
+    "exportPatrolCsvButton": "Hamisha CSV ya Doria",
     "printPatrolButton": "Chapisha Doria",
     "restorePatrol": "Rejesha Doria",
     "startPatrol": "Anza Doria",
-    "noDataToExportTooltip": "Hakuna data ya kunakili"
+    "noDataToExportTooltip": "Hakuna data ya kuhamisha",
+    "exportErrorToast": "Imeshindwa kuhamisha data ya doria"
   },
   "patrolList": {
     "emptyPatrolList": "Hakuna doria za kuonyesha."

--- a/public/locales/sw/patrols.json
+++ b/public/locales/sw/patrols.json
@@ -64,11 +64,12 @@
     "endPatrol": "Maliza Doria",
     "label": "Angalia Chaguzi za Doria",
     "title": "Chaguzi za Doria",
-    "downloadTrackButton": "Pakua Njia ya Doria",
+    "exportPatrolGeoJsonButton": "Nakili Doria kama GeoJson",
+    "exportPatrolCsvButton": "Nakili Doria kama CSV",
     "printPatrolButton": "Chapisha Doria",
     "restorePatrol": "Rejesha Doria",
     "startPatrol": "Anza Doria",
-    "noTrackDataTooltip": "Hakuna data ya kupakua"
+    "noDataToExportTooltip": "Hakuna data ya kunakili"
   },
   "patrolList": {
     "emptyPatrolList": "Hakuna doria za kuonyesha."

--- a/src/PatrolMenu/index.js
+++ b/src/PatrolMenu/index.js
@@ -1,5 +1,4 @@
 import React, { memo, useMemo, useCallback } from 'react';
-import { useSelector } from 'react-redux';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
 import { useReactToPrint } from 'react-to-print';
@@ -14,7 +13,7 @@ import { ReactComponent as CloseIcon } from '../common/images/icons/close-icon.s
 import { ReactComponent as RestoreIcon } from '../common/images/icons/restore.svg';
 
 import { DAS_HOST, PATROL_UI_STATES, PATROL_API_STATES } from '../constants';
-import { TRACKS_API_URL } from '../ducks/tracks';
+import { PATROLS_API_URL } from '../ducks/patrols';
 import { usePatrolsPermissions } from '../hooks/usePermissions';
 import { trackEventFactory, PATROL_LIST_ITEM_CATEGORY } from '../utils/analytics';
 import { canEndPatrol, calcPatrolState } from '../utils/patrols';
@@ -44,32 +43,6 @@ const PatrolMenu = ({
   const patrolState = calcPatrolState(patrol);
 
   const { hasPatrolsUpdatePermission } = usePatrolsPermissions();
-  const patrolLeader = patrol.patrol_segments[0]?.leader;
-  const patrolTimeRange = patrol.patrol_segments[0]?.time_range;
-
-  const patrolLeaderTrackTimes = useSelector((state) =>
-    state.data.tracks[patrolLeader?.id]?.track?.features?.[0]?.properties?.coordinateProperties?.times
-  );
-
-  const doesPatrolLeaderHaveTracksWithinPatrolTimeRange = useMemo(() => {
-    if (!patrolLeaderTrackTimes?.length) return false;
-
-    const patrolStartTimestamp = patrolTimeRange?.start_time
-      ? new Date(patrolTimeRange.start_time).getTime()
-      : null;
-    const patrolEndTimestamp = patrolTimeRange?.end_time
-      ? new Date(patrolTimeRange.end_time).getTime()
-      : null;
-
-    if (!patrolStartTimestamp && !patrolEndTimestamp) return true;
-
-    // Track times are sorted newest-first; check range overlap using only the first/last entries
-    const trackNewest = new Date(patrolLeaderTrackTimes[0]).getTime();
-    const trackOldest = new Date(patrolLeaderTrackTimes[patrolLeaderTrackTimes.length - 1]).getTime();
-
-    return (!patrolStartTimestamp || trackNewest >= patrolStartTimestamp)
-      && (!patrolEndTimestamp || trackOldest <= patrolEndTimestamp);
-  }, [patrolLeaderTrackTimes, patrolTimeRange]);
 
   const patrolIsDone = useMemo(() => {
     return patrolState === PATROL_UI_STATES.DONE;
@@ -132,23 +105,31 @@ const PatrolMenu = ({
     }
   }, [canEnd, onPatrolChange, patrolStartStopTitle]);
 
-  const handleDownloadTrack = useCallback(() => {
-    if (!patrolLeader) return;
+  const handleExportPatrolGeoJson = useCallback(() => {
+    patrolListItemTracker.track('Export patrol GeoJSON from patrol list item kebab menu');
 
-    patrolListItemTracker.track('Download patrol track from patrol list item kebab menu');
-
-    const params = {};
-    if (patrolTimeRange?.start_time) params.since = patrolTimeRange.start_time;
-    if (patrolTimeRange?.end_time) params.until = patrolTimeRange.end_time;
-
-    const sanitizedLeaderName = patrolLeader.name.replace(/[/\\:*?"<>|]/g, '_').trim();
-    void downloadFileFromUrl(TRACKS_API_URL(patrolLeader.id), { params, filename: `Patrol_${patrol.serial_number}_${sanitizedLeaderName}.geojson` })
+    void downloadFileFromUrl(`${PATROLS_API_URL}${patrol.id}`, {
+      params: { format: 'geojson', include_events: true, include_tracks: true },
+      filename: `Patrol_${patrol.serial_number}.geojson`,
+    })
       .catch((error) => {
-        console.error('Failed to download patrol track', error);
+        console.error('Failed to export patrol GeoJSON', error);
       });
-  }, [patrol.serial_number, patrolLeader, patrolTimeRange]);
+  }, [patrol.id, patrol.serial_number]);
 
-  const isDownloadDisabled = !patrolLeader || !doesPatrolLeaderHaveTracksWithinPatrolTimeRange;
+  const handleExportPatrolCsv = useCallback(() => {
+    patrolListItemTracker.track('Export patrol CSV from patrol list item kebab menu');
+
+    void downloadFileFromUrl(`${PATROLS_API_URL}${patrol.id}`, {
+      params: { format: 'csv' },
+      filename: `Patrol_${patrol.serial_number}.csv`,
+    })
+      .catch((error) => {
+        console.error('Failed to export patrol CSV', error);
+      });
+  }, [patrol.id, patrol.serial_number]);
+
+  const isExportDisabled = !patrol.id;
 
   const handlePrint = useReactToPrint({
     contentRef: printableContentRef,
@@ -196,21 +177,39 @@ const PatrolMenu = ({
       </KebabMenu.Option>
     }
 
-    {isDownloadDisabled
+    {isExportDisabled
       ? <OverlayTrigger
           placement="top"
-          overlay={<Tooltip id={`download-track-tooltip-${patrol.id}`}>{t('noTrackDataTooltip')}</Tooltip>}
+          overlay={<Tooltip id={`export-patrol-geojson-tooltip-${patrol.id}`}>{t('noDataToExportTooltip')}</Tooltip>}
         >
         <span>
-          <KebabMenu.Option disabled onClick={handleDownloadTrack}>
+          <KebabMenu.Option disabled onClick={handleExportPatrolGeoJson}>
             <DownloadArrowIcon data-testid="download-arrow-icon" />
-            {t('downloadTrackButton')}
+            {t('exportPatrolGeoJsonButton')}
           </KebabMenu.Option>
         </span>
       </OverlayTrigger>
-      : <KebabMenu.Option onClick={handleDownloadTrack}>
+      : <KebabMenu.Option onClick={handleExportPatrolGeoJson}>
         <DownloadArrowIcon data-testid="download-arrow-icon" />
-        {t('downloadTrackButton')}
+        {t('exportPatrolGeoJsonButton')}
+      </KebabMenu.Option>
+    }
+
+    {isExportDisabled
+      ? <OverlayTrigger
+          placement="top"
+          overlay={<Tooltip id={`export-patrol-csv-tooltip-${patrol.id}`}>{t('noDataToExportTooltip')}</Tooltip>}
+        >
+        <span>
+          <KebabMenu.Option disabled onClick={handleExportPatrolCsv}>
+            <DownloadArrowIcon data-testid="download-arrow-icon" />
+            {t('exportPatrolCsvButton')}
+          </KebabMenu.Option>
+        </span>
+      </OverlayTrigger>
+      : <KebabMenu.Option onClick={handleExportPatrolCsv}>
+        <DownloadArrowIcon data-testid="download-arrow-icon" />
+        {t('exportPatrolCsvButton')}
       </KebabMenu.Option>
     }
   </KebabMenu>;

--- a/src/PatrolMenu/index.js
+++ b/src/PatrolMenu/index.js
@@ -19,6 +19,7 @@ import { trackEventFactory, PATROL_LIST_ITEM_CATEGORY } from '../utils/analytics
 import { canEndPatrol, calcPatrolState } from '../utils/patrols';
 import { basePrintingStyles } from '../utils/styles';
 import { downloadFileFromUrl } from '../utils/download';
+import { showToast } from '../utils/toast';
 
 import TextCopyBtn from '../TextCopyBtn';
 import KebabMenu from '../KebabMenu';
@@ -106,28 +107,34 @@ const PatrolMenu = ({
   }, [canEnd, onPatrolChange, patrolStartStopTitle]);
 
   const handleExportPatrolGeoJson = useCallback(() => {
+    if (!patrol.id) return;
+
     patrolListItemTracker.track('Export patrol GeoJSON from patrol list item kebab menu');
 
-    void downloadFileFromUrl(`${PATROLS_API_URL}${patrol.id}`, {
+    downloadFileFromUrl(`${PATROLS_API_URL}${patrol.id}`, {
       params: { format: 'geojson', include_events: true, include_tracks: true },
       filename: `Patrol_${patrol.serial_number}.geojson`,
     })
       .catch((error) => {
         console.error('Failed to export patrol GeoJSON', error);
+        showToast({ message: t('exportErrorToast') });
       });
-  }, [patrol.id, patrol.serial_number]);
+  }, [patrol.id, patrol.serial_number, t]);
 
   const handleExportPatrolCsv = useCallback(() => {
+    if (!patrol.id) return;
+
     patrolListItemTracker.track('Export patrol CSV from patrol list item kebab menu');
 
-    void downloadFileFromUrl(`${PATROLS_API_URL}${patrol.id}`, {
+    downloadFileFromUrl(`${PATROLS_API_URL}${patrol.id}`, {
       params: { format: 'csv' },
       filename: `Patrol_${patrol.serial_number}.csv`,
     })
       .catch((error) => {
         console.error('Failed to export patrol CSV', error);
+        showToast({ message: t('exportErrorToast') });
       });
-  }, [patrol.id, patrol.serial_number]);
+  }, [patrol.id, patrol.serial_number, t]);
 
   const isExportDisabled = !patrol.id;
 
@@ -180,9 +187,9 @@ const PatrolMenu = ({
     {isExportDisabled
       ? <OverlayTrigger
           placement="top"
-          overlay={<Tooltip id={`export-patrol-geojson-tooltip-${patrol.id}`}>{t('noDataToExportTooltip')}</Tooltip>}
+          overlay={<Tooltip id="export-patrol-geojson-tooltip">{t('noDataToExportTooltip')}</Tooltip>}
         >
-        <span>
+        <span tabIndex={0}>
           <KebabMenu.Option disabled onClick={handleExportPatrolGeoJson}>
             <DownloadArrowIcon data-testid="download-arrow-icon" />
             {t('exportPatrolGeoJsonButton')}
@@ -198,9 +205,9 @@ const PatrolMenu = ({
     {isExportDisabled
       ? <OverlayTrigger
           placement="top"
-          overlay={<Tooltip id={`export-patrol-csv-tooltip-${patrol.id}`}>{t('noDataToExportTooltip')}</Tooltip>}
+          overlay={<Tooltip id="export-patrol-csv-tooltip">{t('noDataToExportTooltip')}</Tooltip>}
         >
-        <span>
+        <span tabIndex={0}>
           <KebabMenu.Option disabled onClick={handleExportPatrolCsv}>
             <DownloadArrowIcon data-testid="download-arrow-icon" />
             {t('exportPatrolCsvButton')}

--- a/src/PatrolMenu/index.test.js
+++ b/src/PatrolMenu/index.test.js
@@ -8,6 +8,7 @@ import userEvent from '@testing-library/user-event';
 import { useReactToPrint } from 'react-to-print';
 
 import { PERMISSION_KEYS, PERMISSIONS, SYSTEM_CONFIG_FLAGS } from '../constants';
+import { PATROLS_API_URL } from '../ducks/patrols';
 import { render, screen } from '../test-utils';
 import { downloadFileFromUrl } from '../utils/download';
 
@@ -17,10 +18,6 @@ jest.mock('react-to-print', () => ({
 }));
 
 jest.mock('../store', () => ({}));
-
-jest.mock('../ducks/tracks', () => ({
-  TRACKS_API_URL: (id) => `/api/v1.0/subject/${id}/tracks/`,
-}));
 
 jest.mock('../utils/download', () => ({
   downloadFileFromUrl: jest.fn(() => Promise.resolve()),
@@ -145,128 +142,66 @@ describe('PatrolMenu', () => {
     });
   });
 
-  describe('Download Patrol Track button', () => {
+  describe('Export Patrol options', () => {
     beforeEach(() => {
       downloadFileFromUrl.mockImplementation(() => Promise.resolve());
-    });
-
-    // patrols[1] has a leader and a start_time, making it suitable for track tests
-    const patrolWithLeader = patrols[1];
-    const leaderId = patrolWithLeader.patrol_segments[0].leader.id;
-    const patrolStartTime = patrolWithLeader.patrol_segments[0].time_range.start_time;
-
-    const makeTrackStore = (times) => ({
-      ...minimumNecessaryStoreStructure,
-      data: {
-        ...minimumNecessaryStoreStructure.data,
-        tracks: {
-          [leaderId]: {
-            track: {
-              features: [{
-                properties: { coordinateProperties: { times } },
-              }],
-            },
-          },
-        },
-      },
     });
 
     const openMenu = async () => {
       await userEvent.click(screen.getByRole('button'));
     };
 
-    const getDownloadOption = () =>
-      screen.getByText('Download Patrol Track').closest('a');
+    const getExportGeoJsonOption = () =>
+      screen.getByText('Export Patrol GeoJson').closest('a');
 
-    test('is disabled when patrol has no leader', async () => {
-      renderPatrolMenu({ ...initialProps, patrol: patrols[0] });
+    const getExportCsvOption = () =>
+      screen.getByText('Export Patrol CSV').closest('a');
+
+    test('both options are disabled when the patrol has no id', async () => {
+      renderPatrolMenu({ ...initialProps, patrol: { ...testPatrol, id: undefined } });
       await openMenu();
-      expect(getDownloadOption()).toHaveClass('disabled');
+      expect(getExportGeoJsonOption()).toHaveClass('disabled');
+      expect(getExportCsvOption()).toHaveClass('disabled');
     });
 
-    test('is disabled when leader has no track in the store', async () => {
-      renderPatrolMenu({ ...initialProps, patrol: patrolWithLeader });
+    test('both options are enabled when the patrol has an id', async () => {
+      renderPatrolMenu({ ...initialProps, patrol: testPatrol });
       await openMenu();
-      expect(getDownloadOption()).toHaveClass('disabled');
+      expect(getExportGeoJsonOption()).not.toHaveClass('disabled');
+      expect(getExportCsvOption()).not.toHaveClass('disabled');
     });
 
-    test('is disabled when track has no points within the patrol time range', async () => {
-      // All times are before the patrol start_time
-      const beforeStart = new Date(new Date(patrolStartTime).getTime() - 60000).toISOString();
-      const store = makeTrackStore([beforeStart]);
-      renderPatrolMenu({ ...initialProps, patrol: patrolWithLeader }, store);
-      await openMenu();
-      expect(getDownloadOption()).toHaveClass('disabled');
-    });
-
-    test('is enabled when track has points within the patrol time range', async () => {
-      // Time is after the patrol start_time
-      const afterStart = new Date(new Date(patrolStartTime).getTime() + 60000).toISOString();
-      const store = makeTrackStore([afterStart]);
-      renderPatrolMenu({ ...initialProps, patrol: patrolWithLeader }, store);
-      await openMenu();
-      expect(getDownloadOption()).not.toHaveClass('disabled');
-    });
-
-    test('calls downloadFileFromUrl with correct url, params, and filename when clicked', async () => {
-      const afterStart = new Date(new Date(patrolStartTime).getTime() + 60000).toISOString();
-      const store = makeTrackStore([afterStart]);
-      renderPatrolMenu({ ...initialProps, patrol: patrolWithLeader }, store);
+    test('GeoJson option calls downloadFileFromUrl with the geojson url, params, and filename when clicked', async () => {
+      renderPatrolMenu({ ...initialProps, patrol: testPatrol });
       await openMenu();
 
-      await userEvent.click(screen.getByText('Download Patrol Track'));
+      await userEvent.click(screen.getByText('Export Patrol GeoJson'));
 
       expect(downloadFileFromUrl).toHaveBeenCalledWith(
-        `/api/v1.0/subject/${leaderId}/tracks/`,
+        `${PATROLS_API_URL}${testPatrol.id}`,
         expect.objectContaining({
-          params: expect.objectContaining({ since: patrolStartTime }),
-          filename: `Patrol_${patrolWithLeader.serial_number}_${patrolWithLeader.patrol_segments[0].leader.name}.geojson`,
+          params: expect.objectContaining({
+            format: 'geojson',
+            include_events: true,
+            include_tracks: true,
+          }),
+          filename: `Patrol_${testPatrol.serial_number}.geojson`,
         })
       );
     });
 
-    test('passes until param when patrol has an end_time', async () => {
-      const patrolEndTime = new Date(new Date(patrolStartTime).getTime() + 3600000).toISOString();
-      const trackTime = new Date(new Date(patrolStartTime).getTime() + 1800000).toISOString();
-      const patrolWithEndTime = {
-        ...patrolWithLeader,
-        patrol_segments: [{
-          ...patrolWithLeader.patrol_segments[0],
-          time_range: { start_time: patrolStartTime, end_time: patrolEndTime },
-        }],
-      };
-      const store = makeTrackStore([trackTime]);
-      renderPatrolMenu({ ...initialProps, patrol: patrolWithEndTime }, store);
+    test('CSV option calls downloadFileFromUrl with the csv url, params, and filename when clicked', async () => {
+      renderPatrolMenu({ ...initialProps, patrol: testPatrol });
       await openMenu();
 
-      await userEvent.click(screen.getByText('Download Patrol Track'));
+      await userEvent.click(screen.getByText('Export Patrol CSV'));
 
       expect(downloadFileFromUrl).toHaveBeenCalledWith(
-        expect.any(String),
+        `${PATROLS_API_URL}${testPatrol.id}`,
         expect.objectContaining({
-          params: expect.objectContaining({ since: patrolStartTime, until: patrolEndTime }),
+          params: { format: 'csv' },
+          filename: `Patrol_${testPatrol.serial_number}.csv`,
         })
-      );
-    });
-
-    test('sanitizes invalid characters in leader name for the filename', async () => {
-      const afterStart = new Date(new Date(patrolStartTime).getTime() + 60000).toISOString();
-      const patrolWithSpecialName = {
-        ...patrolWithLeader,
-        patrol_segments: [{
-          ...patrolWithLeader.patrol_segments[0],
-          leader: { ...patrolWithLeader.patrol_segments[0].leader, name: 'John/Doe:Test' },
-        }],
-      };
-      const store = makeTrackStore([afterStart]);
-      renderPatrolMenu({ ...initialProps, patrol: patrolWithSpecialName }, store);
-      await openMenu();
-
-      await userEvent.click(screen.getByText('Download Patrol Track'));
-
-      expect(downloadFileFromUrl).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({ filename: expect.stringContaining('John_Doe_Test') })
       );
     });
   });

--- a/src/PatrolMenu/index.test.js
+++ b/src/PatrolMenu/index.test.js
@@ -9,8 +9,9 @@ import { useReactToPrint } from 'react-to-print';
 
 import { PERMISSION_KEYS, PERMISSIONS, SYSTEM_CONFIG_FLAGS } from '../constants';
 import { PATROLS_API_URL } from '../ducks/patrols';
-import { render, screen } from '../test-utils';
+import { render, screen, waitFor } from '../test-utils';
 import { downloadFileFromUrl } from '../utils/download';
+import { showToast } from '../utils/toast';
 
 jest.mock('react-to-print', () => ({
   ...jest.requireActual('react-to-print'),
@@ -21,6 +22,10 @@ jest.mock('../store', () => ({}));
 
 jest.mock('../utils/download', () => ({
   downloadFileFromUrl: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../utils/toast', () => ({
+  showToast: jest.fn(),
 }));
 
 describe('PatrolMenu', () => {
@@ -41,7 +46,6 @@ describe('PatrolMenu', () => {
     data: {
       patrolTypes,
       patrolStore: patrols.reduce((acc, p) => ({ ...acc, [p.id]: p }), {}),
-      tracks: {},
     },
     view: {
       systemConfig: {
@@ -145,6 +149,7 @@ describe('PatrolMenu', () => {
   describe('Export Patrol options', () => {
     beforeEach(() => {
       downloadFileFromUrl.mockImplementation(() => Promise.resolve());
+      showToast.mockClear();
     });
 
     const openMenu = async () => {
@@ -203,6 +208,28 @@ describe('PatrolMenu', () => {
           filename: `Patrol_${testPatrol.serial_number}.csv`,
         })
       );
+    });
+
+    test('clicking a disabled export option does not call downloadFileFromUrl', async () => {
+      renderPatrolMenu({ ...initialProps, patrol: { ...testPatrol, id: undefined } });
+      await openMenu();
+
+      await userEvent.click(screen.getByText('Export Patrol GeoJson'));
+      await userEvent.click(screen.getByText('Export Patrol CSV'));
+
+      expect(downloadFileFromUrl).not.toHaveBeenCalled();
+    });
+
+    test('shows an error toast when the export download fails', async () => {
+      downloadFileFromUrl.mockImplementation(() => Promise.reject(new Error('boom')));
+      renderPatrolMenu({ ...initialProps, patrol: testPatrol });
+      await openMenu();
+
+      await userEvent.click(screen.getByText('Export Patrol GeoJson'));
+
+      await waitFor(() => {
+        expect(showToast).toHaveBeenCalledWith({ message: 'Unable to export patrol data' });
+      });
     });
   });
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,7 +7,7 @@ import LocalStorageBackend from 'i18next-localstorage-backend';
 
 import { SUPPORTED_LANGUAGES } from './constants';
 
-const I18N_FILES_VERSION = '1.43';
+const I18N_FILES_VERSION = '1.44';
 
 const preloadNamespaces = [
   'components',

--- a/src/utils/download.js
+++ b/src/utils/download.js
@@ -11,6 +11,7 @@ export const downloadFileFromUrl = async (url, { params = {}, filename = null },
   })
     .catch((error) => {
       console.log('error downloading file', error);
+      throw error;
     });
   const link = document.createElement('a');
 


### PR DESCRIPTION
## Summary

Replaces the patrol kebab-menu option **"Download Patrol Track"** with two export options backed by the new patrol detail export API:

- **Export Patrol GeoJson** — `GET /activity/patrols/<id>?format=geojson&include_events=true&include_tracks=true`, downloaded as `Patrol_<serial>.geojson`
- **Export Patrol CSV** — `GET /activity/patrols/<id>?format=csv` (patrol events export), downloaded as `Patrol_<serial>.csv`

## Details

- The previous implementation downloaded the leader's raw track via the subject tracks API trimmed to the patrol time range; the new endpoint exports patrol-scoped data (track and/or events) server-side.
- Because the export includes events as well as tracks, the options no longer gate on the leader having track data within the patrol time range — they are disabled only for unsaved patrols.
- Translation keys `downloadTrackButton`/`noTrackDataTooltip` replaced with `exportPatrolGeoJsonButton`, `exportPatrolCsvButton`, and `noDataToExportTooltip` across all locales.
- Tests updated to cover both options (labels, disabled state, URL/params/filename per format).

## Depends on

Backend API: https://github.com/PADAS/das/pull/4076

## Jira

[ERA-13735](https://earthranger.atlassian.net/browse/ERA-13735)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ERA-13735]: https://allenai.atlassian.net/browse/ERA-13735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ