### PR TITLE
ERA-13745: V1 cleared enum/dropdown field fails "must be equal to one of the allowed values" validation on re-save

### DIFF
--- a/src/ReportManager/DetailsSection/index.js
+++ b/src/ReportManager/DetailsSection/index.js
@@ -10,6 +10,7 @@ import { ReactComponent as PencilWritingIcon } from '../../common/images/icons/p
 
 import { EVENT_FORM_STATES, PREVIEW_FEATURES, VALID_EVENT_GEOMETRY_TYPES } from '../../constants';
 import {
+  filterOutEnumErrorsForClearedFields,
   filterOutErrorsForHiddenProperties,
   filterOutRequiredValueOnSchemaPropErrors,
   getLinearErrorPropTree,
@@ -126,14 +127,19 @@ const DetailsSection = ({
     eventTracker.track('Change Report Time');
   };
 
+  const eventUISchema = eventSchema?.uiSchema;
   const transformErrors = useCallback((errors) => {
     const filteredErrors = filterOutErrorsForHiddenProperties(
-      filterOutRequiredValueOnSchemaPropErrors(errors),
-      eventSchema.uiSchema
+      filterOutEnumErrorsForClearedFields(
+        filterOutRequiredValueOnSchemaPropErrors(errors),
+        reportForm.event_details,
+        jsonSchema
+      ),
+      eventUISchema
     );
 
     return filteredErrors.map((error) => ({ ...error, linearProperty: getLinearErrorPropTree(error.property) }));
-  }, [eventSchema?.uiSchema]);
+  }, [eventUISchema, jsonSchema, reportForm.event_details]);
 
   return <div ref={ref}>
     <div className={styles.globalDetails}>
@@ -279,7 +285,7 @@ const DetailsSection = ({
         ObjectFieldTemplate,
       }}
       transformErrors={transformErrors}
-      uiSchema={eventSchema?.uiSchema}
+      uiSchema={eventUISchema}
       validator={formValidator}
     >
       <button ref={submitFormButtonRef} type="submit" />

--- a/src/ReportManager/ReportDetailView/index.test.js
+++ b/src/ReportManager/ReportDetailView/index.test.js
@@ -375,6 +375,185 @@ describe('ReportManager - ReportDetailView', () => {
     });
   });
 
+  test('allows saving when a cleared legacy dropdown would otherwise fail enum validation', async () => {
+    const accidentSchema = eventSchemas.accident_rep.base;
+    // Drop the fixture's `required: []`: an empty array fails ajv's own meta-schema
+    // validation.
+    const { required: _unusedRequired, ...baseSchemaWithoutRequired } = accidentSchema.schema;
+    state.data.eventSchemas = {
+      ...eventSchemas,
+      accident_rep: {
+        ...eventSchemas.accident_rep,
+        790: {
+          ...accidentSchema,
+          schema: {
+            ...baseSchemaWithoutRequired,
+            id: 'https://era-7995.pamdas.org/api/v1.0/activity/events/schema/eventtype/accident_rep_enum_clear_test',
+            properties: {
+              ...accidentSchema.schema.properties,
+              severity: {
+                type: 'string',
+                title: 'Severity',
+                enum: ['minor', 'major'],
+                enumNames: ['Minor', 'Major'],
+                key: 'severity',
+              },
+            },
+          },
+          uiSchema: {
+            ...accidentSchema.uiSchema,
+            'ui:groups': [{
+              origin: 'inferred',
+              items: ['type_accident', 'number_people_involved', 'animals_involved', 'severity'],
+            }],
+          },
+        },
+      },
+    };
+    state.data.eventStore = {
+      ...state.data.eventStore,
+      790: {
+        ...mockReport,
+        event_type: 'accident_rep',
+        event_details: { severity: 'minor', type_accident: 'Truck crash' },
+        id: '790',
+      },
+    };
+
+    renderWithWrapper(<ReportDetailView isNewReport={false} reportId="790" />);
+
+    await userEvent.selectOptions(await screen.findByLabelText('Severity'), '');
+
+    // Also edits an unrelated field, confirming the cleared value coexists with
+    // other, unrelated changes in the saved payload.
+    await userEvent.type(await screen.findByLabelText('Type of accident'), '!');
+
+    await userEvent.click(await screen.findByText('Save'));
+
+    await waitFor(() => {
+      expect(generateSaveActionsForReportLikeObject).toHaveBeenCalledTimes(1);
+    });
+    expect(generateSaveActionsForReportLikeObject.mock.calls[0][0].event_details).toEqual({
+      severity: '',
+      type_accident: 'Truck crash!',
+    });
+  });
+
+  test('allows saving without further changes when reopening an event whose stored event_details already has an empty enum value', async () => {
+    const accidentSchema = eventSchemas.accident_rep.base;
+    // Drop the fixture's `required: []`: an empty array fails ajv's own meta-schema
+    // validation.
+    const { required: _unusedRequired, ...baseSchemaWithoutRequired } = accidentSchema.schema;
+    state.data.eventSchemas = {
+      ...eventSchemas,
+      accident_rep: {
+        ...eventSchemas.accident_rep,
+        791: {
+          ...accidentSchema,
+          schema: {
+            ...baseSchemaWithoutRequired,
+            id: 'https://era-7995.pamdas.org/api/v1.0/activity/events/schema/eventtype/accident_rep_reopen_enum_test',
+            properties: {
+              ...accidentSchema.schema.properties,
+              severity: {
+                type: 'string',
+                title: 'Severity',
+                enum: ['minor', 'major'],
+                enumNames: ['Minor', 'Major'],
+                key: 'severity',
+              },
+            },
+          },
+          uiSchema: {
+            ...accidentSchema.uiSchema,
+            'ui:groups': [{
+              origin: 'inferred',
+              items: ['type_accident', 'number_people_involved', 'animals_involved', 'severity'],
+            }],
+          },
+        },
+      },
+    };
+    state.data.eventStore = {
+      ...state.data.eventStore,
+      791: {
+        ...mockReport,
+        event_type: 'accident_rep',
+        event_details: { severity: '', type_accident: 'Truck crash' },
+        id: '791',
+      },
+    };
+
+    renderWithWrapper(<ReportDetailView isNewReport={false} reportId="791" />);
+
+    await screen.findByLabelText('Severity');
+
+    await userEvent.click(await screen.findByText('Save'));
+
+    await waitFor(() => {
+      expect(generateSaveActionsForReportLikeObject).toHaveBeenCalledTimes(1);
+    });
+    expect(generateSaveActionsForReportLikeObject.mock.calls[0][0].event_details).toEqual({
+      severity: '',
+      type_accident: 'Truck crash',
+    });
+  });
+
+  test('still blocks saving when a cleared legacy dropdown is required by the schema', async () => {
+    const accidentSchema = eventSchemas.accident_rep.base;
+    state.data.eventSchemas = {
+      ...eventSchemas,
+      accident_rep: {
+        ...eventSchemas.accident_rep,
+        790: {
+          ...accidentSchema,
+          schema: {
+            ...accidentSchema.schema,
+            id: 'https://era-7995.pamdas.org/api/v1.0/activity/events/schema/eventtype/accident_rep_required_enum_test',
+            properties: {
+              ...accidentSchema.schema.properties,
+              severity: {
+                type: 'string',
+                title: 'Severity',
+                enum: ['minor', 'major'],
+                enumNames: ['Minor', 'Major'],
+                key: 'severity',
+              },
+            },
+            required: ['severity'],
+          },
+          uiSchema: {
+            ...accidentSchema.uiSchema,
+            'ui:groups': [{
+              origin: 'inferred',
+              items: ['type_accident', 'number_people_involved', 'animals_involved', 'severity'],
+            }],
+          },
+        },
+      },
+    };
+    state.data.eventStore = {
+      ...state.data.eventStore,
+      790: {
+        ...mockReport,
+        event_type: 'accident_rep',
+        event_details: { severity: 'minor', type_accident: 'Truck crash' },
+        id: '790',
+      },
+    };
+
+    renderWithWrapper(<ReportDetailView isNewReport={false} reportId="790" />);
+
+    await userEvent.selectOptions(await screen.findByLabelText(/Severity/), '');
+    await userEvent.type(await screen.findByLabelText('Type of accident'), '!');
+
+    document.querySelector('form').noValidate = true;
+    await userEvent.click(await screen.findByText('Save'));
+
+    expect(await screen.findAllByTestId('error-message')).not.toHaveLength(0);
+    expect(generateSaveActionsForReportLikeObject).not.toHaveBeenCalled();
+  });
+
   test('sets the state when user changes it', async () => {
     renderWithWrapper(
       <ReportDetailView

--- a/src/utils/event-schemas.js
+++ b/src/utils/event-schemas.js
@@ -19,7 +19,7 @@ const isFieldRequired = (schema, propPath) => {
   for (let index = 0; index < propPath.length; index += 1) {
     const key = propPath[index];
     if (index === propPath.length - 1) {
-      return !!currentSchema?.required?.includes(key);
+      return Array.isArray(currentSchema?.required) && currentSchema.required.includes(key);
     }
 
     currentSchema = typeof key === 'number' ? currentSchema?.items : currentSchema?.properties?.[key];

--- a/src/utils/event-schemas.js
+++ b/src/utils/event-schemas.js
@@ -1,3 +1,5 @@
+import { get } from 'lodash-es';
+
 export const getLinearErrorPropTree = (errorProperty) => {
   if (errorProperty == null || typeof errorProperty !== 'string') {
     return [];
@@ -10,6 +12,37 @@ export const getLinearErrorPropTree = (errorProperty) => {
 };
 
 export const filterOutRequiredValueOnSchemaPropErrors = errors => errors.filter(err => !JSON.stringify(err).includes('required should be array'));
+
+const isFieldRequired = (schema, propPath) => {
+  let currentSchema = schema;
+
+  for (let index = 0; index < propPath.length; index += 1) {
+    const key = propPath[index];
+    if (index === propPath.length - 1) {
+      return !!currentSchema?.required?.includes(key);
+    }
+
+    currentSchema = typeof key === 'number' ? currentSchema?.items : currentSchema?.properties?.[key];
+  }
+
+  return false;
+};
+
+export const filterOutEnumErrorsForClearedFields = (errors, eventDetails, schema) => {
+  const details = eventDetails ?? {};
+
+  return errors.filter((err) => {
+    if (err.name !== 'enum') {
+      return true;
+    }
+
+    const propPath = getLinearErrorPropTree(err.property);
+    const value = get(details, propPath);
+    const isCleared = value === '' || value === undefined;
+
+    return !isCleared || isFieldRequired(schema, propPath);
+  });
+};
 
 export const filterOutErrorsForHiddenProperties = (errors, uiSchema) => {
   const propsInForm =

--- a/src/utils/event-schemas.test.js
+++ b/src/utils/event-schemas.test.js
@@ -1,4 +1,9 @@
-import { filterOutRequiredValueOnSchemaPropErrors, getLinearErrorPropTree, filterOutErrorsForHiddenProperties } from './event-schemas';
+import {
+  filterOutEnumErrorsForClearedFields,
+  filterOutErrorsForHiddenProperties,
+  filterOutRequiredValueOnSchemaPropErrors,
+  getLinearErrorPropTree,
+} from './event-schemas';
 
 describe('getLinearErrorPropTree', () => {
   const errorPropTree = '.properties[\'reportcounty\'].enum';
@@ -113,5 +118,165 @@ describe('filterOutRequiredValueOnSchemaPropErrors', () => {
 
   test('preserving other error messages', () => {
     expect(filtered).toEqual(expect.arrayContaining([error1]));
+  });
+});
+
+describe('filterOutEnumErrorsForClearedFields', () => {
+  const clearedFieldError = {
+    'name': 'enum',
+    'property': '.single_select',
+    'message': 'must be equal to one of the allowed values',
+    'params': { 'allowedValues': ['new', 'old'] },
+    'stack': '\'I\'m a single select query\' must be equal to one of the allowed values',
+    'schemaPath': '#/properties/single_select/enum',
+  };
+
+  const genuineEnumError = {
+    'name': 'enum',
+    'property': '.another_select',
+    'message': 'must be equal to one of the allowed values',
+    'params': { 'allowedValues': ['new', 'old'] },
+    'stack': '\'Another select\' must be equal to one of the allowed values',
+    'schemaPath': '#/properties/another_select/enum',
+  };
+
+  const otherError = {
+    'name': 'minItems',
+    'property': '.reportcounty',
+    'message': 'should NOT have fewer than 1 items',
+    'params': { 'limit': 1 },
+    'stack': '.reportcounty should NOT have fewer than 1 items',
+    'schemaPath': '#/properties/reportcounty/minItems',
+  };
+
+  const eventDetails = { single_select: '', another_select: 'not-a-valid-value' };
+
+  const filtered = filterOutEnumErrorsForClearedFields([clearedFieldError, genuineEnumError, otherError], eventDetails);
+
+  test('removing an "enum" error for a field whose current value is an empty string', () => {
+    expect(filtered).not.toEqual(expect.arrayContaining([clearedFieldError]));
+  });
+
+  test('preserving an "enum" error for a field whose current value is not an empty string', () => {
+    expect(filtered).toEqual(expect.arrayContaining([genuineEnumError]));
+  });
+
+  test('preserving errors that are not "enum" errors', () => {
+    expect(filtered).toEqual(expect.arrayContaining([otherError]));
+  });
+
+  test('removing an "enum" error for a nested field whose current value is an empty string', () => {
+    const nestedClearedFieldError = {
+      'name': 'enum',
+      'property': '.properties[\'parent\'].properties[\'child\'].enum',
+      'message': 'must be equal to one of the allowed values',
+      'params': { 'allowedValues': ['new', 'old'] },
+      'schemaPath': '#/properties/parent/properties/child/enum',
+    };
+    const nestedEventDetails = { parent: { child: '' } };
+
+    const nestedFiltered = filterOutEnumErrorsForClearedFields([nestedClearedFieldError], nestedEventDetails);
+
+    expect(nestedFiltered).not.toEqual(expect.arrayContaining([nestedClearedFieldError]));
+  });
+
+  test('preserving an "enum" error for a nested field whose current value is not an empty string', () => {
+    const nestedGenuineEnumError = {
+      'name': 'enum',
+      'property': '.properties[\'parent\'].properties[\'child\'].enum',
+      'message': 'must be equal to one of the allowed values',
+      'params': { 'allowedValues': ['new', 'old'] },
+      'schemaPath': '#/properties/parent/properties/child/enum',
+    };
+    const nestedEventDetails = { parent: { child: 'not-a-valid-value' } };
+
+    const nestedFiltered = filterOutEnumErrorsForClearedFields([nestedGenuineEnumError], nestedEventDetails);
+
+    expect(nestedFiltered).toEqual(expect.arrayContaining([nestedGenuineEnumError]));
+  });
+
+  test('not throwing when eventDetails is null', () => {
+    expect(() => filterOutEnumErrorsForClearedFields([clearedFieldError], null)).not.toThrow();
+  });
+
+  test('removing an "enum" error for a nested field left undefined (onLegacyFormChange does not coerce nested fields to \'\')', () => {
+    const nestedClearedFieldError = {
+      'name': 'enum',
+      'property': '.properties[\'parent\'].properties[\'child\'].enum',
+      'message': 'must be equal to one of the allowed values',
+      'params': { 'allowedValues': ['new', 'old'] },
+      'schemaPath': '#/properties/parent/properties/child/enum',
+    };
+    const nestedEventDetails = { parent: { child: undefined } };
+
+    const nestedFiltered = filterOutEnumErrorsForClearedFields([nestedClearedFieldError], nestedEventDetails);
+
+    expect(nestedFiltered).not.toEqual(expect.arrayContaining([nestedClearedFieldError]));
+  });
+
+  test('preserving an "enum" error for a cleared field that the schema marks as required', () => {
+    const requiredFieldError = {
+      'name': 'enum',
+      'property': '.single_select',
+      'message': 'must be equal to one of the allowed values',
+      'params': { 'allowedValues': ['new', 'old'] },
+      'schemaPath': '#/properties/single_select/enum',
+    };
+    const schema = { type: 'object', properties: { single_select: {} }, required: ['single_select'] };
+
+    const requiredFiltered = filterOutEnumErrorsForClearedFields([requiredFieldError], eventDetails, schema);
+
+    expect(requiredFiltered).toEqual(expect.arrayContaining([requiredFieldError]));
+  });
+
+  test('removing an "enum" error for a cleared field the schema does not require, even when a schema is supplied', () => {
+    const schema = { type: 'object', properties: { single_select: {} }, required: [] };
+
+    const optionalFiltered = filterOutEnumErrorsForClearedFields([clearedFieldError], eventDetails, schema);
+
+    expect(optionalFiltered).not.toEqual(expect.arrayContaining([clearedFieldError]));
+  });
+
+  test('preserving an "enum" error for a cleared nested field that the schema marks as required', () => {
+    const nestedRequiredFieldError = {
+      'name': 'enum',
+      'property': '.properties[\'parent\'].properties[\'child\'].enum',
+      'message': 'must be equal to one of the allowed values',
+      'params': { 'allowedValues': ['new', 'old'] },
+      'schemaPath': '#/properties/parent/properties/child/enum',
+    };
+    const nestedEventDetails = { parent: { child: '' } };
+    const schema = {
+      type: 'object',
+      properties: { parent: { type: 'object', properties: { child: {} }, required: ['child'] } },
+    };
+
+    const nestedFiltered = filterOutEnumErrorsForClearedFields([nestedRequiredFieldError], nestedEventDetails, schema);
+
+    expect(nestedFiltered).toEqual(expect.arrayContaining([nestedRequiredFieldError]));
+  });
+
+  test('preserving an "enum" error for a cleared field required inside an array item\'s schema', () => {
+    const arrayItemRequiredFieldError = {
+      'name': 'enum',
+      'property': '.properties[\'incidents\'][0].properties[\'severity\'].enum',
+      'message': 'must be equal to one of the allowed values',
+      'params': { 'allowedValues': ['minor', 'major'] },
+      'schemaPath': '#/properties/incidents/items/properties/severity/enum',
+    };
+    const arrayEventDetails = { incidents: [{ severity: '' }] };
+    const schema = {
+      type: 'object',
+      properties: {
+        incidents: {
+          type: 'array',
+          items: { type: 'object', properties: { severity: {} }, required: ['severity'] },
+        },
+      },
+    };
+
+    const arrayFiltered = filterOutEnumErrorsForClearedFields([arrayItemRequiredFieldError], arrayEventDetails, schema);
+
+    expect(arrayFiltered).toEqual(expect.arrayContaining([arrayItemRequiredFieldError]));
   });
 });

--- a/src/utils/event-schemas.test.js
+++ b/src/utils/event-schemas.test.js
@@ -279,4 +279,14 @@ describe('filterOutEnumErrorsForClearedFields', () => {
 
     expect(arrayFiltered).toEqual(expect.arrayContaining([arrayItemRequiredFieldError]));
   });
+
+  test('not throwing and removing the "enum" error when the schema\'s "required" is malformed (not an array)', () => {
+    const schema = { type: 'object', properties: { single_select: {} }, required: true };
+
+    expect(() => filterOutEnumErrorsForClearedFields([clearedFieldError], eventDetails, schema)).not.toThrow();
+
+    const malformedFiltered = filterOutEnumErrorsForClearedFields([clearedFieldError], eventDetails, schema);
+
+    expect(malformedFiltered).not.toEqual(expect.arrayContaining([clearedFieldError]));
+  });
 });


### PR DESCRIPTION
## What does this PR do?
Implement error filtering for cleared fields in event details
- Added a new utility function, `filterOutEnumErrorsForClearedFields`, to handle enum validation errors for fields that have been cleared (set to empty or undefined).
- Updated the `transformErrors` function in `DetailsSection` to utilize the new error filtering logic.
- Enhanced tests in `event-schemas.test.js` to cover various scenarios for cleared fields, ensuring proper handling of enum errors based on schema requirements.
- Adjusted the `ReportDetailView` tests to validate saving behavior when dealing with cleared dropdowns and their associated enum validations.

### Relevant link(s)
- [ERA-13745](https://allenai.atlassian.net/browse/ERA-13745)


[ERA-13745]: https://allenai.atlassian.net/browse/ERA-13745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ