### PR TITLE
ERA-13405: RFC 9470 MFA step-up handler in the REST API client

### DIFF
--- a/src/RequestConfigManager/index.js
+++ b/src/RequestConfigManager/index.js
@@ -7,7 +7,7 @@ import { toast } from 'react-toastify';
 import { clearAuth, resetMasterCancelToken } from '../ducks/auth';
 
 import { REACT_APP_ROUTE_PREFIX } from '../constants';
-import { recoverAuth } from '../utils/auth-recovery';
+import { isStepUpChallenge, parseAuthChallenge, recoverAuth } from '../utils/auth-recovery';
 import { showToast } from '../utils/toast';
 import useAuthRecovery from '../hooks/useAuthRecovery';
 import useNavigate from '../hooks/useNavigate';
@@ -68,10 +68,14 @@ const RequestConfigManager = ({
   const handle401Errors = useCallback(async (error) => {
     const isAuthError = error?.response?.status === 401 && !error.config?.skipAuth;
     const request = error?.config;
+    // Step-up is allowed even after a silent renew (retriedAfterRefresh): it redirects rather
+    // than looping, and a renewed-but-MFA-stale token surfaces the step-up only on the replay.
+    const challenge = error?.response?.headers?.['www-authenticate'];
+    const stepUp = isStepUpChallenge(challenge);
 
-    if (isAuthError && request && !request.retriedAfterRefresh) {
+    if (isAuthError && request && (stepUp || !request.retriedAfterRefresh)) {
       try {
-        const accessToken = await recoverAuth();
+        const accessToken = await recoverAuth(stepUp ? { stepUp: true, challenge: parseAuthChallenge(challenge) } : undefined);
         return axios({
           ...request,
           retriedAfterRefresh: true,

--- a/src/RequestConfigManager/index.test.js
+++ b/src/RequestConfigManager/index.test.js
@@ -23,7 +23,13 @@ jest.mock('axios', () => {
 jest.mock('react-router', () => ({ __esModule: true, useLocation: jest.fn() }));
 jest.mock('../hooks/useNavigate');
 jest.mock('../hooks/useAuthRecovery');
-jest.mock('../utils/auth-recovery', () => ({ recoverAuth: jest.fn() }));
+// Stub the store singleton so requireActual(auth-recovery) doesn't build the real reducer tree.
+jest.mock('../store', () => ({ __esModule: true, default: { dispatch: jest.fn(), getState: () => ({ data: {} }) } }));
+// Real challenge parsers (isStepUpChallenge / parseAuthChallenge); only recoverAuth is stubbed.
+jest.mock('../utils/auth-recovery', () => ({
+  ...jest.requireActual('../utils/auth-recovery'),
+  recoverAuth: jest.fn(),
+}));
 
 const renderManager = () => {
   const store = mockStore({
@@ -79,6 +85,70 @@ describe('RequestConfigManager 401 handling', () => {
       }),
     }));
     expect(result).toEqual({ status: 200, data: 'ok' });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  test('a 401 carrying an RFC 9470 step-up challenge routes to interactive step-up', async () => {
+    recoverAuth.mockResolvedValue('mfa.jwt.token');
+    axios.mockResolvedValue({ status: 200, data: 'ok' });
+
+    const { rejected } = renderManager();
+    const challenge = 'Bearer error="insufficient_user_authentication", acr_values="http://schemas.openid.net/pape/policies/2007/06/multi-factor", max_age="31536000"';
+    const error = {
+      response: { status: 401, headers: { 'www-authenticate': challenge } },
+      config: { headers: {}, url: '/api/v1.0/events' },
+    };
+
+    await rejected(error);
+
+    expect(recoverAuth).toHaveBeenCalledWith({
+      stepUp: true,
+      challenge: {
+        error: 'insufficient_user_authentication',
+        acrValues: 'http://schemas.openid.net/pape/policies/2007/06/multi-factor',
+        maxAge: '31536000',
+      },
+    });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  test('a 401 with an ordinary WWW-Authenticate challenge takes the silent-renew path', async () => {
+    recoverAuth.mockResolvedValue('new.jwt.token');
+    axios.mockResolvedValue({ status: 200, data: 'ok' });
+
+    const { rejected } = renderManager();
+    const error = {
+      response: { status: 401, headers: { 'www-authenticate': 'Bearer error="invalid_token"' } },
+      config: { headers: {}, url: '/api/v1.0/events' },
+    };
+    await rejected(error);
+
+    expect(recoverAuth).toHaveBeenCalledWith(undefined);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  test('escalates to step-up (not sign-out) when a silently-renewed request then 401s with a step-up challenge', async () => {
+    recoverAuth.mockResolvedValue('renewed.jwt.token');
+    axios.mockResolvedValue({ status: 200, data: 'ok' });
+
+    const { rejected } = renderManager();
+
+    // Ordinary 401 → silent renew → replay carries retriedAfterRefresh.
+    await rejected(make401());
+    const replayConfig = axios.mock.calls[0][0];
+    expect(replayConfig.retriedAfterRefresh).toBe(true);
+
+    // The replay comes back as a step-up 401 (token now valid but MFA stale).
+    const challenge = 'Bearer error="insufficient_user_authentication", acr_values="urn:mfa", max_age="3600"';
+    await rejected({
+      response: { status: 401, headers: { 'www-authenticate': challenge } },
+      config: replayConfig,
+    });
+
+    expect(recoverAuth).toHaveBeenCalledWith({
+      stepUp: true,
+      challenge: { error: 'insufficient_user_authentication', acrValues: 'urn:mfa', maxAge: '3600' },
+    });
     expect(navigate).not.toHaveBeenCalled();
   });
 

--- a/src/hooks/useAuthRecovery.js
+++ b/src/hooks/useAuthRecovery.js
@@ -1,18 +1,40 @@
 import { useEffect } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
+import { useSelector } from 'react-redux';
+import { useLocation } from 'react-router';
 
+import appConfig from '../config';
 import { registerAuthRecovery } from '../utils/auth-recovery';
+import { buildAuth0AuthorizationParams } from '../utils/auth0';
+import { setIntendedPostAuth0SuccessRoute } from '../utils/auth';
 
 /**
  * Registers the live @auth0/auth0-react primitives into the shared auth-recovery unit
  * so the axios interceptor and the websocket handler can both drive token renewal.
  */
 const useAuthRecovery = () => {
-  const { getAccessTokenSilently } = useAuth0();
+  const { getAccessTokenSilently, loginWithRedirect } = useAuth0();
+  const { pathname, search } = useLocation();
+  const idpOrgId = useSelector((state) => state.view.systemConfig?.idp_org_id);
 
   useEffect(() => {
-    registerAuthRecovery({ silentRenew: () => getAccessTokenSilently() });
-  }, [getAccessTokenSilently]);
+    registerAuthRecovery({
+      silentRenew: () => getAccessTokenSilently(),
+      // Interactive MFA step-up: re-run PKCE with the challenge's acr_values/max_age. The
+      // redirect navigates away, so return a never-settling promise (no premature replay).
+      stepUp: async ({ acrValues, maxAge } = {}) => {
+        setIntendedPostAuth0SuccessRoute(`${pathname}${search}`);
+        await loginWithRedirect({
+          authorizationParams: {
+            ...buildAuth0AuthorizationParams(appConfig.auth0.audience, idpOrgId),
+            ...(acrValues ? { acr_values: acrValues } : {}),
+            ...(maxAge ? { max_age: maxAge } : {}),
+          },
+        });
+        return new Promise(() => {});
+      },
+    });
+  }, [getAccessTokenSilently, loginWithRedirect, idpOrgId, pathname, search]);
 };
 
 export default useAuthRecovery;

--- a/src/hooks/useAuthRecovery.test.js
+++ b/src/hooks/useAuthRecovery.test.js
@@ -1,0 +1,89 @@
+import { renderHook } from '@testing-library/react';
+import { useAuth0 } from '@auth0/auth0-react';
+import { useSelector } from 'react-redux';
+import { useLocation } from 'react-router';
+
+import useAuthRecovery from './useAuthRecovery';
+import { registerAuthRecovery } from '../utils/auth-recovery';
+import { setIntendedPostAuth0SuccessRoute } from '../utils/auth';
+
+jest.mock('@auth0/auth0-react');
+jest.mock('react-redux', () => ({ useSelector: jest.fn() }));
+jest.mock('react-router', () => ({ __esModule: true, useLocation: jest.fn() }));
+jest.mock('../utils/auth-recovery', () => ({ registerAuthRecovery: jest.fn() }));
+jest.mock('../utils/auth', () => ({ setIntendedPostAuth0SuccessRoute: jest.fn() }));
+jest.mock('../config', () => ({ __esModule: true, default: { auth0: { audience: 'https://api.example' } } }));
+
+const getRegistered = () => registerAuthRecovery.mock.calls.at(-1)[0];
+
+describe('useAuthRecovery', () => {
+  let getAccessTokenSilently;
+  let loginWithRedirect;
+
+  beforeEach(() => {
+    getAccessTokenSilently = jest.fn();
+    loginWithRedirect = jest.fn().mockResolvedValue(undefined);
+    useAuth0.mockReturnValue({ getAccessTokenSilently, loginWithRedirect });
+    useSelector.mockReturnValue(null); // idp_org_id (common-DB site)
+    useLocation.mockReturnValue({ pathname: '/events/123', search: '?foo=bar' });
+  });
+
+  test('registers a silentRenew primitive backed by getAccessTokenSilently', async () => {
+    renderHook(() => useAuthRecovery());
+
+    await getRegistered().silentRenew();
+
+    expect(getAccessTokenSilently).toHaveBeenCalledTimes(1);
+  });
+
+  test('registers a stepUp primitive that stashes returnTo and re-runs PKCE with acr_values/max_age', () => {
+    renderHook(() => useAuthRecovery());
+
+    getRegistered().stepUp({ acrValues: 'urn:mfa', maxAge: '3600' });
+
+    expect(setIntendedPostAuth0SuccessRoute).toHaveBeenCalledWith('/events/123?foo=bar');
+    expect(loginWithRedirect).toHaveBeenCalledWith({
+      authorizationParams: expect.objectContaining({
+        audience: 'https://api.example',
+        acr_values: 'urn:mfa',
+        max_age: '3600',
+      }),
+    });
+  });
+
+  test('stepUp omits acr_values / max_age when the challenge lacks them', () => {
+    renderHook(() => useAuthRecovery());
+
+    getRegistered().stepUp({});
+
+    const { authorizationParams } = loginWithRedirect.mock.calls[0][0];
+    expect(Object.keys(authorizationParams)).not.toContain('acr_values');
+    expect(Object.keys(authorizationParams)).not.toContain('max_age');
+  });
+
+  test('stepUp rejects when loginWithRedirect fails, so recovery can fall through to sign-out', async () => {
+    loginWithRedirect.mockRejectedValue(new Error('pkce_failed'));
+    renderHook(() => useAuthRecovery());
+
+    let settled = 'pending';
+    getRegistered().stepUp({ acrValues: 'urn:mfa', maxAge: '3600' })
+      .then(() => { settled = 'resolved'; }, () => { settled = 'rejected'; });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(settled).toBe('rejected');
+  });
+
+  test('stepUp does not settle on a successful redirect (blocks replay until the page unloads)', async () => {
+    loginWithRedirect.mockResolvedValue(undefined);
+    renderHook(() => useAuthRecovery());
+
+    let settled = 'pending';
+    getRegistered().stepUp({ acrValues: 'urn:mfa', maxAge: '3600' })
+      .then(() => { settled = 'resolved'; }, () => { settled = 'rejected'; });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(settled).toBe('pending');
+  });
+});

--- a/src/utils/auth-recovery.js
+++ b/src/utils/auth-recovery.js
@@ -2,10 +2,12 @@ import store from '../store';
 import { applyAccessToken } from '../ducks/auth';
 
 /**
- * Shared, single-flight auth recovery. Concurrent 401s collapse into one in-flight
- * token renewal that every caller awaits, and the renewed token is applied once.
- * Auth0 primitives are injected via `registerAuthRecovery` (they are React-hook-bound),
- * not imported.
+ * Shared, single-flight auth recovery, keyed by mode (silent renewal vs interactive
+ * step-up). Concurrent same-mode 401s collapse into one in-flight renewal that every
+ * caller awaits, and its token is applied once. The two modes run independently, so a
+ * step-up never collapses into an in-flight silent renewal (a same-ACR silent token can't
+ * satisfy an MFA challenge). Auth0 primitives are injected via `registerAuthRecovery`
+ * (they are React-hook-bound), not imported.
  */
 
 const STEP_UP_ERROR = 'insufficient_user_authentication';
@@ -44,17 +46,20 @@ const withTimeout = async (promise, ms) => {
 
 let primitives = { silentRenew: null, stepUp: null };
 
-// The one shared in-flight recovery promise (null when idle).
-let inFlight = null;
+// In-flight recovery, keyed by mode: a step-up must never collapse into an in-flight
+// silent renewal (a silent token is same-ACR and can't satisfy the MFA challenge).
+let inFlight = { silent: null, stepUp: null };
 
 export const registerAuthRecovery = (next) => {
   primitives = { ...primitives, ...next };
 };
 
 export const recoverAuth = ({ stepUp = false, challenge = null } = {}) => {
-  if (!inFlight) {
-    inFlight = (async () => {
-      // Only silent renewal is wired; the stepUp branch is a reserved seam for MFA step-up.
+  const mode = stepUp ? 'stepUp' : 'silent';
+  if (!inFlight[mode]) {
+    // Same-mode callers coalesce onto this flight, so the first caller's challenge is used
+    // (challenges are identical for a given requirement).
+    inFlight[mode] = (async () => {
       const recover = stepUp ? primitives.stepUp : primitives.silentRenew;
       if (typeof recover !== 'function') {
         throw new Error(`auth-recovery: no ${stepUp ? 'stepUp' : 'silentRenew'} primitive registered`);
@@ -69,14 +74,14 @@ export const recoverAuth = ({ stepUp = false, challenge = null } = {}) => {
       store.dispatch(applyAccessToken(accessToken));
       return accessToken;
     })().finally(() => {
-      inFlight = null;
+      inFlight[mode] = null;
     });
   }
-  return inFlight;
+  return inFlight[mode];
 };
 
 // Test-only: reset module singletons between cases.
 export const __resetAuthRecoveryForTests = () => {
   primitives = { silentRenew: null, stepUp: null };
-  inFlight = null;
+  inFlight = { silent: null, stepUp: null };
 };

--- a/src/utils/auth-recovery.js
+++ b/src/utils/auth-recovery.js
@@ -8,6 +8,23 @@ import { applyAccessToken } from '../ducks/auth';
  * not imported.
  */
 
+const STEP_UP_ERROR = 'insufficient_user_authentication';
+
+// Parse an RFC 9470 Bearer challenge (the WWW-Authenticate header). Assumes a single
+// Bearer challenge, which is what ER Server emits.
+export const parseAuthChallenge = (challenge) => {
+  if (typeof challenge !== 'string') return null;
+  const read = (pattern) => challenge.match(pattern)?.[1];
+  return {
+    error: read(/error="([^"]*)"/),
+    acrValues: read(/acr_values="([^"]*)"/),
+    maxAge: read(/max_age="([^"]*)"/),
+  };
+};
+
+export const isStepUpChallenge = (challenge) =>
+  parseAuthChallenge(challenge)?.error === STEP_UP_ERROR;
+
 // A stalled silent renewal (e.g. a network black-hole) must not hang recovery for both
 // transports, so it is time-boxed. Interactive step-up is deliberately NOT bounded — it
 // waits on the user completing MFA, which can take far longer than any network timeout.

--- a/src/utils/auth-recovery.test.js
+++ b/src/utils/auth-recovery.test.js
@@ -1,6 +1,8 @@
 import {
   recoverAuth,
   registerAuthRecovery,
+  isStepUpChallenge,
+  parseAuthChallenge,
   __resetAuthRecoveryForTests,
 } from './auth-recovery';
 import store from '../store';
@@ -125,5 +127,49 @@ describe('auth-recovery', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+});
+
+describe('auth-recovery challenge parsing', () => {
+  const STEP_UP = 'Bearer error="insufficient_user_authentication", acr_values="http://schemas.openid.net/pape/policies/2007/06/multi-factor", max_age="31536000"';
+
+  describe('isStepUpChallenge', () => {
+    test('true for an RFC 9470 insufficient_user_authentication challenge', () => {
+      expect(isStepUpChallenge(STEP_UP)).toBe(true);
+    });
+
+    test('false for an ordinary Bearer challenge, a different error, or a non-string', () => {
+      expect(isStepUpChallenge('Bearer realm="vector-tiles"')).toBe(false);
+      expect(isStepUpChallenge('Bearer error="invalid_token"')).toBe(false);
+      expect(isStepUpChallenge(undefined)).toBe(false);
+      expect(isStepUpChallenge(null)).toBe(false);
+    });
+
+    test('false when the phrase appears only in error_description, not the error field', () => {
+      expect(isStepUpChallenge(
+        'Bearer error="invalid_token", error_description="not insufficient_user_authentication"'
+      )).toBe(false);
+    });
+  });
+
+  describe('parseAuthChallenge', () => {
+    test('extracts error, acrValues, and maxAge', () => {
+      expect(parseAuthChallenge(STEP_UP)).toEqual({
+        error: 'insufficient_user_authentication',
+        acrValues: 'http://schemas.openid.net/pape/policies/2007/06/multi-factor',
+        maxAge: '31536000',
+      });
+    });
+
+    test('leaves absent fields undefined', () => {
+      const parsed = parseAuthChallenge('Bearer error="insufficient_user_authentication"');
+      expect(parsed.error).toBe('insufficient_user_authentication');
+      expect(parsed.acrValues).toBeUndefined();
+      expect(parsed.maxAge).toBeUndefined();
+    });
+
+    test('returns null for a non-string', () => {
+      expect(parseAuthChallenge(undefined)).toBeNull();
+    });
   });
 });

--- a/src/utils/auth-recovery.test.js
+++ b/src/utils/auth-recovery.test.js
@@ -128,6 +128,60 @@ describe('auth-recovery', () => {
       jest.useRealTimers();
     }
   });
+
+  test('a step-up request does not collapse into an in-flight silent renewal', async () => {
+    jest.useFakeTimers();
+    try {
+      let resolveSilent;
+      const silentRenew = jest.fn(() => new Promise((resolve) => { resolveSilent = resolve; }));
+      const stepUp = jest.fn().mockResolvedValue('stepped.token');
+      registerAuthRecovery({ silentRenew, stepUp });
+
+      const silentPending = recoverAuth();
+      const stepUpPending = recoverAuth({ stepUp: true, challenge: {} });
+
+      // The step-up must run its own primitive, not join the in-flight silent renewal.
+      expect(stepUp).toHaveBeenCalledTimes(1);
+      await expect(stepUpPending).resolves.toBe('stepped.token');
+
+      resolveSilent('silent.token');
+      await expect(silentPending).resolves.toBe('silent.token');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('a silent renewal does not collapse into an in-flight step-up', async () => {
+    let resolveStepUp;
+    const stepUp = jest.fn(() => new Promise((resolve) => { resolveStepUp = resolve; }));
+    const silentRenew = jest.fn().mockResolvedValue('silent.token');
+    registerAuthRecovery({ silentRenew, stepUp });
+
+    const stepUpPending = recoverAuth({ stepUp: true, challenge: {} });
+    const silentPending = recoverAuth();
+
+    // The silent renewal runs its own primitive, not the in-flight step-up.
+    expect(silentRenew).toHaveBeenCalledTimes(1);
+    await expect(silentPending).resolves.toBe('silent.token');
+
+    resolveStepUp('stepped.token');
+    await expect(stepUpPending).resolves.toBe('stepped.token');
+  });
+
+  test('concurrent step-up requests coalesce into a single step-up', async () => {
+    let resolveStepUp;
+    const stepUp = jest.fn(() => new Promise((resolve) => { resolveStepUp = resolve; }));
+    registerAuthRecovery({ stepUp });
+
+    const first = recoverAuth({ stepUp: true, challenge: {} });
+    const second = recoverAuth({ stepUp: true, challenge: {} });
+
+    expect(stepUp).toHaveBeenCalledTimes(1);
+
+    resolveStepUp('stepped.token');
+    await expect(first).resolves.toBe('stepped.token');
+    await expect(second).resolves.toBe('stepped.token');
+  });
 });
 
 describe('auth-recovery challenge parsing', () => {


### PR DESCRIPTION
## What & why

[ERA-13405](https://allenai.atlassian.net/browse/ERA-13405)

Adds the RFC 9470 MFA step-up handler to ER Web's REST client, building on the shared `auth-recovery` unit from ERA-13685. A `401 WWW-Authenticate: Bearer error="insufficient_user_authentication"` now triggers a transparent Auth0 step-up (re-run PKCE with the challenge's `acr_values`/`max_age`) instead of an opaque auth failure.

## Commits

1. **parse RFC 9470 step-up challenges** — `isStepUpChallenge` / `parseAuthChallenge` in `utils/auth-recovery` (shared, so the socket handler in ERA-13733 reuses them).
2. **key auth-recovery single-flight by mode** — `inFlight` is `{ silent, stepUp }`, so a step-up can't collapse into an in-flight silent renewal (a same-ACR silent token never satisfies the MFA challenge).
3. **route step-up 401s in the interceptor** — `RequestConfigManager.handle401Errors` reads `WWW-Authenticate`; a step-up challenge routes to `recoverAuth({ stepUp: true, challenge })`, an ordinary 401 keeps the silent-renew path.
4. **register the interactive step-up primitive** — `useAuthRecovery` registers `stepUp` = `loginWithRedirect` with the challenge's `acr_values`/`max_age`, returnTo stashed; the redirect callback re-bootstraps with the MFA-bearing token.

## How it works (end to end)

Step-up 401 → interceptor parses `acr_values`/`max_age` → `recoverAuth({ stepUp })` → `loginWithRedirect` → user completes MFA → the redirect callback (`Auth0TokenManager`) re-bootstraps with the MFA token and returns the user to the original route.


https://github.com/user-attachments/assets/724ad217-fa0f-4065-85a1-5502d983739a



## Dependencies / status

- Builds on **ERA-13685** (shared `auth-recovery` unit) — merged.
- Server emission **ERA-13387** (`WWW-Authenticate` step-up on 401) is **In Test** — end-to-end exercise needs a `require_mfa` env, hence the `deploy` label.
- **Socket** step-up (**ERA-13733**) is deferred, blocked on server **ERA-13732**; this PR is REST-only.

## Behavior notes — worth discussing

- **The step-up redirect discards unsaved in-flight state.** `loginWithRedirect` is a full-page navigation, so a half-entered report / patrol / notes are lost. This is benign at the default `mfa_max_age_seconds` (365 days) — step-up is then effectively a login-time event, before any data entry. But a tenant that sets a **short** `mfa_max_age` re-introduces *mid-session, mid-form* step-ups and real data loss. It's not a regression (new with MFA) and is strictly better than the opaque sign-out it replaces (which would also lose the form, then drop you at login). Escape hatch if it bites: the **popup** variant (`getAccessTokenWithPopup`, no reload) — the design is seam'd so only the `stepUp` primitive changes.
- **Silent ↔ step-up interaction.**
  - **(A) handled here:** the per-request `retriedAfterRefresh` marker is bypassed for step-up (`stepUp || !retriedAfterRefresh`), so a token that is expired *and* MFA-stale (silent-renews, then the replay 401s with a step-up challenge) escalates to step-up instead of signing out. Step-up redirects rather than looping, so bypassing the marker is safe.
  - **(B) deferred to ERA-13732/13733:** until the socket can *see* the step-up challenge, on a `require_mfa` site it treats the MFA rejection as a generic 401 → silent-renew → sign-out, racing the REST redirect (likely benign — the hard redirect wins — but messy). The mode-keyed single-flight is already set up so that once the socket recognizes step-up, both transports coalesce into a single redirect.
  - Both only bite once `require_mfa` is enabled; **(A)** specifically needs token-expiry and MFA-staleness to coincide (short `mfa_max_age`; never at the 365-day default).

## Testing

- Unit: challenge parsing (incl. an `error_description` decoy), mode-keyed single-flight (both directions + concurrent step-up coalescing), interceptor silent/step-up routing + the escalation case, and the `stepUp` primitive (reject-surfaces + never-settle).
- Full suite green.

## Deploy

`deploy` label added to spin up a `require_mfa`-capable feature env for manual end-to-end verification (the unit tests mock at the seams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ERA-13405]: https://allenai.atlassian.net/browse/ERA-13405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ