### PR TITLE
ERA-13808: Opening a contained event from an Incident crashes the app when an Events feed filter is active

### DIFF
--- a/src/DetailViewComponents/ActivitySection/ContainedReportListItem/index.js
+++ b/src/DetailViewComponents/ActivitySection/ContainedReportListItem/index.js
@@ -9,6 +9,7 @@ import { ReactComponent as ArrowIntoIcon } from '../../../common/images/icons/ar
 import { ReactComponent as ArrowUpSimpleIcon } from '../../../common/images/icons/arrow-up-simple.svg';
 
 import { fetchEvent } from '../../../ducks/events';
+import { getIsEventFullyLoaded } from '../../../utils/events';
 import { TAB_KEYS } from '../../../constants';
 import useNavigate from '../../../hooks/useNavigate';
 
@@ -29,15 +30,17 @@ const ContainedReportListItem = ({ cardsExpanded, onCollapse, onExpand, report }
 
   const reportFromEventStore = useSelector((state) => state.data.eventStore[report.id]);
 
+  const isEventFullyLoaded = getIsEventFullyLoaded(reportFromEventStore);
+
   const isOpen = useMemo(() => cardsExpanded.includes(report), [cardsExpanded, report]);
 
   const onClickArrowIntoIcon = useCallback(() => navigate(`/${TAB_KEYS.EVENTS}/${report.id}`), [navigate, report]);
 
   useEffect(() => {
-    if (!reportFromEventStore) {
+    if (!isEventFullyLoaded) {
       dispatch(fetchEvent(report.id));
     }
-  }, [dispatch, report.id, reportFromEventStore]);
+  }, [dispatch, isEventFullyLoaded, report.id]);
 
   return <li>
     <div
@@ -75,7 +78,7 @@ const ContainedReportListItem = ({ cardsExpanded, onCollapse, onExpand, report }
       in={isOpen}
     >
       <div>
-        {reportFromEventStore
+        {isEventFullyLoaded
           ? <ReportFormSummary report={reportFromEventStore} />
           : <div className={styles.loaderWrapper}>
             <MoonLoader color={LOADER_COLOR} size={LOADER_SIZE} />

--- a/src/ReportManager/index.js
+++ b/src/ReportManager/index.js
@@ -10,6 +10,7 @@ import {
 } from '../utils/analytics';
 import { fetchEvent } from '../ducks/events';
 import { getCurrentIdFromURL } from '../utils/navigation';
+import { getIsEventFullyLoaded } from '../utils/events';
 import { NavigationContext } from '../NavigationContextProvider';
 import { selectEventTypeById } from '../selectors/event-types';
 import { TAB_KEYS } from '../constants';
@@ -77,9 +78,9 @@ const ReportManager = ({ communityInputValue = null, hidePriority = false, hideR
   const event = useSelector((state) => state.data.eventStore[reportId]);
   const eventType = useSelector((state) => selectEventTypeById(state, newReportTypeId));
 
-  const [isLoadingReport, setIsLoadingReport] = useState(true);
+  const isEventFullyLoaded = getIsEventFullyLoaded(event);
 
-  const shouldRenderReportDetailView = !!(isNewReport ? eventType : (event && !isLoadingReport));
+  const shouldRenderReportDetailView = !!(isNewReport ? eventType : isEventFullyLoaded);
 
   const onAddReport = useCallback((formProps, reportData, reportTypeId) => {
     setAddedReportFormProps({ ...formProps, onCancelAddedReport });
@@ -102,20 +103,11 @@ const ReportManager = ({ communityInputValue = null, hidePriority = false, hideR
   }, [eventType, fallbackPath, isNewReport, location.pathname, location.search, location.state, navigate, newReportTemporalId, reportIdProp]);
 
   useEffect(() => {
-    const shouldFetchEventDetails = !event
-      || !event.event_details
-      || !event.files
-      || !event.notes
-      || !event.updates;
-    if (!isNewReport && shouldFetchEventDetails) {
-      setIsLoadingReport(true);
+    if (!isNewReport && !isEventFullyLoaded) {
       dispatch(fetchEvent(reportId))
-        .then(() => setIsLoadingReport(false))
         .catch(() => navigate(`/${TAB_KEYS.EVENTS}`, { replace: true }));
-    } else {
-      setIsLoadingReport(false);
     }
-  }, [dispatch, event, isNewReport, navigate, reportId]);
+  }, [dispatch, isEventFullyLoaded, isNewReport, navigate, reportId]);
 
   return <TrackerContext.Provider value={reportTracker}>
     {shouldRenderReportDetailView ? <ReportDetailView

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -48,6 +48,12 @@ export const getReporterById = (id) => {
 
 export const displayTitleForEvent = (event, eventTypes) => event.title || eventTypeTitleForEvent(event, eventTypes);
 
+export const getIsEventFullyLoaded = (event) => !!event
+  && !!event.event_details
+  && !!event.files
+  && !!event.notes
+  && !!event.updates;
+
 export const getCoordinatesForEvent = (event) => {
   if (event?.geojson?.geometry?.type === 'Polygon') {
     return event.geojson.geometry.coordinates.reduce((accumulator, shape) => [...accumulator, ...shape], []);


### PR DESCRIPTION
## What does this PR do?
Stop trusting stored events from the incident and event views. Validate they are fully loaded and if not, fetch.

- Updated ContainedReportListItem and ReportManager components to utilize the new getIsEventFullyLoaded function for determining event load status.
- Simplified conditional checks for fetching event details and rendering report summaries based on event completeness.

### Relevant link(s)
- [ERA-13808](https://allenai.atlassian.net/browse/ERA-13808)


[ERA-13808]: https://allenai.atlassian.net/browse/ERA-13808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ