### PR TITLE
ERA-13733: RFC 9470 MFA step-up over the rt_api websocket

### DIFF
--- a/src/utils/auth-recovery.js
+++ b/src/utils/auth-recovery.js
@@ -27,15 +27,15 @@ export const parseAuthChallenge = (challenge) => {
 export const isStepUpChallenge = (challenge) =>
   parseAuthChallenge(challenge)?.error === STEP_UP_ERROR;
 
-// A stalled silent renewal (e.g. a network black-hole) must not hang recovery for both
-// transports, so it is time-boxed. Interactive step-up is deliberately NOT bounded — it
-// waits on the user completing MFA, which can take far longer than any network timeout.
+// Time-boxed so a stalled recovery can't hang forever. Step-up's longer bound only trips
+// if the redirect never navigated (a real redirect unloads the page first).
 const SILENT_RENEW_TIMEOUT_MS = 30_000;
+const STEP_UP_REDIRECT_TIMEOUT_MS = 60_000;
 
-const withTimeout = async (promise, ms) => {
+const withTimeout = async (promise, ms, label = 'recovery') => {
   let timeoutId;
   const timeout = new Promise((_, reject) => {
-    timeoutId = setTimeout(() => reject(new Error('auth-recovery: renewal timed out')), ms);
+    timeoutId = setTimeout(() => reject(new Error(`auth-recovery: ${label} timed out`)), ms);
   });
   try {
     return await Promise.race([promise, timeout]);
@@ -65,9 +65,11 @@ export const recoverAuth = ({ stepUp = false, challenge = null } = {}) => {
         throw new Error(`auth-recovery: no ${stepUp ? 'stepUp' : 'silentRenew'} primitive registered`);
       }
 
-      const accessToken = stepUp
-        ? await recover(challenge)
-        : await withTimeout(recover(challenge), SILENT_RENEW_TIMEOUT_MS);
+      const accessToken = await withTimeout(
+        recover(challenge),
+        stepUp ? STEP_UP_REDIRECT_TIMEOUT_MS : SILENT_RENEW_TIMEOUT_MS,
+        stepUp ? 'step-up redirect' : 'silent renewal',
+      );
       if (!accessToken) {
         throw new Error('auth-recovery: renewal returned no token');
       }

--- a/src/utils/auth-recovery.test.js
+++ b/src/utils/auth-recovery.test.js
@@ -98,7 +98,7 @@ describe('auth-recovery', () => {
       const silentRenew = jest.fn(() => new Promise(() => {}));
       registerAuthRecovery({ silentRenew });
 
-      const rejection = expect(recoverAuth()).rejects.toThrow(/timed out/);
+      const rejection = expect(recoverAuth()).rejects.toThrow(/silent renewal timed out/);
       await jest.advanceTimersByTimeAsync(30_000);
       await rejection;
 
@@ -112,18 +112,22 @@ describe('auth-recovery', () => {
     }
   });
 
-  test('does not time out an interactive step-up (it waits on the user)', async () => {
+  test('times out a step-up whose redirect never navigates, clearing in-flight so a later step-up retries', async () => {
     jest.useFakeTimers();
     try {
-      const stepUp = jest.fn(() => new Promise((resolve) => {
-        setTimeout(() => resolve('stepped.token'), 90_000); // past the 30s silent-renewal timeout
-      }));
+      // A redirect that resolves but never navigates: pending forever.
+      const stepUp = jest.fn(() => new Promise(() => {}));
       registerAuthRecovery({ stepUp });
 
-      const pending = recoverAuth({ stepUp: true });
+      const rejection = expect(recoverAuth({ stepUp: true, challenge: {} })).rejects.toThrow(/step-up redirect timed out/);
       await jest.advanceTimersByTimeAsync(60_000);
-      await jest.advanceTimersByTimeAsync(30_000);
-      await expect(pending).resolves.toBe('stepped.token');
+      await rejection;
+
+      expect(store.dispatch).not.toHaveBeenCalled();
+
+      stepUp.mockImplementationOnce(() => Promise.resolve('stepped.token'));
+      await expect(recoverAuth({ stepUp: true, challenge: {} })).resolves.toBe('stepped.token');
+      expect(stepUp).toHaveBeenCalledTimes(2);
     } finally {
       jest.useRealTimers();
     }

--- a/src/withSocketConnection/index.test.js
+++ b/src/withSocketConnection/index.test.js
@@ -6,7 +6,11 @@ import { recoverAuth } from '../utils/auth-recovery';
 import { clearAuth } from '../ducks/auth';
 
 jest.mock('socket.io-client', () => ({ __esModule: true, default: jest.fn() }));
-jest.mock('../utils/auth-recovery', () => ({ recoverAuth: jest.fn() }));
+// Real parsers; only recoverAuth is stubbed.
+jest.mock('../utils/auth-recovery', () => ({
+  ...jest.requireActual('../utils/auth-recovery'),
+  recoverAuth: jest.fn(),
+}));
 jest.mock('../ducks/auth', () => ({ clearAuth: jest.fn() }));
 // The socket handler dispatches through the imported store singleton; stub it so the
 // test controls dispatch and importing the hook doesn't build the real reducer tree.
@@ -142,5 +146,67 @@ describe('websocket auth recovery (resp_authorization)', () => {
 
     expect(recoverAuth).toHaveBeenCalledTimes(2);
     expect(clearAuth).not.toHaveBeenCalled();
+  });
+
+  test('a 401 carrying the RFC 9470 step-up challenge routes to interactive step-up, not silent-renew', async () => {
+    // Step-up never settles (redirect); assert the routing decision, not a completion.
+    recoverAuth.mockReturnValue(new Promise(() => {}));
+    const challenge = 'Bearer error="insufficient_user_authentication", acr_values="http://schemas.openid.net/pape/policies/2007/06/multi-factor", max_age="31536000"';
+
+    const { socket, store } = bindSocket();
+    await act(async () => {
+      socket.handlers.resp_authorization({ status: { code: 401, www_authenticate: challenge } });
+      await Promise.resolve();
+    });
+
+    expect(recoverAuth).toHaveBeenCalledWith({
+      stepUp: true,
+      challenge: {
+        error: 'insufficient_user_authentication',
+        acrValues: 'http://schemas.openid.net/pape/policies/2007/06/multi-factor',
+        maxAge: '31536000',
+      },
+    });
+    expect(clearAuth).not.toHaveBeenCalled();
+    expect(store.dispatch).not.toHaveBeenCalledWith(CLEAR_AUTH_ACTION);
+  });
+
+  test('a 401 with an ordinary (non-step-up) challenge still takes the silent-renew path', async () => {
+    recoverAuth.mockResolvedValue('fresh.token');
+
+    const { socket } = bindSocket();
+    await act(async () => {
+      await socket.handlers.resp_authorization({
+        status: { code: 401, www_authenticate: 'Bearer error="invalid_token"' },
+      });
+    });
+
+    expect(recoverAuth).toHaveBeenCalledWith(undefined);
+    expect(clearAuth).not.toHaveBeenCalled();
+  });
+
+  test('escalates to step-up (not sign-out) when a silently-renewed socket then 401s with a step-up challenge', async () => {
+    const { socket, store } = bindSocket();
+
+    // Ordinary 401 → silent renew → re-authorize (sets the once-per-cycle guard).
+    recoverAuth.mockResolvedValueOnce('renewed.token');
+    await act(async () => {
+      await socket.handlers.resp_authorization({ status: { code: 401 } });
+    });
+
+    // The re-authorize 401s with a step-up challenge (guard already set); step-up bypasses it.
+    recoverAuth.mockReturnValue(new Promise(() => {}));
+    const challenge = 'Bearer error="insufficient_user_authentication", acr_values="urn:mfa", max_age="3600"';
+    await act(async () => {
+      socket.handlers.resp_authorization({ status: { code: 401, www_authenticate: challenge } });
+      await Promise.resolve();
+    });
+
+    expect(recoverAuth).toHaveBeenLastCalledWith({
+      stepUp: true,
+      challenge: { error: 'insufficient_user_authentication', acrValues: 'urn:mfa', maxAge: '3600' },
+    });
+    expect(clearAuth).not.toHaveBeenCalled();
+    expect(store.dispatch).not.toHaveBeenCalledWith(CLEAR_AUTH_ACTION);
   });
 });

--- a/src/withSocketConnection/useRealTimeImplementation/index.js
+++ b/src/withSocketConnection/useRealTimeImplementation/index.js
@@ -4,7 +4,7 @@ import { DAS_HOST } from '../../constants';
 import { resetSocketStateTracking } from './helpers';
 import { SOCKET_HEALTHY_STATUS } from '../../ducks/system-status';
 import { clearAuth } from '../../ducks/auth';
-import { recoverAuth } from '../../utils/auth-recovery';
+import { isStepUpChallenge, parseAuthChallenge, recoverAuth } from '../../utils/auth-recovery';
 import { events } from './config';
 import { calcEventFilterForRequest } from '../../utils/event-filter';
 import { calcPatrolFilterForRequest } from '../../utils/patrol-filter';
@@ -73,10 +73,13 @@ const useRealTimeImplementation = () => {
     socket.on('resp_authorization', async (msg) => {
       const { status } = msg;
       if (status.code === 401) {
-        if (!authRetried) {
+        // Step-up bypasses the once-per-cycle guard: it redirects rather than looping.
+        const challenge = status.www_authenticate;
+        const stepUp = isStepUpChallenge(challenge);
+        if (stepUp || !authRetried) {
           authRetried = true;
           try {
-            await recoverAuth();
+            await recoverAuth(stepUp ? { stepUp: true, challenge: parseAuthChallenge(challenge) } : undefined);
             console.log('realtime: token renewed; re-authorizing');
             return authorize();
           } catch (renewalError) {


### PR DESCRIPTION
## What & why

[ERA-13733](https://allenai.atlassian.net/browse/ERA-13733)

Handles the RFC 9470 MFA step-up challenge over the `rt_api` websocket, the socket sibling of the REST handler in #1659 (ERA-13405). On a `require_mfa` site the server now surfaces the challenge on a `resp_authorization` 401 as `status.www_authenticate` (a raw `WWW-Authenticate` string — das#4085 / ERA-13732). This routes it through the shared `auth-recovery` unit's interactive step-up instead of a silent-renew (which is same-ACR and can't satisfy MFA) followed by a blind sign-out.

Also hardens the shared unit with a step-up **redirect-handoff watchdog** (raised in review on #1659).

> **Stacked on #1659.** Base is `ERA-13405`, so this diff is just the two ERA-13733 commits. GitHub will auto-retarget the base to `develop` when #1659 merges; this PR must merge **after** #1659.

## Commits

1. **route step-up 401s over the websocket** — `useRealTimeImplementation`'s `resp_authorization` handler reads `status.www_authenticate`; a step-up challenge routes to `recoverAuth({ stepUp: true, challenge })` (redirect — never silent-renews), an ordinary 401 keeps the ERA-13685 silent-renew path. Step-up bypasses the per-bind `authRetried` guard (`stepUp || !authRetried`) so a renewed-but-MFA-stale token escalates to step-up rather than signing out. Mirrors the REST interceptor.
2. **bound the step-up redirect handoff (watchdog)** — see below.

## How it works (end to end)

Socket step-up 401 → handler parses `status.www_authenticate` → `recoverAuth({ stepUp })` → `loginWithRedirect` (the interactive primitive owned by ERA-13405) → user completes MFA → the redirect callback re-bootstraps with the MFA token. The rebuilt socket's `connect` handler reads the fresh token from the store and re-authorizes — so no bespoke socket recovery is needed. Because the flight is mode-keyed single-flight, a concurrent REST + socket step-up coalesces into **one** redirect.

## The watchdog (addresses @chrisj-er's note on #1659)

The `stepUp` primitive resolves `loginWithRedirect` and then stays pending (`new Promise(() => {})`) so recovery doesn't replay before the page unloads — which means `recoverAuth`'s `inFlight.stepUp` latch relied on unload to clear. If `loginWithRedirect` ever resolved *without* navigating, the latch stuck forever and every later step-up 401 hung with no sign-out fallback.

Fix: time-box the step-up flight with a generous `STEP_UP_REDIRECT_TIMEOUT_MS = 60_000` via the existing `withTimeout` (silent renewal stays 30s). A successful redirect unloads the page in well under a second, so the bound can **only** fire when the redirect never navigated — converting an indefinite hang into a recoverable sign-out and releasing the latch. It never truncates the user's MFA, which happens on the Auth0 page *after* unload (not on this pending promise).

## Dependencies / status

- **Stacked on #1659 (ERA-13405)** — the REST step-up + the shared parsers, single-flight, and interactive `stepUp` primitive this reuses.
- Builds on **ERA-13685** (shared `auth-recovery` unit + socket silent-renew) — merged.
- Server socket emission **ERA-13732** (das#4085) is **In Pull Request**. The payload is a raw `WWW-Authenticate` string in `status.www_authenticate`, byte-compatible with the HTTP header so the REST parser (`isStepUpChallenge`/`parseAuthChallenge`) is reused unchanged.
- `require_mfa` (**ERA-13387**) is **In Test** — end-to-end exercise needs a `require_mfa` env, hence the `deploy` label.

## Behavior notes — worth discussing

- **AC3 (concurrent REST + socket → a single step-up)** falls out of ERA-13405's mode-keyed single-flight; the socket handler joins the same `inFlight.stepUp` flight. Not re-asserted at the socket layer here (`recoverAuth` is mocked in the socket test); it's pinned in `auth-recovery.test.js`.
- **Deferred hardening (core-review finding).** Step-up loop-prevention is currently *implicit*: both transports bypass their anti-loop guards for step-up, safe only because the redirect primitive never resolves with a token (it navigates away, or the watchdog rejects → sign-out). This is fine for the redirect variant shipping here. **If the popup escape-hatch variant is ever adopted** (it resolves in-page with a token), an explicit "step-up attempted once per cycle" marker is required, or a repeated step-up 401 would loop. Tied to the popup variant, deliberately not in this PR.
- **The redirect discards unsaved in-flight state** — carries over verbatim from #1659 (same `stepUp` primitive). Benign at the default `mfa_max_age_seconds` (365 days); a short per-tenant window re-introduces mid-form step-ups. Escape hatch is the popup variant (see above).

## Testing

- **Socket** (`withSocketConnection/index.test.js`): step-up challenge routes to the interactive path (exact parsed `{ stepUp, challenge }` args, no silent-renew, no sign-out); an ordinary (non-step-up) `www_authenticate` still silent-renews; and the guard-bypass escalation (a silently-renewed socket then 401s with a step-up challenge → step-up, not sign-out).
- **Shared unit** (`utils/auth-recovery.test.js`): the watchdog rejects a step-up whose redirect never navigates, does not dispatch a token, and releases `inFlight.stepUp` so a later step-up retries.
- Full suite green (2891).

## Deploy

`deploy` label added to spin up a `require_mfa`-capable feature env for manual end-to-end verification (the unit tests mock at the seams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ERA-13733]: https://allenai.atlassian.net/browse/ERA-13733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ