### PR TITLE
ERA-8882 Show polygon area when measuring with the map ruler

### DIFF
--- a/public/locales/en-US/map-controls.json
+++ b/public/locales/en-US/map-controls.json
@@ -24,6 +24,7 @@
   },
   "mapDrawingTools": {
     "addPointLabel": "Click to add a point. \n Hit 'enter' or 'return' to complete.",
+    "areaLabel": "Area: {{area}}",
     "bearingLabel": "Bearing: {{bearing}}°",
     "distanceLabel": "Distance: {{distance}}",
     "instructionsLabel": "Click & drag to add a point",
@@ -41,6 +42,7 @@
     "title": "Map ruler"
   },
   "pointPopup": {
+    "areaLabel": "Area:",
     "bearingLabel": "Bearing:",
     "distanceLabel": "Distance from start:",
     "finishButton": "click here to finish"

--- a/public/locales/es/map-controls.json
+++ b/public/locales/es/map-controls.json
@@ -24,6 +24,7 @@
   },
   "mapDrawingTools": {
     "addPointLabel": "Click para agregar un punto.\n Presione 'enter' para completar.",
+    "areaLabel": "Área: {{area}}",
     "bearingLabel": "Rumbo: {{bearing}}°",
     "distanceLabel": "Distancia: {{distance}}",
     "instructionsLabel": "Haga click y arrastre para agregar un punto",
@@ -41,6 +42,7 @@
     "title": "Regla del mapa"
   },
   "pointPopup": {
+    "areaLabel": "Área:",
     "bearingLabel": "Rumbo:",
     "distanceLabel": "Distancia del inicio:",
     "finishButton": "Click para finalizar"

--- a/public/locales/fr/map-controls.json
+++ b/public/locales/fr/map-controls.json
@@ -24,6 +24,7 @@
   },
   "mapDrawingTools": {
     "addPointLabel": "Cliquez pour ajouter un point. Sélectionner \"entrée\" pour finaliser.",
+    "areaLabel": "Superficie: {{area}}",
     "bearingLabel": "Direction: {{bearing}}°",
     "distanceLabel": "Distance: {{distance}}",
     "instructionsLabel": "Cliquez puis glissez pour ajouter un point",
@@ -41,6 +42,7 @@
     "title": "Règle "
   },
   "pointPopup": {
+    "areaLabel": "Superficie :",
     "bearingLabel": "Direction: ",
     "distanceLabel": "Distance depuis l'origine",
     "finishButton": "Cliquez ici pour finaliser"

--- a/public/locales/ne-NP/map-controls.json
+++ b/public/locales/ne-NP/map-controls.json
@@ -18,6 +18,7 @@
     },
     "mapDrawingTools": {
         "addPointLabel": "नयाँ बिन्दु थप्न क्लिक गर्नुहोस् । पुरा गर्नका लागि ‘enter’ वा ‘return’ थिच्नुहोस् ।",
+        "areaLabel": "क्षेत्रफल: {{area}}",
         "bearingLabel": "असर: {{bearing}}°",
         "distanceLabel": "दूरी: {{distance}}",
         "instructionsLabel": "नयाँ बिन्दु थप्नका लागि क्लिक गरेर तान्नुहोस्",
@@ -35,6 +36,7 @@
         "title": "नक्शाको मापक"
     },
     "pointPopup": {
+        "areaLabel": "क्षेत्रफल:",
         "bearingLabel": "असर:",
         "distanceLabel": "सुरु देखिको दुरी:",
         "finishButton": "समाप्त गर्न यहाँ क्लिक गर्नुहोस्"

--- a/public/locales/pt/map-controls.json
+++ b/public/locales/pt/map-controls.json
@@ -18,6 +18,7 @@
     },
     "mapDrawingTools": {
         "addPointLabel": "Clique para adicionar um ponto. Pressione \"Enter\" ou \"Voltar\" para completar.",
+        "areaLabel": "Área: {{area}}",
         "bearingLabel": "Direção {{bearing}}°",
         "distanceLabel": "Distância: {{distance}}",
         "instructionsLabel": "Clique e arraste para adicionar um ponto",
@@ -35,6 +36,7 @@
         "title": "Régua"
     },
     "pointPopup": {
+        "areaLabel": "Área:",
         "bearingLabel": "Direção:",
         "distanceLabel": "Distância a partir do início",
         "finishButton": "Clique aqui para finalizar"

--- a/public/locales/sw/map-controls.json
+++ b/public/locales/sw/map-controls.json
@@ -24,6 +24,7 @@
   },
   "mapDrawingTools": {
     "addPointLabel": "Bonyeza ili kuongeza alama. \n Bonyeza 'enter' au 'return' kumaliza.",
+    "areaLabel": "Eneo: {{area}}",
     "bearingLabel": "Mwelekeo: {{bearing}}°",
     "distanceLabel": "Umbali: {{distance}}",
     "instructionsLabel": "Bonyeza & buruta ili kuongeza alama",
@@ -41,6 +42,7 @@
     "title": "Pima ramani"
   },
   "pointPopup": {
+    "areaLabel": "Eneo:",
     "bearingLabel": "Mwelekeo:",
     "distanceLabel": "Umbali kutoka mwanzo:",
     "finishButton": "bonyeza hapa kumaliza"

--- a/src/MapDrawingTools/MapLayers.js
+++ b/src/MapDrawingTools/MapLayers.js
@@ -10,6 +10,7 @@ import {
   circlePaint,
   fillLayout,
   fillPaint,
+  lightFillPaint,
   symbolPaint,
   lineSymbolLayout,
   polygonSymbolLayout,
@@ -41,6 +42,7 @@ const MapDrawingLayers = ({
   isHoveringGeometry,
   setIsHoveringGeometry,
   setIsHoveringMidpoint,
+  showLineFill,
 }) => {
   const map = useContext(MapContext);
 
@@ -85,7 +87,7 @@ const MapDrawingLayers = ({
     id: LAYER_IDS.FILL,
     type: 'fill',
     sourceId: SOURCE_IDS.FILL_SOURCE,
-    paint: fillPaint,
+    paint: showLineFill ? lightFillPaint : fillPaint,
     layout: fillLayout
   }]);
 
@@ -132,8 +134,8 @@ const MapDrawingLayers = ({
 
   useMapEventBinding('mouseenter', onCircleMouseEnter, LAYER_IDS.POINTS, !!pointsLayer);
   useMapEventBinding('mouseleave', onCircleMouseLeave, LAYER_IDS.POINTS, !!pointsLayer);
-  useMapEventBinding('mouseenter', onFillMouseEnter, LAYER_IDS.FILL, !!fillLayer);
-  useMapEventBinding('mouseleave', onFillMouseLeave, LAYER_IDS.FILL, !!fillLayer);
+  useMapEventBinding('mouseenter', onFillMouseEnter, LAYER_IDS.FILL, !!fillLayer && !showLineFill);
+  useMapEventBinding('mouseleave', onFillMouseLeave, LAYER_IDS.FILL, !!fillLayer && !showLineFill);
 
   useEffect(() => {
     setIsHoveringGeometry(isHoveringCircle || isHoveringPolygonFill);

--- a/src/MapDrawingTools/hooks.js
+++ b/src/MapDrawingTools/hooks.js
@@ -29,7 +29,8 @@ export const useDrawToolGeoJson = (
   drawMode = DRAWING_MODES.POLYGON,
   polygonHover = false,
   draggedPoint = null,
-  isMediumLayoutOrLarger = true
+  isMediumLayoutOrLarger = true,
+  showLineFill = false
 ) => {
   const { setMapDrawingData } = useContext(MapDrawingToolsContext);
 
@@ -55,6 +56,11 @@ export const useDrawToolGeoJson = (
     return vertexCoordinates;
   }, [cursorCoords, draggedPoint, drawMode, isDrawing, isMediumLayoutOrLarger, points]);
 
+  const distinctVertexCoordinates = useMemo(
+    () => vertexCoordinates.filter((coordinates, index) => index === 0 || !isEqual(coordinates, vertexCoordinates[index - 1])),
+    [vertexCoordinates]
+  );
+
   const geoJson = useMemo(() => {
     const data = {
       drawnLinePoints: featureCollection([]),
@@ -67,6 +73,9 @@ export const useDrawToolGeoJson = (
     const shouldCalculatePolygonData = drawMode === DRAWING_MODES.POLYGON
       && vertexCoordinates.length > POINTS_IN_A_LINE;
     const shouldCalculateMidpointsData = shouldCalculatePolygonData && !isDrawing && !draggedPoint && polygonHover;
+    const shouldCalculateLineFillData = showLineFill
+      && !shouldCalculatePolygonData
+      && distinctVertexCoordinates.length > POINTS_IN_A_LINE;
 
     const isPolygonClosed = shouldCalculatePolygonData
       && isEqual(vertexCoordinates[0], vertexCoordinates[vertexCoordinates.length - 1]);
@@ -92,6 +101,13 @@ export const useDrawToolGeoJson = (
       data.fillLabelPoint = createLabelPointGeoJsonForPolygonThrottled(data.fillPolygon);
     }
 
+    if (shouldCalculateLineFillData) {
+      data.fillPolygon = createFillPolygonGeoJsonForCoords([
+        ...distinctVertexCoordinates,
+        distinctVertexCoordinates[0],
+      ]);
+    }
+
     if (shouldCalculateMidpointsData) {
       data.drawnLinePoints = featureCollection([
         ...data.drawnLinePoints.features,
@@ -100,7 +116,7 @@ export const useDrawToolGeoJson = (
     }
 
     return data;
-  }, [vertexCoordinates, drawMode, isDrawing, draggedPoint, polygonHover, isMediumLayoutOrLarger]);
+  }, [vertexCoordinates, distinctVertexCoordinates, drawMode, isDrawing, draggedPoint, polygonHover, isMediumLayoutOrLarger, showLineFill]);
 
   const setMapDrawingDataThrottledRef = useRef(throttle((newGeoJson) => {
     setMapDrawingData(newGeoJson);

--- a/src/MapDrawingTools/index.js
+++ b/src/MapDrawingTools/index.js
@@ -197,7 +197,7 @@ const MapDrawingTools = ({
 
 export default memo(MapDrawingTools);
 
-const DefaultCursorPopup = ({ coords, drawing, isHoveringMidpoint, lineLength, points }) => {
+export const DefaultCursorPopup = ({ area = null, coords, drawing, isHoveringMidpoint, lineLength, points }) => {
   const map = useContext(MapContext);
   const { t } = useTranslation('map-controls', { keyPrefix: 'mapDrawingTools' });
 
@@ -222,6 +222,7 @@ const DefaultCursorPopup = ({ coords, drawing, isHoveringMidpoint, lineLength, p
               bearing: calcPositiveBearing(points[points.length - 1], coords).toFixed(2)
             })}
           </p>
+          {!!area && <p>{t('areaLabel', { area })}</p>}
           <p>
             {t('distanceLabel', {
               distance: lineLength

--- a/src/MapDrawingTools/index.js
+++ b/src/MapDrawingTools/index.js
@@ -35,6 +35,7 @@ const MapDrawingTools = ({
   onClickPoint = noop,
   points,
   renderCursorPopup = defaultCursorPopupRenderFn,
+  showLineFill = false,
 }) => {
   const map = useContext(MapContext);
 
@@ -60,7 +61,8 @@ const MapDrawingTools = ({
     drawingMode,
     isHoveringGeometry,
     draggedPoint,
-    isMediumLayoutOrLarger
+    isMediumLayoutOrLarger,
+    showLineFill
   );
 
   const showLayer = pointerLocation || points.length;
@@ -190,6 +192,7 @@ const MapDrawingTools = ({
       isHoveringGeometry={isHoveringGeometry}
       setIsHoveringGeometry={setIsHoveringGeometry}
       setIsHoveringMidpoint={setIsHoveringMidpoint}
+      showLineFill={showLineFill}
     />
     {children}
   </>;

--- a/src/MapDrawingTools/index.test.js
+++ b/src/MapDrawingTools/index.test.js
@@ -260,6 +260,93 @@ describe('MapDrawingTools', () => {
     });
   });
 
+  describe('the line fill', () => {
+    const renderLineDrawingTools = (setMapDrawingData, props) => render(
+      <MapContext.Provider value={map}>
+        <MapDrawingToolsContext.Provider value={{ setMapDrawingData }}>
+          <MapDrawingTools
+            drawing={drawing}
+            drawingMode={DRAWING_MODES.LINE}
+            points={[[1, 2], [2, 3], [4, 1]]}
+            {...props}
+          />
+        </MapDrawingToolsContext.Provider>
+      </MapContext.Provider>
+    );
+
+    const getLastDrawingData = (setMapDrawingData) =>
+      setMapDrawingData.mock.calls[setMapDrawingData.mock.calls.length - 1][0];
+
+    test('fills the closed ring of the drawn line when enabled', async () => {
+      const setMapDrawingData = jest.fn();
+
+      renderLineDrawingTools(setMapDrawingData, { showLineFill: true });
+
+      await waitFor(() => {
+        const { fillPolygon } = getLastDrawingData(setMapDrawingData);
+
+        expect(fillPolygon.geometry.type).toBe('Polygon');
+        expect(fillPolygon.geometry.coordinates[0]).toEqual([[1, 2], [2, 3], [4, 1], [1, 2]]);
+      });
+    });
+
+    test('does not label the filled area on the map', async () => {
+      const setMapDrawingData = jest.fn();
+
+      renderLineDrawingTools(setMapDrawingData, { showLineFill: true });
+
+      await waitFor(() => {
+        expect(getLastDrawingData(setMapDrawingData).fillLabelPoint.features).toHaveLength(0);
+      });
+    });
+
+    test('does not fill when disabled', async () => {
+      const setMapDrawingData = jest.fn();
+
+      renderLineDrawingTools(setMapDrawingData);
+
+      await waitFor(() => {
+        expect(getLastDrawingData(setMapDrawingData).fillPolygon.features).toHaveLength(0);
+      });
+    });
+
+    test('does not fill with fewer than three distinct vertices', async () => {
+      const setMapDrawingData = jest.fn();
+
+      renderLineDrawingTools(setMapDrawingData, { points: [[1, 2], [2, 3]], showLineFill: true });
+
+      await waitFor(() => {
+        expect(getLastDrawingData(setMapDrawingData).fillPolygon.features).toHaveLength(0);
+      });
+    });
+
+    test('counts the cursor location as a vertex while drawing', async () => {
+      const setMapDrawingData = jest.fn();
+
+      renderLineDrawingTools(setMapDrawingData, { points: [[1, 2], [2, 3]], showLineFill: true });
+
+      map.__test__.fireHandlers('mousemove', { lngLat: { lng: 4, lat: 1 } });
+
+      await waitFor(() => {
+        const { fillPolygon } = getLastDrawingData(setMapDrawingData);
+
+        expect(fillPolygon.geometry.coordinates[0]).toEqual([[1, 2], [2, 3], [4, 1], [1, 2]]);
+      });
+    });
+
+    test('ignores a cursor location identical to the last point', async () => {
+      const setMapDrawingData = jest.fn();
+
+      renderLineDrawingTools(setMapDrawingData, { points: [[1, 2], [2, 3]], showLineFill: true });
+
+      map.__test__.fireHandlers('mousemove', { lngLat: { lng: 2, lat: 3 } });
+
+      await waitFor(() => {
+        expect(getLastDrawingData(setMapDrawingData).fillPolygon.features).toHaveLength(0);
+      });
+    });
+  });
+
   describe('the cursor popup', () => {
     test('rendering a cursor popup with point details when drawing and the mouse is moved', async () => {
       const points = [[1, 2], [2, 3], [4, 5]];

--- a/src/MapDrawingTools/index.test.js
+++ b/src/MapDrawingTools/index.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { createMapMock } from '../__test-helpers/mocks';
 
 import { MapContext } from '../MapContext';
-import MapDrawingTools, { DRAWING_MODES } from './';
+import MapDrawingTools, { DefaultCursorPopup, DRAWING_MODES } from './';
 import MapDrawingToolsContextProvider, { MapDrawingToolsContext } from './ContextProvider';
 import { useMatchMedia } from '../hooks';
 import { render, waitFor } from '../test-utils';
@@ -319,6 +319,42 @@ describe('MapDrawingTools', () => {
 
       await waitFor(() => {
         expect(container).not.toHaveTextContent('Cursor popup rendering stuff');
+      });
+    });
+
+    describe('DefaultCursorPopup', () => {
+      const renderCursorPopup = (props) => {
+        render(
+          <MapContext.Provider value={map}>
+            <DefaultCursorPopup
+              coords={[2, 2]}
+              drawing
+              lineLength="1.23km"
+              points={[[1, 2], [2, 3]]}
+              {...props}
+            />
+          </MapContext.Provider>
+        );
+
+        return popupDomContent[popupDomContent.length - 1];
+      };
+
+      test('shows only the bearing and the distance without an area', () => {
+        const popup = renderCursorPopup();
+
+        expect(popup).toHaveTextContent('Bearing:');
+        expect(popup).toHaveTextContent('Distance: 1.23km');
+        expect(popup).not.toHaveTextContent('Area:');
+      });
+
+      test('shows the area between the bearing and the distance', () => {
+        const popup = renderCursorPopup({ area: '6181.86km²' });
+
+        const paragraphs = [...popup.querySelectorAll('p')].map((paragraph) => paragraph.textContent);
+
+        expect(paragraphs[0]).toContain('Bearing:');
+        expect(paragraphs[1]).toBe('Area: 6181.86km²');
+        expect(paragraphs[2]).toBe('Distance: 1.23km');
       });
     });
   });

--- a/src/MapDrawingTools/layerStyles.js
+++ b/src/MapDrawingTools/layerStyles.js
@@ -97,3 +97,4 @@ export const circlePaint = {
 
 export const fillLayout = { visibility: 'visible' };
 export const fillPaint = { 'fill-color': 'red', 'fill-opacity': 0.4 };
+export const lightFillPaint = { ...fillPaint, 'fill-opacity': 0.1 };

--- a/src/MapRulerControl/PointPopup.js
+++ b/src/MapRulerControl/PointPopup.js
@@ -6,6 +6,7 @@ import GpsFormatToggle from '../GpsFormatToggle';
 import AddItemButton from '../AddItemButton';
 import Popup from '../Popup';
 import { calcPositiveBearing } from '../utils/location';
+import { calcPolygonAreaDisplayString } from './utils';
 
 import { MAP_INTERACTION_CATEGORY } from '../utils/analytics';
 
@@ -33,6 +34,8 @@ const PointPopup = (props) => {
 
   }, [isFirstPoint, pointIndex, points]);
 
+  const polygonArea = useMemo(() => calcPolygonAreaDisplayString(points), [points]);
+
   const bearingFromPrev = useMemo(() => {
     if (isFirstPoint) return null;
 
@@ -57,6 +60,10 @@ const PointPopup = (props) => {
         <p>
           <strong>{t('bearingLabel')}</strong> {bearingFromPrev}&deg; <br />
           <strong>{t('distanceLabel')}</strong> {distanceFromStart}
+          {points.length >= 3 && <>
+            <br />
+            <strong>{t('areaLabel')}</strong> {polygonArea}
+          </>}
         </p>
       </>}
       <AddItemButton

--- a/src/MapRulerControl/PointPopup.test.js
+++ b/src/MapRulerControl/PointPopup.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { GPS_FORMATS } from '../utils/location';
+import { MapContext } from '../MapContext';
+import { mockStore } from '../__test-helpers/MockStore';
+import { createMapMock } from '../__test-helpers/mocks';
+import { render } from '../test-utils';
+
+import PointPopup from './PointPopup';
+
+const popupDomContent = [];
+
+jest.mock('mapbox-gl', () => ({
+  ...jest.requireActual('mapbox-gl'),
+  Popup: class {
+    addTo() {}
+    on() {}
+    remove() {}
+    setDOMContent(domContent) { popupDomContent.push(domContent); }
+    setLngLat() {}
+    setOffset() {}
+  },
+}));
+
+jest.mock('../AddItemButton', () => () => null);
+
+const store = {
+  data: {},
+  view: {
+    coordinateReferenceSystems: {
+      selectedCoordinateRepresentations: Object.values(GPS_FORMATS),
+      storedSystems: [],
+    },
+    userPreferences: { gpsFormat: GPS_FORMATS.DEG },
+  },
+};
+
+const renderComponent = (points, { drawing = false, pointIndex = points.length - 1 } = {}) => {
+  render(
+    <Provider store={mockStore(store)}>
+      <MapContext.Provider value={createMapMock()}>
+        <PointPopup drawing={drawing} points={points} pointIndex={pointIndex} onClickFinish={jest.fn()} />
+      </MapContext.Provider>
+    </Provider>
+  );
+
+  return popupDomContent[popupDomContent.length - 1];
+};
+
+describe('MapRulerControl - PointPopup', () => {
+  beforeEach(() => {
+    popupDomContent.length = 0;
+  });
+
+  test('does not show the area with fewer than three points', () => {
+    const popup = renderComponent([[0, 0], [1, 0]]);
+
+    expect(popup).toHaveTextContent('Distance from start:');
+    expect(popup).not.toHaveTextContent('Area:');
+  });
+
+  test('shows the area of the closed ring with three points', () => {
+    const popup = renderComponent([[0, 0], [1, 0], [1, 1]]);
+
+    expect(popup).toHaveTextContent('Area: 6181.86km²');
+  });
+
+  test('shows the area on a popup for a point other than the last one', () => {
+    const popup = renderComponent([[0, 0], [1, 0], [1, 1]], { pointIndex: 1 });
+
+    expect(popup).toHaveTextContent('Area: 6181.86km²');
+  });
+
+  test('while drawing, shows only the finish button', () => {
+    const popup = renderComponent([[0, 0], [1, 0], [1, 1]], { drawing: true });
+
+    expect(popup).toHaveTextContent('click here to finish');
+    expect(popup).not.toHaveTextContent('Area:');
+  });
+});

--- a/src/MapRulerControl/index.js
+++ b/src/MapRulerControl/index.js
@@ -12,8 +12,10 @@ import { MapContext } from '../MapContext';
 import { setIsPickingLocation } from '../ducks/map-ui';
 import { useMapEventBinding } from '../hooks';
 
-import MapDrawingTools, { DRAWING_MODES } from '../MapDrawingTools';
+import MapDrawingTools, { DefaultCursorPopup, DRAWING_MODES } from '../MapDrawingTools';
 import PointPopup from './PointPopup';
+
+import { calcCursorPolygonAreaDisplayString } from './utils';
 
 import * as styles from './styles.module.scss';
 
@@ -72,6 +74,11 @@ const MapRulerControl = ({ setIsPickingLocation }) => {
   const onFinish = useCallback(() => { // KEEP
     setDrawingState(false);
   }, []);
+
+  const renderCursorPopup = useCallback((cursorPopupProps) => <DefaultCursorPopup
+    {...cursorPopupProps}
+    area={calcCursorPolygonAreaDisplayString(cursorPopupProps.points, cursorPopupProps.coords)}
+  />, []);
 
   const popupPointSelected = (selectedPointIndex > -1) && !!points[selectedPointIndex];
 
@@ -195,6 +202,7 @@ const MapRulerControl = ({ setIsPickingLocation }) => {
       points={points}
       onChange={onDrawChange}
       onClickPoint={onClickPoint}
+      renderCursorPopup={renderCursorPopup}
     />}
   </>;
 };

--- a/src/MapRulerControl/index.js
+++ b/src/MapRulerControl/index.js
@@ -13,6 +13,7 @@ import { setIsPickingLocation } from '../ducks/map-ui';
 import { useMapEventBinding } from '../hooks';
 
 import MapDrawingTools, { DefaultCursorPopup, DRAWING_MODES } from '../MapDrawingTools';
+import MapDrawingToolsContextProvider from '../MapDrawingTools/ContextProvider';
 import PointPopup from './PointPopup';
 
 import { calcCursorPolygonAreaDisplayString } from './utils';
@@ -196,14 +197,17 @@ const MapRulerControl = ({ setIsPickingLocation }) => {
       {drawing && <PointPopup map={map} points={points} pointIndex={points.length - 1} drawing={drawing} onClickFinish={onFinish} />}
       {!drawing && popupPointSelected && <PointPopup map={map} points={points} pointIndex={selectedPointIndex} drawing={drawing} />}
     </>}
-    {active && <MapDrawingTools
-      drawing={drawing}
-      drawingMode={DRAWING_MODES.LINE}
-      points={points}
-      onChange={onDrawChange}
-      onClickPoint={onClickPoint}
-      renderCursorPopup={renderCursorPopup}
-    />}
+    {active && <MapDrawingToolsContextProvider>
+      <MapDrawingTools
+        drawing={drawing}
+        drawingMode={DRAWING_MODES.LINE}
+        points={points}
+        onChange={onDrawChange}
+        onClickPoint={onClickPoint}
+        renderCursorPopup={renderCursorPopup}
+        showLineFill
+      />
+    </MapDrawingToolsContextProvider>}
   </>;
 };
 

--- a/src/MapRulerControl/index.test.js
+++ b/src/MapRulerControl/index.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import userEvent from '@testing-library/user-event';
+
+import { MapContext } from '../MapContext';
+import { MapDrawingToolsContext } from '../MapDrawingTools/ContextProvider';
+import { createMapMock } from '../__test-helpers/mocks';
+import { mockStore } from '../__test-helpers/MockStore';
+import { render, screen } from '../test-utils';
+
+import MapRulerControl from './';
+
+jest.mock('mapbox-gl', () => ({
+  ...jest.requireActual('mapbox-gl'),
+  Popup: class {
+    addTo() {}
+    on() {}
+    remove() {}
+    setDOMContent() {}
+    setLngLat() {}
+    setOffset() {}
+  },
+}));
+
+describe('MapRulerControl', () => {
+  let map, setMapDrawingData;
+
+  beforeEach(() => {
+    map = createMapMock();
+    map.queryRenderedFeatures.mockReturnValue([]);
+    setMapDrawingData = jest.fn();
+  });
+
+  test('keeps its drawing data out of the surrounding map drawing tools context', async () => {
+    render(
+      <Provider store={mockStore({ data: {}, view: {} })}>
+        <MapContext.Provider value={map}>
+          <MapDrawingToolsContext.Provider value={{ setMapDrawingData }}>
+            <MapRulerControl />
+          </MapDrawingToolsContext.Provider>
+        </MapContext.Provider>
+      </Provider>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Map ruler' }));
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeVisible();
+    expect(setMapDrawingData).not.toHaveBeenCalled();
+  });
+});

--- a/src/MapRulerControl/utils.js
+++ b/src/MapRulerControl/utils.js
@@ -1,0 +1,17 @@
+import { area, polygon } from '@turf/turf';
+import isEqual from 'react-fast-compare';
+
+export const calcPolygonAreaDisplayString = (points) => {
+  if (points.length < 3) return null;
+
+  return `${(area(polygon([[...points, points[0]]])) / 1_000_000).toFixed(2)}km²`;
+};
+
+export const calcCursorPolygonAreaDisplayString = (points, cursorCoords) => {
+  const lastPoint = points[points.length - 1];
+  const ring = !!cursorCoords && !isEqual(cursorCoords, lastPoint)
+    ? [...points, cursorCoords]
+    : points;
+
+  return calcPolygonAreaDisplayString(ring);
+};

--- a/src/MapRulerControl/utils.test.js
+++ b/src/MapRulerControl/utils.test.js
@@ -1,0 +1,31 @@
+import { calcCursorPolygonAreaDisplayString, calcPolygonAreaDisplayString } from './utils';
+
+describe('MapRulerControl - area utils', () => {
+  describe('calcPolygonAreaDisplayString', () => {
+    test('returns null with fewer than three points', () => {
+      expect(calcPolygonAreaDisplayString([[0, 0], [1, 0]])).toBeNull();
+    });
+
+    test('closes the ring and returns the area in square kilometers', () => {
+      expect(calcPolygonAreaDisplayString([[0, 0], [1, 0], [1, 1]])).toBe('6181.86km²');
+    });
+  });
+
+  describe('calcCursorPolygonAreaDisplayString', () => {
+    test('counts the cursor location as a vertex', () => {
+      expect(calcCursorPolygonAreaDisplayString([[0, 0], [1, 0]], [1, 1])).toBe('6181.86km²');
+    });
+
+    test('ignores a cursor location identical to the last point', () => {
+      expect(calcCursorPolygonAreaDisplayString([[0, 0], [1, 0]], [1, 0])).toBeNull();
+    });
+
+    test('returns null when the ring would have fewer than three distinct vertices', () => {
+      expect(calcCursorPolygonAreaDisplayString([[0, 0]], [1, 0])).toBeNull();
+    });
+
+    test('returns null without a cursor location and fewer than three points', () => {
+      expect(calcCursorPolygonAreaDisplayString([[0, 0], [1, 0]], null)).toBeNull();
+    });
+  });
+});

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,7 +7,7 @@ import LocalStorageBackend from 'i18next-localstorage-backend';
 
 import { SUPPORTED_LANGUAGES } from './constants';
 
-const I18N_FILES_VERSION = '1.43';
+const I18N_FILES_VERSION = '1.44';
 
 const preloadNamespaces = [
   'components',


### PR DESCRIPTION
## What

Shows the area of the polygon outlined by the map ruler's segments once three or more vertices exist.

- **While drawing**: the cursor popup gains an `Area:` line between the existing `Bearing:` and `Distance:` lines. The polygon is the committed points plus the current cursor position, closed back to the first point, so the value updates live with mouse movement, clicks, and point drags — per the ticket's acceptance criteria it appears from 2 committed points onward.
- **After finishing**: each selected point's popup shows the measured polygon's area alongside bearing and distance-from-start.

Area is computed with turf (`polygon` + `area`) and displayed in km² to 2 decimals, consistent with the existing km distance readout. Shared helpers live in `src/MapRulerControl/utils.js`.

## How

`DefaultCursorPopup` in `MapDrawingTools` takes an optional `area` prop (default `null`) injected via the existing `renderCursorPopup` override, so other consumers (e.g. `ReportGeometryDrawer`) are unaffected. New i18n keys `pointPopup.areaLabel` and `mapDrawingTools.areaLabel` in all six locales; `I18N_FILES_VERSION` bumped to 1.44.

## Testing

New unit coverage for the area helpers (ring gating, cursor-vertex handling), the point popup (area absent below 3 points, present at 3+, shown on non-last points), and the cursor popup (paragraph order bearing → area → distance; unchanged without `area`). `yarn test src/MapRulerControl src/MapDrawingTools`: 3 suites, 26 tests passing; consumer suites (`ReportGeometryDrawer`, `AreaPicker`) unaffected. ESLint/stylelint at pre-existing baseline.

[ERA-8882](https://allenai.atlassian.net/browse/ERA-8882)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ERA-8882]: https://allenai.atlassian.net/browse/ERA-8882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ