### PR TITLE
docs: tell Claude not to add unnecessary code/test comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,14 @@ The server stores a canonical **JSON Schema** per event type. Client-side editin
 - Functional components with hooks; props destructured in function signature.
 - No PropTypes.
 
+#### Comments
+
+- Do not add new comments unless they are genuinely necessary. Assume the reader knows the language and the codebase; well-named functions and variables should carry the meaning instead.
+- A comment earns its place only when the code cannot: a non-obvious *why* (a workaround, a subtle constraint, an intentional deviation), a caveat, or a link to an external reference. Comments that restate *what* the code does are noise — delete them from your own output before finishing.
+- Never narrate the change or your reasoning in a comment (e.g. `// added this`, `// now using X instead of Y`, `// this fixes the bug`). Comments describe the code as it stands, not how it got there — the diff and commit message are for that.
+- The same rules apply to test files: describe intent through `describe`/`it` names, not inline commentary.
+- Leave existing comments alone unless they are wrong or you are changing the code they document.
+
 #### Accessibility
 
 - **WCAG 2.1 AA** compliance.


### PR DESCRIPTION
## Summary

Adds a `#### Comments` subsection under **Development Preferences** in `AGENTS.md` (which `CLAUDE.md` symlinks to), giving Claude a clear hint not to add new comments in code or tests unless genuinely necessary.

Motivated by repeated codeowner feedback on PRs about Claude-authored comments.

The guidance:
- Default to **no new comments** — assume the reader knows the language/codebase; naming carries meaning.
- A comment earns its place only for a non-obvious *why* (workaround, constraint, intentional deviation), a caveat, or an external reference. "What the code does" comments are noise.
- **No change-narration** comments (`// added this`, `// now using X instead of Y`, `// this fixes the bug`) — the diff and commit message are for that.
- Same rules apply to **test files**.
- Leave existing comments alone unless wrong or the code they document is changing.

## Notes

This is a guidance hint, not enforcement. If a hard backstop is wanted, a lint rule / PR-time check would be stronger than a prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)